### PR TITLE
1166 baselinejsontimestamp use gmt with milliseconds httpspkggodevtimetimeformat

### DIFF
--- a/cmd/vpm/baseline.go
+++ b/cmd/vpm/baseline.go
@@ -66,7 +66,7 @@ func saveBaselineInfo(compileRes *compileResult, baselineDir string) error {
 
 	baselineInfoObj := baselineInfo{
 		BaselinePackageUrl: compileRes.modulePath,
-		Timestamp:          time.Now().Format(timestampFormat),
+		Timestamp:          time.Now().In(time.FixedZone("GMT", 0)).Format(timestampFormat),
 		GitCommitHash:      gitCommitHash,
 	}
 

--- a/cmd/vpm/const.go
+++ b/cmd/vpm/const.go
@@ -13,5 +13,5 @@ const (
 	pkgDirName           = "pkg"
 	defaultPermissions   = 0766
 	baselineInfoFileName = "baseline.json"
-	timestampFormat      = "20060102150405"
+	timestampFormat      = "Mon, 02 Jan 2006 15:04:05.000 GMT"
 )


### PR DESCRIPTION
fix #1166 