### PR TITLE
#1110 vpm cmd: eliminate test that deletes go mod cache

### DIFF
--- a/cmd/vpm/main_test.go
+++ b/cmd/vpm/main_test.go
@@ -15,9 +15,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/untillpro/goutils/exec"
-
-	"github.com/voedger/voedger/cmd/vpm/internal/dm"
 )
 
 //go:embed test/myapp/*
@@ -125,88 +122,6 @@ func TestErrorsInCompile(t *testing.T) {
 			}
 			fmt.Println(err.Error())
 		})
-	}
-}
-
-func TestMissedDependency(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	require := require.New(t)
-
-	wd, err := os.Getwd()
-	require.NoError(err)
-	defer func() {
-		_ = os.Chdir(wd)
-	}()
-
-	tempDir := t.TempDir()
-	err = copyContents(testMyAppFS, tempDir)
-	require.NoError(err)
-	testDir := fmt.Sprintf("%s/test/myapp", tempDir)
-
-	testSteps := []struct {
-		name string
-		step func(t *testing.T)
-	}{
-		{
-			name: "compile",
-			step: func(t *testing.T) {
-				err := os.Chdir(testDir)
-				require.NoError(err)
-
-				err = execRootCmd([]string{"vpm", "compile", fmt.Sprintf(" -C %s", testDir)}, "1.0.0")
-				require.NoError(err)
-			},
-		},
-		{
-			name: "clean dependency cache",
-			step: func(t *testing.T) {
-				err := os.Chdir(testDir)
-				require.NoError(err)
-
-				goCacheCleanCmd := new(exec.PipedExec).Command("go", "clean", "-modcache")
-				err = goCacheCleanCmd.Run(nil, nil)
-				require.NoError(err)
-
-				goDM, err := dm.NewGoBasedDependencyManager()
-				require.NoError(err)
-
-				localPath := path.Join(goDM.CachePath(), sysQPN)
-
-				_, err = os.Stat(localPath)
-				require.True(os.IsNotExist(err))
-			},
-		},
-		{
-			name: "check dependency integrity after",
-			step: func(t *testing.T) {
-				err := os.Chdir(testDir)
-				require.NoError(err)
-
-				goDM, err := dm.NewGoBasedDependencyManager()
-				require.NoError(err)
-
-				localPath, err := goDM.LocalPath(sysQPN)
-				require.NoError(err)
-
-				_, err = os.Stat(localPath)
-				require.False(os.IsNotExist(err))
-			},
-		},
-		{
-			name: "compile again",
-			step: func(t *testing.T) {
-				err := os.Chdir(testDir)
-				require.NoError(err)
-
-				err = execRootCmd([]string{"vpm", "compile", fmt.Sprintf(" -C %s", testDir)}, "1.0.0")
-				require.NoError(err)
-			},
-		},
-	}
-	for _, testStep := range testSteps {
-		t.Run(testStep.name, testStep.step)
 	}
 }
 


### PR DESCRIPTION
Resolves #1110 vpm cmd: eliminate test that deletes go mod cache
