### PR TITLE
#795 ACL: rename `sys.Login` -> `registry.Login`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/net v0.9.0
 	golang.org/x/text v0.9.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -47,6 +48,5 @@ require (
 	github.com/untillpro/gojay v1.2.17-0.20201109133446-b1069e05b56c // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/iauthnzimpl/consts.go
+++ b/pkg/iauthnzimpl/consts.go
@@ -19,7 +19,7 @@ var (
 	qNameTestDeniedCmd                              = appdef.NewQName(appdef.SysPackage, "TestDeniedCmd")
 	qNameTestDeniedQry                              = appdef.NewQName(appdef.SysPackage, "TestDeniedQry")
 	qNameTestDeniedCDoc                             = appdef.NewQName(appdef.SysPackage, "TestDeniedCDoc")
-	qNameCDocLogin                                  = appdef.NewQName(appdef.SysPackage, "Login")
+	qNameCDocLogin                                  = appdef.NewQName(registry.RegistryPackage, "Login")
 	qNameCDocChildWorkspace                         = appdef.NewQName(appdef.SysPackage, "ChildWorkspace")
 	qNameCDocWorkspaceKindUser                      = appdef.NewQName(appdef.SysPackage, "UserProfile")
 	qNameCDocWorkspaceKindDevice                    = appdef.NewQName(appdef.SysPackage, "DeviceProfile")


### PR DESCRIPTION
Resolves #795 ACL: rename `sys.Login` -> `registry.Login`
