### PR TITLE
#983 relocate sys.Raw outside the workspace definition in sql

### DIFF
--- a/pkg/sys/sys.sql
+++ b/pkg/sys/sys.sql
@@ -17,10 +17,11 @@ ABSTRACT TABLE Singleton INHERITS CDoc();
 
 ALTERABLE WORKSPACE AppWorkspaceWS();
 
+TYPE Raw (
+	Body raw(65535) NOT NULL
+);
+
 ABSTRACT WORKSPACE Workspace (
-	TYPE Raw (
-		Body raw(65535) NOT NULL
-	);
 
 	TABLE ChildWorkspace INHERITS CDoc (
 		WSName varchar NOT NULL,


### PR DESCRIPTION
Resolves #983 relocate sys.Raw outside the workspace definition in sql
