### PR TITLE
#1157 need clear error description instead of panic in parser (`unexpected root table kind 0`)

### DIFF
--- a/pkg/parser/errors.go
+++ b/pkg/parser/errors.go
@@ -68,6 +68,10 @@ func ErrCouldNotImport(pkgName string) error {
 	return fmt.Errorf("could not import %s", pkgName)
 }
 
+func ErrUnexpectedRootTableKind(kind int) error {
+	return fmt.Errorf("unexpected root table kind %d", kind)
+}
+
 func ErrReferenceToAbstractTable(tblName string) error {
 	return fmt.Errorf("reference to abstract table %s", tblName)
 }

--- a/pkg/parser/impl_analyse.go
+++ b/pkg/parser/impl_analyse.go
@@ -579,7 +579,12 @@ func analyseNestedTables(items []TableItemExpr, rootTableKind appdef.TypeKind, c
 				return
 			}
 			if nestedTable.Inherits == nil {
-				nestedTable.tableTypeKind = getNestedTableKind(rootTableKind)
+				var err error
+				nestedTable.tableTypeKind, err = getNestedTableKind(rootTableKind)
+				if err != nil {
+					c.stmtErr(pos, err)
+					return
+				}
 			} else {
 				var err error
 				nestedTable.tableTypeKind, nestedTable.singletone, err = getTableTypeKind(nestedTable, c.pkg, c)
@@ -587,7 +592,11 @@ func analyseNestedTables(items []TableItemExpr, rootTableKind appdef.TypeKind, c
 					c.stmtErr(pos, err)
 					return
 				}
-				tk := getNestedTableKind(rootTableKind)
+				tk, err := getNestedTableKind(rootTableKind)
+				if err != nil {
+					c.stmtErr(pos, err)
+					return
+				}
 				if nestedTable.tableTypeKind != tk {
 					c.stmtErr(pos, ErrNestedTableIncorrectKind)
 					return

--- a/pkg/parser/impl_build.go
+++ b/pkg/parser/impl_build.go
@@ -761,7 +761,11 @@ func (c *buildContext) addTableFieldToTable(field *FieldExpr, ictx *iterateCtx) 
 
 	if wrec != nil || orec != nil || crec != nil {
 		//tk := getNestedTableKind(ctx.defs[0].kind)
-		tk := getNestedTableKind(c.defCtx().kind)
+		tk, err := getNestedTableKind(c.defCtx().kind)
+		if err != nil {
+			c.stmtErr(&field.Pos, err)
+			return
+		}
 		if (wrec != nil && tk != appdef.TypeKind_WRecord) ||
 			(orec != nil && tk != appdef.TypeKind_ORecord) ||
 			(crec != nil && tk != appdef.TypeKind_CRecord) {

--- a/pkg/parser/utils.go
+++ b/pkg/parser/utils.go
@@ -258,16 +258,16 @@ func maybeSysPkg(pkg Ident) bool {
 	return (pkg == "" || pkg == appdef.SysPackage)
 }
 
-func getNestedTableKind(rootTableKind appdef.TypeKind) appdef.TypeKind {
+func getNestedTableKind(rootTableKind appdef.TypeKind) (appdef.TypeKind, error) {
 	switch rootTableKind {
 	case appdef.TypeKind_CDoc, appdef.TypeKind_CRecord:
-		return appdef.TypeKind_CRecord
+		return appdef.TypeKind_CRecord, nil
 	case appdef.TypeKind_ODoc, appdef.TypeKind_ORecord:
-		return appdef.TypeKind_ORecord
+		return appdef.TypeKind_ORecord, nil
 	case appdef.TypeKind_WDoc, appdef.TypeKind_WRecord:
-		return appdef.TypeKind_WRecord
+		return appdef.TypeKind_WRecord, nil
 	default:
-		panic(fmt.Sprintf("unexpected root table kind %d", rootTableKind))
+		return appdef.TypeKind_null, ErrUnexpectedRootTableKind(int(rootTableKind))
 	}
 }
 


### PR DESCRIPTION
Resolves #1157 need clear error description instead of panic in parser (`unexpected root table kind 0`)
