### PR TITLE
#913 sql: nil pointer dereference on parsing a VIEW without PRIMARY KEY

### DIFF
--- a/pkg/parser/impl_analyse.go
+++ b/pkg/parser/impl_analyse.go
@@ -159,7 +159,9 @@ func analyseView(view *ViewStmt, c *iterateCtx) {
 	}
 	if view.pkRef == nil {
 		c.stmtErr(&view.Pos, ErrPrimaryKeyNotDefined)
+		return
 	}
+
 	for _, pkf := range view.pkRef.PartitionKeyFields {
 		index, ok := fields[string(pkf)]
 		if !ok {

--- a/pkg/parser/impl_test.go
+++ b/pkg/parser/impl_test.go
@@ -787,6 +787,17 @@ func Test_Views(t *testing.T) {
 		);
 	)
 	`, "file2.sql:4:4: reference to abstract table abc", "file2.sql:5:4: unexisting undefined")
+
+	f(`APPLICATION test(); WORKSPACE Workspace (
+		VIEW test(
+			fld1 int32
+		) AS RESULT OF Proj1;
+		EXTENSION ENGINE BUILTIN (
+			PROJECTOR Proj1 ON (Orders) INTENTS (View(test));
+			COMMAND Orders()
+		);
+	)
+	`, "file2.sql:2:3: primary key not defined")
 }
 
 func Test_Views2(t *testing.T) {


### PR DESCRIPTION
Resolves #913 sql: nil pointer dereference on parsing a VIEW without PRIMARY KEY
