### PR TITLE
#856 Fix typo: `regfistryapp`

### DIFF
--- a/pkg/apps/sys/registryapp/provide.go
+++ b/pkg/apps/sys/registryapp/provide.go
@@ -24,6 +24,6 @@ func Provide(smtpCfg smtp.Cfg, rebuildRegistry bool) apps.AppBuilder {
 		// sys/registry resources
 		registry.Provide(cfg, appDefBuilder, apis.IAppStructsProvider, apis.ITokens, apis.IFederation, ep)
 		cfg.AddSyncProjectors(registry.ProvideSyncProjectorLoginIdxFactory())
-		apps.RegisterSchemaFS(registrySchemaFS, "github.com/voedger/voedger/pkg/apps/sys/regfistryapp", ep)
+		apps.RegisterSchemaFS(registrySchemaFS, "github.com/voedger/voedger/pkg/apps/sys/registryapp", ep)
 	}
 }


### PR DESCRIPTION
Resolves #856 Fix typo: `regfistryapp`
