### PR TITLE
Migrate system sources from bp3 to voedger  (#119)

### DIFF
--- a/pkg/vit/mock/impl.go
+++ b/pkg/vit/mock/impl.go
@@ -128,9 +128,10 @@ type Object struct {
 	mock.Mock
 }
 
-func (o *Object) AsInt32(name string) int32   { return o.Called(name).Get(0).(int32) }
-func (o *Object) AsInt64(name string) int64   { return o.Called(name).Get(0).(int64) }
-func (o *Object) AsString(name string) string { return o.Called(name).String(0) }
+func (o *Object) AsInt32(name string) int32                                { return o.Called(name).Get(0).(int32) }
+func (o *Object) AsInt64(name string) int64                                { return o.Called(name).Get(0).(int64) }
+func (o *Object) AsString(name string) string                              { return o.Called(name).String(0) }
+func (o *Object) Elements(container string, cb func(el istructs.IElement)) { o.Called(container, cb) }
 
 type Record struct {
 	istructs.IRecord


### PR DESCRIPTION
(small update to vit/mock: Elements() added to Object mock)