### PR TITLE
#1397 ctool replace: check that backup folder exists and accessible

### DIFF
--- a/cmd/ctool/backup.go
+++ b/cmd/ctool/backup.go
@@ -160,3 +160,12 @@ func checkBackupFolders(cluster *clusterType) error {
 	}
 	return err
 }
+
+// Checking the presence of a Backup folder on node
+func checkBackupFolderOnHost(cluster *clusterType, addr string) error {
+	if e := newScriptExecuter(cluster.sshKey, "").
+		run("check-remote-folder.sh", addr, backupFolder); e != nil {
+		return fmt.Errorf(errBackupFolderIsNotPrepared, addr, ErrBackupFolderIsNotPrepared)
+	}
+	return nil
+}

--- a/cmd/ctool/cluster.go
+++ b/cmd/ctool/cluster.go
@@ -632,6 +632,12 @@ func (c *clusterType) applyCmd(cmd *cmdType) error {
 			if err := hostIsAvailable(c, newAddr); err != nil {
 				return fmt.Errorf(errHostIsNotAvailable, newAddr, ErrHostIsNotAvailable)
 			}
+
+			if len(c.Cron.Backup) > 0 && node.NodeRole == nrDBNode {
+				if err := checkBackupFolderOnHost(c, newAddr); err != nil {
+					return err
+				}
+			}
 		}
 
 		node.DesiredNodeState = newNodeState(newAddr, node.desiredNodeVersion(c))

--- a/cmd/ctool/scripts/drafts/utils.sh
+++ b/cmd/ctool/scripts/drafts/utils.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-set -x
+set +x
 
 utils_SSH_PORT() {
     port="${VOEDGER_NODE_SSH_PORT:-22}"


### PR DESCRIPTION
Resolves #1397 ctool replace: check that backup folder exists and accessible
