### PR TITLE
#1182 fix copyright of `utils/verificationcode.go`

### DIFF
--- a/pkg/utils/verificationcode.go
+++ b/pkg/utils/verificationcode.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-present unTill Software Development Group B.V.
+ * Copyright (c) 2023-present unTill Pro, Ltd.
  * @author Denis Gribanov
  */
 


### PR DESCRIPTION
Resolves #1182 fix copyright of `utils/verificationcode.go`
