### PR TITLE
#1006 fix query processor: wrong "Body" field type on Raw Arg

### DIFF
--- a/pkg/processors/query/impl.go
+++ b/pkg/processors/query/impl.go
@@ -194,7 +194,7 @@ func newQueryProcessorPipeline(requestCtx context.Context, authn iauthnz.IAuthen
 			parsType := qw.appStructs.AppDef().Type(qw.queryFunction.ParamsType())
 			if parsType.QName() == istructs.QNameRaw {
 				qw.requestData["args"] = map[string]interface{}{
-					processors.Field_RawObject_Body: qw.msg.Body(),
+					processors.Field_RawObject_Body: string(qw.msg.Body()),
 				}
 				return nil
 			}


### PR DESCRIPTION
Resolves #1006 fix query processor: wrong "Body" field type on Raw Arg
