### PR TITLE
#804 investigate "`sys.Login` not found" error

### DIFF
--- a/pkg/registry/impl_issueprincipaltoken.go
+++ b/pkg/registry/impl_issueprincipaltoken.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/untillpro/goutils/logger"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/istructsmem"
 	"github.com/voedger/voedger/pkg/itokens"
@@ -36,6 +37,7 @@ func (q *iptRR) AsString(name string) string {
 
 func provideIssuePrincipalTokenExec(asp istructs.IAppStructsProvider, itokens itokens.ITokens) istructsmem.ExecQueryClosure {
 	return func(ctx context.Context, args istructs.ExecQueryArgs, callback istructs.ExecQueryCallback) (err error) {
+		logger.Info(0)
 		login := args.ArgumentObject.AsString(authnz.Field_Login)
 		appName := args.ArgumentObject.AsString(authnz.Field_AppName)
 
@@ -61,8 +63,10 @@ func provideIssuePrincipalTokenExec(asp istructs.IAppStructsProvider, itokens it
 			return err
 		}
 
+		logger.Info(1)
 		cdocLogin, doesLoginExist, err := GetCDocLogin(login, args.State, args.Workspace, appName)
 		if err != nil {
+			logger.Error(1, err)
 			return err
 		}
 

--- a/pkg/registry/utils.go
+++ b/pkg/registry/utils.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/untillpro/goutils/logger"
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/state"
@@ -36,10 +37,13 @@ func GetCDocLoginID(st istructs.IState, appWSID istructs.WSID, appName string, l
 	loginHash := GetLoginHash(login)
 	kb.PutInt64(field_AppWSID, int64(appWSID))
 	kb.PutString(field_AppIDLoginHash, appName+"/"+loginHash)
+	logger.Info(2)
 	loginIdx, ok, err := st.CanExist(kb)
 	if err != nil {
+		logger.Error(2, err)
 		return istructs.NullRecordID, err
 	}
+	logger.Info(3)
 	if !ok {
 		return istructs.NullRecordID, nil
 	}
@@ -63,7 +67,11 @@ func GetCDocLogin(login string, st istructs.IState, appWSID istructs.WSID, appNa
 		return nil, doesLoginExist, err
 	}
 	kb.PutRecordID(state.Field_ID, cdocLoginID)
+	logger.Info(4)
 	cdocLogin, err = st.MustExist(kb)
+	if err != nil {
+		logger.Error(4, err)
+	}
 	return
 }
 


### PR DESCRIPTION
Resolves #804 investigate "`sys.Login` not found" error
