### PR TITLE
#951 define `c.sys.CUD` and deprecated `c.sys.Init` in sql

### DIFF
--- a/pkg/sys/sys.sql
+++ b/pkg/sys/sys.sql
@@ -328,6 +328,8 @@ ABSTRACT WORKSPACE Workspace (
 
         -- builtin
 
+        COMMAND CUD();
+        COMMAND Init(); -- Deprecated: use c.sys.CUD instead. Kept for backward compatibility only
         QUERY Echo(EchoParams) RETURNS EchoResult;
         QUERY GRCount RETURNS GRCountResult;
         QUERY Modules RETURNS ModulesResult;


### PR DESCRIPTION
Resolves #951 define `c.sys.CUD` and deprecated `c.sys.Init` in sql
