### PR TITLE
#1299 parser: `projector after insert` on the workspace descriptor causes `unknown table` error

### DIFF
--- a/pkg/parser/impl_analyse.go
+++ b/pkg/parser/impl_analyse.go
@@ -438,6 +438,17 @@ func analyseProjector(v *ProjectorStmt, c *iterateCtx) {
 		trigger := &v.Triggers[i]
 		for _, qname := range trigger.QNames {
 			if len(trigger.TableActions) > 0 {
+
+				wd, pkg, err := lookupInCtx[*WsDescriptorStmt](qname, c)
+				if err != nil {
+					c.stmtErr(&qname.Pos, err)
+					continue
+				}
+				if wd != nil {
+					trigger.qNames = append(trigger.qNames, pkg.NewQName(wd.Name))
+					continue
+				}
+
 				resolveFunc := func(table *TableStmt, pkg *PackageSchemaAST) error {
 					sysDoc := (pkg.QualifiedPackageName == appdef.SysPackage) && (table.Name == nameCRecord || table.Name == nameWRecord)
 					if table.Abstract && !sysDoc {

--- a/pkg/parser/utils.go
+++ b/pkg/parser/utils.go
@@ -112,7 +112,7 @@ func lookupInSysPackage[stmtType *WorkspaceStmt](ctx *basicContext, fn DefQName)
 }
 
 func lookupInCtx[stmtType *TableStmt | *TypeStmt | *FunctionStmt | *CommandStmt | *RateStmt | *TagStmt | *ProjectorStmt |
-	*WorkspaceStmt | *ViewStmt | *StorageStmt | *LimitStmt | *QueryStmt | *RoleStmt](fn DefQName, ictx *iterateCtx) (stmtType, *PackageSchemaAST, error) {
+	*WorkspaceStmt | *ViewStmt | *StorageStmt | *LimitStmt | *QueryStmt | *RoleStmt | *WsDescriptorStmt](fn DefQName, ictx *iterateCtx) (stmtType, *PackageSchemaAST, error) {
 	schema, err := getTargetSchema(fn, ictx)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Resolves #1299 parser: `projector after insert` on the workspace descriptor causes `unknown table` error
