### PR TITLE
#1449 VIT: additional fixes to initializing childs of child workspaces

### DIFF
--- a/pkg/vit/utils.go
+++ b/pkg/vit/utils.go
@@ -182,6 +182,7 @@ func (vit *VIT) waitForWorkspace(wsName string, owner *Principal, respGetter fun
 					TemplateName:   resp.SectionRow()[tmplNameIdx].(string),
 					TemplateParams: resp.SectionRow()[tmplParamsIdx].(string),
 					ClusterID:      istructs.MainClusterID,
+					ownerLoginName: owner.Name,
 				},
 				WSID:    wsid,
 				WSError: wsError,


### PR DESCRIPTION
Resolves #1449 VIT: additional fixes to initializing childs of child workspaces
