### PR TITLE
#1195 parser: ParsePackageDir() does not work in root of embed.FS

### DIFF
--- a/pkg/parser/impl.go
+++ b/pkg/parser/impl.go
@@ -70,7 +70,11 @@ func parseFSImpl(fs IReadFS, dir string) (schemas []*FileSchemaAST, errs []error
 		if strings.ToLower(filepath.Ext(entry.Name())) == ".sql" {
 			var fpath string
 			if _, ok := fs.(embed.FS); ok {
-				fpath = fmt.Sprintf("%s/%s", dir, entry.Name()) // The path separator is a forward slash, even on Windows systems
+				if dir == "." || dir == "" {
+					fpath = entry.Name()
+				} else {
+					fpath = fmt.Sprintf("%s/%s", dir, entry.Name()) // The path separator is a forward slash, even on Windows systems
+				}
 			} else {
 				fpath = filepath.Join(dir, entry.Name())
 			}

--- a/pkg/parser/impl_test.go
+++ b/pkg/parser/impl_test.go
@@ -1934,3 +1934,13 @@ TABLE MyTable1 INHERITS ODocUnknown ( MyField ref(registry.Login) NOT NULL );
 	}, "\n"))
 
 }
+
+//go:embed package.sql
+var pkgSqlFS embed.FS
+
+func TestDot(t *testing.T) {
+	t.Run("dot", func(t *testing.T) {
+		_, err := ParsePackageDir("github.com/untillpro/main", pkgSqlFS, ".")
+		require.NoError(t, err)
+	})
+}

--- a/pkg/parser/package.sql
+++ b/pkg/parser/package.sql
@@ -1,0 +1,10 @@
+/*
+* Copyright (c) 2023-present unTill Pro, Ltd.
+*/
+TYPE TypeWithName (
+    Name text
+);
+
+TYPE Order (
+    Name text
+);


### PR DESCRIPTION
Resolves #1195 parser: ParsePackageDir() does not work in root of embed.FS
