### PR TITLE
#911 name conflict `view.sys.Uniques` and `p.sys.Uniques`

### DIFF
--- a/pkg/sys/uniques/consts.go
+++ b/pkg/sys/uniques/consts.go
@@ -4,9 +4,16 @@
 
 package uniques
 
+import "github.com/voedger/voedger/pkg/appdef"
+
 const (
 	field_ID         = "ID"
 	field_ValuesHash = "ValuesHash"
 	field_QName      = "QName"
 	field_Values     = "Values"
+)
+
+var (
+	qNameApplyUniques = appdef.NewQName(appdef.SysPackage, "ApplyUniques")
+	qNameViewUniques  = appdef.NewQName(appdef.SysPackage, "Uniques")
 )

--- a/pkg/sys/uniques/impl.go
+++ b/pkg/sys/uniques/impl.go
@@ -18,7 +18,7 @@ import (
 	coreutils "github.com/voedger/voedger/pkg/utils"
 )
 
-func provideUniquesProjectorFunc(appDef appdef.IAppDef) func(event istructs.IPLogEvent, state istructs.IState, intents istructs.IIntents) (err error) {
+func provideApplyUniques(appDef appdef.IAppDef) func(event istructs.IPLogEvent, state istructs.IState, intents istructs.IIntents) (err error) {
 	return func(event istructs.IPLogEvent, st istructs.IState, intents istructs.IIntents) (err error) {
 		return event.CUDs(func(rec istructs.ICUDRow) (err error) {
 			if unique, ok := appDef.Type(rec.QName()).(appdef.IUniques); ok {
@@ -168,7 +168,7 @@ func update(rec istructs.ICUDRow, uf appdef.IField, st istructs.IState, intents 
 }
 
 func getUniqueViewRecord(st istructs.IState, rec istructs.IRowReader, uf appdef.IField) (istructs.IStateValue, istructs.IStateKeyBuilder, bool, error) {
-	kb, err := st.KeyBuilder(state.View, QNameViewUniques)
+	kb, err := st.KeyBuilder(state.View, qNameViewUniques)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/sys/uniques/provide.go
+++ b/pkg/sys/uniques/provide.go
@@ -11,11 +11,9 @@ import (
 	"github.com/voedger/voedger/pkg/projectors"
 )
 
-var QNameViewUniques = appdef.NewQName(appdef.SysPackage, "Uniques")
-
 func Provide(cfg *istructsmem.AppConfigType, appDefBuilder appdef.IAppDefBuilder) {
 
-	projectors.ProvideViewDef(appDefBuilder, QNameViewUniques, func(view appdef.IViewBuilder) {
+	projectors.ProvideViewDef(appDefBuilder, qNameViewUniques, func(view appdef.IViewBuilder) {
 		view.KeyBuilder().PartKeyBuilder().
 			AddField(field_QName, appdef.DataKind_QName).
 			AddField(field_ValuesHash, appdef.DataKind_int64)
@@ -26,8 +24,8 @@ func Provide(cfg *istructsmem.AppConfigType, appDefBuilder appdef.IAppDefBuilder
 	})
 	cfg.AddSyncProjectors(func(partition istructs.PartitionID) istructs.Projector {
 		return istructs.Projector{
-			Name: QNameViewUniques,
-			Func: provideUniquesProjectorFunc(appDefBuilder),
+			Name: qNameApplyUniques,
+			Func: provideApplyUniques(appDefBuilder),
 		}
 	})
 	cfg.AddEventValidators(provideEventUniqueValidator())

--- a/pkg/sys/uniques/utils.go
+++ b/pkg/sys/uniques/utils.go
@@ -26,7 +26,7 @@ func GetUniqueID(appStructs istructs.IAppStructs, doc istructs.IRowReader, wsid 
 }
 
 func getUniqueIDByValues(appStructs istructs.IAppStructs, wsid istructs.WSID, qName appdef.QName, uniqueKeyValues []byte) (istructs.RecordID, bool, error) {
-	kb := appStructs.ViewRecords().KeyBuilder(QNameViewUniques)
+	kb := appStructs.ViewRecords().KeyBuilder(qNameViewUniques)
 	if err := buildUniqueViewKeyByValues(kb, qName, uniqueKeyValues); err != nil {
 		// notest
 		return istructs.NullRecordID, false, err


### PR DESCRIPTION
Resolves #911 name conflict `view.sys.Uniques` and `p.sys.Uniques`
