### PR TITLE
#1125 deny `sys.IsActive` + other fields update in client CUDs only, allow in result CUDs of commands

### DIFF
--- a/pkg/processors/command/provide.go
+++ b/pkg/processors/command/provide.go
@@ -79,6 +79,7 @@ func ProvideServiceFactory(bus ibus.IBus, asp istructs.IAppStructsProvider, now 
 				pipeline.WireFunc("parseCUDs", parseCUDs),
 				pipeline.WireSyncOperator("wrongArgsCatcher", &wrongArgsCatcher{}), // any error before -> wrap error into bad request http error
 				pipeline.WireFunc("authorizeCUDs", cmdProc.authorizeCUDs),
+				pipeline.WireFunc("checkIsActiveinCUDs", checkIsActiveInCUDs),
 				pipeline.WireFunc("writeCUDs", cmdProc.writeCUDs),
 				pipeline.WireFunc("getCmdResultBuilder", cmdProc.getCmdResultBuilder),
 				pipeline.WireFunc("buildCommandArgs", cmdProc.buildCommandArgs),

--- a/pkg/sys/builtin/impl_sysisactivevalidation.go
+++ b/pkg/sys/builtin/impl_sysisactivevalidation.go
@@ -9,51 +9,21 @@ import (
 	"context"
 	"errors"
 
-	"github.com/untillpro/goutils/iterate"
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/istructsmem"
 )
 
 func provideSysIsActiveValidation(cfg *istructsmem.AppConfigType) {
-	cfg.AddCUDValidators(denyIsActiveAndOtherFieldsMixing, denyInsertDeactivatedRecord)
-}
-
-var denyIsActiveAndOtherFieldsMixing = istructs.CUDValidator{
-	Match: func(cud istructs.ICUDRow, wsid istructs.WSID, cmdQName appdef.QName) bool {
-		return !cud.IsNew()
-	},
-	Validate: func(ctx context.Context, appStructs istructs.IAppStructs, cudRow istructs.ICUDRow, wsid istructs.WSID, cmdQName appdef.QName) error {
-		sysIsActiveUpdating := false
-		hasOnlySystemFields := true
-		fields := []string{}
-		isActiveAndOtherFieldsMixedOnUpdate, _, _ := iterate.FindFirstMap(cudRow.ModifiedFields, func(fieldName string, _ interface{}) bool {
-			fields = append(fields, fieldName)
-			if !appdef.IsSysField(fieldName) {
-				hasOnlySystemFields = false
-			} else if fieldName == appdef.SystemField_IsActive {
-				sysIsActiveUpdating = true
+	cfg.AddCUDValidators(istructs.CUDValidator{
+		Match: func(cud istructs.ICUDRow, wsid istructs.WSID, cmdQName appdef.QName) bool {
+			return cud.IsNew()
+		},
+		Validate: func(ctx context.Context, appStructs istructs.IAppStructs, cudRow istructs.ICUDRow, wsid istructs.WSID, cmdQName appdef.QName) error {
+			if !cudRow.AsBool(appdef.SystemField_IsActive) {
+				return errors.New("inserting a deactivated record is not allowed")
 			}
-			if sysIsActiveUpdating && !hasOnlySystemFields {
-				return true
-			}
-			return false
-		})
-		if isActiveAndOtherFieldsMixedOnUpdate {
-			return errors.New("updating other fields is not allowed if sys.IsActive is updating")
-		}
-		return nil
-	},
-}
-
-var denyInsertDeactivatedRecord = istructs.CUDValidator{
-	Match: func(cud istructs.ICUDRow, wsid istructs.WSID, cmdQName appdef.QName) bool {
-		return cud.IsNew()
-	},
-	Validate: func(ctx context.Context, appStructs istructs.IAppStructs, cudRow istructs.ICUDRow, wsid istructs.WSID, cmdQName appdef.QName) error {
-		if !cudRow.AsBool(appdef.SystemField_IsActive) {
-			return errors.New("inserting a deactivated record is not allowed")
-		}
-		return nil
-	},
+			return nil
+		},
+	})
 }


### PR DESCRIPTION
Resolves #1125 deny `sys.IsActive` + other fields update in client CUDs only, allow in result CUDs of commands
