### PR TITLE
#1462 VVM: validate if correct execs are provided for funcs and projectors defined in vSQL and vice versa

### DIFF
--- a/pkg/processors/command/impl_test.go
+++ b/pkg/processors/command/impl_test.go
@@ -56,7 +56,7 @@ func TestBasicUsage(t *testing.T) {
 	testCmdQNameParams := appdef.NewQName(appdef.SysPackage, "TestParams")
 	// схема unlogged-параметров тестовой команды
 	testCmdQNameParamsUnlogged := appdef.NewQName(appdef.SysPackage, "TestParamsUnlogged")
-	prepareAppDef := func(appDef appdef.IAppDefBuilder, _ *istructsmem.AppConfigType) {
+	prepareAppDef := func(appDef appdef.IAppDefBuilder, cfg *istructsmem.AppConfigType) {
 		pars := appDef.AddObject(testCmdQNameParams)
 		pars.AddField("Text", appdef.DataKind_string, true)
 
@@ -66,6 +66,33 @@ func TestBasicUsage(t *testing.T) {
 		appDef.AddCDoc(testCDoc).AddContainer("TestCRecord", testCRecord, 0, 1)
 		appDef.AddCRecord(testCRecord)
 		appDef.AddCommand(testCmdQName).SetUnloggedParam(testCmdQNameParamsUnlogged).SetParam(testCmdQNameParams)
+
+		// сама тестовая команда
+		testExec := func(args istructs.ExecCommandArgs) (err error) {
+			cuds := args.Workpiece.(*cmdWorkpiece).parsedCUDs
+			if len(cuds) > 0 {
+				require.Len(cuds, 1)
+				require.Equal(float64(1), cuds[0].fields[appdef.SystemField_ID])
+				require.Equal(testCDoc.String(), cuds[0].fields[appdef.SystemField_QName])
+				close(cudsCheck)
+			}
+			require.Equal(istructs.WSID(1), args.PrepareArgs.Workspace)
+			require.NotNil(args.State)
+
+			// просто проверим, что мы получили то, что передал клиент
+			text := args.ArgumentObject.AsString("Text")
+			if text == "fire error" {
+				return errors.New(text)
+			} else {
+				require.Equal("hello", text)
+			}
+			require.Equal("pass", args.ArgumentUnloggedObject.AsString("Password"))
+
+			check <- 1 // сигнал: проверки случились
+			return
+		}
+		testCmd := istructsmem.NewCommandFunction(testCmdQName, testExec)
+		cfg.Resources.Add(testCmd)
 	}
 
 	app := setUp(t, prepareAppDef)
@@ -84,33 +111,6 @@ func TestBasicUsage(t *testing.T) {
 	})
 	app.n10nBroker.Subscribe(channelID, projectionKey)
 	defer app.n10nBroker.Unsubscribe(channelID, projectionKey)
-
-	// сама тестовая команда
-	testExec := func(args istructs.ExecCommandArgs) (err error) {
-		cuds := args.Workpiece.(*cmdWorkpiece).parsedCUDs
-		if len(cuds) > 0 {
-			require.Len(cuds, 1)
-			require.Equal(float64(1), cuds[0].fields[appdef.SystemField_ID])
-			require.Equal(testCDoc.String(), cuds[0].fields[appdef.SystemField_QName])
-			close(cudsCheck)
-		}
-		require.Equal(istructs.WSID(1), args.PrepareArgs.Workspace)
-		require.NotNil(args.State)
-
-		// просто проверим, что мы получили то, что передал клиент
-		text := args.ArgumentObject.AsString("Text")
-		if text == "fire error" {
-			return errors.New(text)
-		} else {
-			require.Equal("hello", text)
-		}
-		require.Equal("pass", args.ArgumentUnloggedObject.AsString("Password"))
-
-		check <- 1 // сигнал: проверки случились
-		return
-	}
-	testCmd := istructsmem.NewCommandFunction(testCmdQName, testExec)
-	app.cfg.Resources.Add(testCmd)
 
 	t.Run("basic usage", func(t *testing.T) {
 		// command processor работает через ibus.SendResponse -> нам нужен sender -> тестируем через ibus.SendRequest2()
@@ -184,7 +184,7 @@ func sendCUD(t *testing.T, wsid istructs.WSID, app testApp, expectedCode ...int)
 	return respData
 }
 
-func TestRecoveryOnProjectorError(t *testing.T) {
+func TestRecoveryOnSyncProjectorError(t *testing.T) {
 	require := require.New(t)
 
 	cudQName := appdef.NewQName(appdef.SysPackage, "CUD")
@@ -209,7 +209,8 @@ func TestRecoveryOnProjectorError(t *testing.T) {
 				},
 			}
 		})
-		appDef.AddProjector(failingProjQName).AddEvent(cudQName, appdef.ProjectorEventKind_Execute)
+		appDef.AddProjector(failingProjQName).AddEvent(cudQName, appdef.ProjectorEventKind_Execute).SetSync(true)
+		cfg.Resources.Add(istructsmem.NewCommandFunction(cudQName, istructsmem.NullCommandExec))
 	})
 	defer tearDown(app)
 
@@ -248,6 +249,7 @@ func TestRecovery(t *testing.T) {
 		appDef.AddCDoc(testCDoc).AddContainer("TestCRecord", testCRecord, 0, 1)
 		appDef.AddWDoc(testWDoc)
 		appDef.AddCommand(cudQName)
+		cfg.Resources.Add(istructsmem.NewCommandFunction(cudQName, istructsmem.NullCommandExec))
 	})
 	defer tearDown(app)
 
@@ -302,9 +304,10 @@ func TestCUDUpdate(t *testing.T) {
 	testQName := appdef.NewQName("test", "test")
 
 	cudQName := appdef.NewQName(appdef.SysPackage, "CUD")
-	app := setUp(t, func(appDef appdef.IAppDefBuilder, _ *istructsmem.AppConfigType) {
-		_ = appDef.AddCDoc(testQName).AddField("IntFld", appdef.DataKind_int32, false)
-		_ = appDef.AddCommand(cudQName)
+	app := setUp(t, func(appDef appdef.IAppDefBuilder, cfg *istructsmem.AppConfigType) {
+		appDef.AddCDoc(testQName).AddField("IntFld", appdef.DataKind_int32, false)
+		appDef.AddCommand(cudQName)
+		cfg.Resources.Add(istructsmem.NewCommandFunction(cudQName, istructsmem.NullCommandExec))
 	})
 	defer tearDown(app)
 
@@ -356,9 +359,10 @@ func Test400BadRequestOnCUDErrors(t *testing.T) {
 	testQName := appdef.NewQName("test", "test")
 
 	cudQName := appdef.NewQName(appdef.SysPackage, "CUD")
-	app := setUp(t, func(appDef appdef.IAppDefBuilder, _ *istructsmem.AppConfigType) {
-		_ = appDef.AddCDoc(testQName)
-		_ = appDef.AddCommand(cudQName)
+	app := setUp(t, func(appDef appdef.IAppDefBuilder, cfg *istructsmem.AppConfigType) {
+		appDef.AddCDoc(testQName)
+		appDef.AddCommand(cudQName)
+		cfg.Resources.Add(istructsmem.NewCommandFunction(cudQName, istructsmem.NullCommandExec))
 	})
 	defer tearDown(app)
 
@@ -408,7 +412,7 @@ func Test400BadRequests(t *testing.T) {
 	testCmdQNameParamsUnlogged := appdef.NewQName(appdef.SysPackage, "TestParamsUnlogged")
 
 	testCmdQName := appdef.NewQName(appdef.SysPackage, "Test")
-	app := setUp(t, func(appDef appdef.IAppDefBuilder, _ *istructsmem.AppConfigType) {
+	app := setUp(t, func(appDef appdef.IAppDefBuilder, cfg *istructsmem.AppConfigType) {
 		appDef.AddObject(testCmdQNameParams).
 			AddField("Text", appdef.DataKind_string, true)
 
@@ -416,15 +420,9 @@ func Test400BadRequests(t *testing.T) {
 			AddField("Password", appdef.DataKind_string, true)
 
 		appDef.AddCommand(testCmdQName).SetUnloggedParam(testCmdQNameParamsUnlogged).SetParam(testCmdQNameParams)
+		cfg.Resources.Add(istructsmem.NewCommandFunction(testCmdQName, istructsmem.NullCommandExec))
 	})
 	defer tearDown(app)
-
-	testCmd := istructsmem.NewCommandFunction(testCmdQName, func(args istructs.ExecCommandArgs) (err error) {
-		_ = args.ArgumentObject.AsString("Text")
-		_ = args.ArgumentUnloggedObject.AsString("Password")
-		return nil
-	})
-	app.cfg.Resources.Add(testCmd)
 
 	baseReq := ibus.Request{
 		WSID:     1,
@@ -485,15 +483,14 @@ func TestAuthnz(t *testing.T) {
 
 	qNameAllowedCmd := appdef.NewQName(appdef.SysPackage, "TestAllowedCmd")
 	qNameDeniedCmd := appdef.NewQName(appdef.SysPackage, "TestDeniedCmd") // the same in core/iauthnzimpl
-	app := setUp(t, func(appDef appdef.IAppDefBuilder, _ *istructsmem.AppConfigType) {
+	app := setUp(t, func(appDef appdef.IAppDefBuilder, cfg *istructsmem.AppConfigType) {
 		appDef.AddCDoc(qNameTestDeniedCDoc)
 		appDef.AddCommand(qNameAllowedCmd)
 		appDef.AddCommand(qNameDeniedCmd)
+		cfg.Resources.Add(istructsmem.NewCommandFunction(qNameAllowedCmd, istructsmem.NullCommandExec))
+		cfg.Resources.Add(istructsmem.NewCommandFunction(qNameDeniedCmd, istructsmem.NullCommandExec))
 	})
 	defer tearDown(app)
-
-	app.cfg.Resources.Add(istructsmem.NewCommandFunction(qNameDeniedCmd, istructsmem.NullCommandExec))
-	app.cfg.Resources.Add(istructsmem.NewCommandFunction(qNameAllowedCmd, istructsmem.NullCommandExec))
 
 	pp := payloads.PrincipalPayload{
 		Login:       "testlogin",
@@ -563,20 +560,16 @@ func getAuthHeader(token string) map[string][]string {
 func TestBasicUsage_FuncWithRawArg(t *testing.T) {
 	require := require.New(t)
 	testCmdQName := appdef.NewQName(appdef.SysPackage, "Test")
-	app := setUp(t, func(appDef appdef.IAppDefBuilder, _ *istructsmem.AppConfigType) {
+	ch := make(chan interface{})
+	app := setUp(t, func(appDef appdef.IAppDefBuilder, cfg *istructsmem.AppConfigType) {
 		appDef.AddCommand(testCmdQName).SetParam(istructs.QNameRaw)
+		cfg.Resources.Add(istructsmem.NewCommandFunction(testCmdQName, func(args istructs.ExecCommandArgs) (err error) {
+			require.EqualValues("custom content", args.ArgumentObject.AsString(processors.Field_RawObject_Body))
+			close(ch)
+			return
+		}))
 	})
 	defer tearDown(app)
-
-	ch := make(chan interface{})
-	testExec := func(args istructs.ExecCommandArgs) (err error) {
-		require.EqualValues("custom content", args.ArgumentObject.AsString(processors.Field_RawObject_Body))
-		close(ch)
-		return
-	}
-	testCmd := istructsmem.NewCommandFunction(testCmdQName, testExec)
-
-	app.cfg.Resources.Add(testCmd)
 
 	request := ibus.Request{
 		Body:     []byte(`custom content`),

--- a/pkg/projectors/async_test.go
+++ b/pkg/projectors/async_test.go
@@ -58,6 +58,13 @@ func TestBasicUsage_AsynchronousActualizer(t *testing.T) {
 		},
 		func(cfg *istructsmem.AppConfigType) {
 			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+			cfg.AddAsyncProjectors(
+				func(partition istructs.PartitionID) istructs.Projector {
+					return istructs.Projector{Name: incrementorName}
+				}, func(partition istructs.PartitionID) istructs.Projector {
+					return istructs.Projector{Name: decrementorName}
+				},
+			)
 		})
 	partitionNr := istructs.PartitionID(1) // test within partition 1
 
@@ -146,6 +153,11 @@ func Test_AsynchronousActualizer_FlushByRange(t *testing.T) {
 		},
 		func(cfg *istructsmem.AppConfigType) {
 			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+			cfg.AddAsyncProjectors(
+				func(partition istructs.PartitionID) istructs.Projector {
+					return istructs.Projector{Name: incrementorName}
+				},
+			)
 		})
 	partitionNr := istructs.PartitionID(2) // test within partition 2
 
@@ -221,6 +233,9 @@ func Test_AsynchronousActualizer_FlushByInterval(t *testing.T) {
 		},
 		func(cfg *istructsmem.AppConfigType) {
 			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+			cfg.AddAsyncProjectors(func(partition istructs.PartitionID) istructs.Projector {
+				return istructs.Projector{Name: incrementorName}
+			})
 		})
 	partitionNr := istructs.PartitionID(1) // test within partition 1
 
@@ -303,6 +318,9 @@ func Test_AsynchronousActualizer_ErrorAndRestore(t *testing.T) {
 		},
 		func(cfg *istructsmem.AppConfigType) {
 			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+			cfg.AddAsyncProjectors(func(partition istructs.PartitionID) istructs.Projector {
+				return istructs.Projector{Name: name}
+			})
 		})
 	partitionNr := istructs.PartitionID(1) // test within partition 1
 
@@ -414,6 +432,9 @@ func Test_AsynchronousActualizer_ResumeReadAfterNotifications(t *testing.T) {
 		},
 		func(cfg *istructsmem.AppConfigType) {
 			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+			cfg.AddAsyncProjectors(func(partition istructs.PartitionID) istructs.Projector {
+				return istructs.Projector{Name: incrementorName}
+			})
 		})
 	partitionNr := istructs.PartitionID(1) // test within partition 1
 
@@ -543,6 +564,9 @@ func Test_AsynchronousActualizer_Stress(t *testing.T) {
 		},
 		func(cfg *istructsmem.AppConfigType) {
 			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+			cfg.AddAsyncProjectors(func(partition istructs.PartitionID) istructs.Projector {
+				return istructs.Projector{Name: incrementorName}
+			})
 		})
 	partitionNr := istructs.PartitionID(1) // test within partition 1
 
@@ -647,6 +671,9 @@ func Test_AsynchronousActualizer_NonBuffered(t *testing.T) {
 		},
 		func(cfg *istructsmem.AppConfigType) {
 			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+			cfg.AddAsyncProjectors(func(partition istructs.PartitionID) istructs.Projector {
+				return istructs.Projector{Name: incrementorName}
+			})
 		})
 	partitionNr := istructs.PartitionID(2) // test within partition 2
 
@@ -764,6 +791,9 @@ func Test_AsynchronousActualizer_Stress_NonBuffered(t *testing.T) {
 		},
 		func(cfg *istructsmem.AppConfigType) {
 			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+			cfg.AddAsyncProjectors(func(partition istructs.PartitionID) istructs.Projector {
+				return istructs.Projector{Name: incrementorName}
+			})
 		})
 	partitions := make([]*testPartition, totalPartitions)
 
@@ -928,6 +958,9 @@ func Test_AsynchronousActualizer_Stress_Buffered(t *testing.T) {
 		},
 		func(cfg *istructsmem.AppConfigType) {
 			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+			cfg.AddAsyncProjectors(func(partition istructs.PartitionID) istructs.Projector {
+				return istructs.Projector{Name: incrementorName}
+			})
 		})
 	partitions := make([]*testPartition, totalPartitions)
 

--- a/pkg/projectors/impl_test.go
+++ b/pkg/projectors/impl_test.go
@@ -51,10 +51,20 @@ func TestBasicUsage_SynchronousActualizer(t *testing.T) {
 			ProvideViewDef(appDef, incProjectionView, buildProjectionView)
 			ProvideViewDef(appDef, decProjectionView, buildProjectionView)
 			appDef.AddCommand(testQName)
-			appDef.AddProjector(incrementorName).AddEvent(testQName, appdef.ProjectorEventKind_Execute)
-			appDef.AddProjector(decrementorName).AddEvent(testQName, appdef.ProjectorEventKind_Execute)
+			appDef.AddProjector(incrementorName).AddEvent(testQName, appdef.ProjectorEventKind_Execute).SetSync(true)
+			appDef.AddProjector(decrementorName).AddEvent(testQName, appdef.ProjectorEventKind_Execute).SetSync(true)
 		},
-		nil)
+		func(cfg *istructsmem.AppConfigType) {
+			cfg.AddSyncProjectors(
+				func(istructs.PartitionID) istructs.Projector {
+					return istructs.Projector{Name: incrementorName}
+				},
+				func(istructs.PartitionID) istructs.Projector {
+					return istructs.Projector{Name: decrementorName}
+				},
+			)
+			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+		})
 	actualizerFactory := ProvideSyncActualizerFactory()
 
 	// create actualizer with two factories
@@ -229,10 +239,20 @@ func Test_ErrorInSyncActualizer(t *testing.T) {
 			ProvideViewDef(appDef, incProjectionView, buildProjectionView)
 			ProvideViewDef(appDef, decProjectionView, buildProjectionView)
 			appDef.AddCommand(testQName)
-			appDef.AddProjector(incrementorName).AddEvent(testQName, appdef.ProjectorEventKind_Execute)
-			appDef.AddProjector(decrementorName).AddEvent(testQName, appdef.ProjectorEventKind_Execute)
+			appDef.AddProjector(incrementorName).AddEvent(testQName, appdef.ProjectorEventKind_Execute).SetSync(true)
+			appDef.AddProjector(decrementorName).AddEvent(testQName, appdef.ProjectorEventKind_Execute).SetSync(true)
 		},
-		nil)
+		func(cfg *istructsmem.AppConfigType) {
+			cfg.AddSyncProjectors(
+				func(istructs.PartitionID) istructs.Projector {
+					return istructs.Projector{Name: incrementorName}
+				},
+				func(istructs.PartitionID) istructs.Projector {
+					return istructs.Projector{Name: decrementorName}
+				},
+			)
+			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+		})
 	actualizerFactory := ProvideSyncActualizerFactory()
 
 	// create actualizer with two factories

--- a/pkg/sys/collection/collection_test.go
+++ b/pkg/sys/collection/collection_test.go
@@ -63,7 +63,8 @@ func buildAppParts(t *testing.T) (appParts appparts.IAppPartitions, cleanup func
 		adb.AddWRecord(istructs.QNameWRecord)
 		adb.AddProjector(QNameProjectorCollection).
 			AddEvent(istructs.QNameCRecord, appdef.ProjectorEventKind_Insert, appdef.ProjectorEventKind_Update).
-			AddIntent(state.View, QNameCollectionView)
+			AddIntent(state.View, QNameCollectionView).
+			SetSync(true)
 	}
 	{
 		// fill IAppDef with funcs. That is done here manually because we o not use sys.sql here

--- a/pkg/sys/it/impl_test.go
+++ b/pkg/sys/it/impl_test.go
@@ -47,12 +47,6 @@ func TestBasicUsage(t *testing.T) {
 	cfg := it.NewOwnVITConfig(
 		it.WithApp(istructs.AppQName_test1_app2, func(apis apps.APIs, cfg *istructsmem.AppConfigType, appDefBuilder appdef.IAppDefBuilder, ep extensionpoints.IExtensionPoint) apps.AppPackages {
 			qNameCmdGreeter := appdef.NewQName(app2pkg, "Greeter")
-			// appDefBuilder.AddQuery(qNameCmdGreeter).
-			// 	SetParam(appDefBuilder.AddObject(appdef.NewQName(appdef.SysPackage, "GreeterParams")).
-			// 		AddField("Text", appdef.DataKind_string, true).(appdef.IType).QName()).
-			// 	SetResult(appDefBuilder.AddObject(appdef.NewQName(appdef.SysPackage, "GreeterResult")).
-			// 		AddField("Res", appdef.DataKind_string, true).(appdef.IType).QName())
-
 			cfg.Resources.Add(istructsmem.NewQueryFunction(
 				qNameCmdGreeter,
 				func(_ context.Context, args istructs.ExecQueryArgs, callback istructs.ExecQueryCallback) (err error) {

--- a/pkg/sys/it/testapp.sql
+++ b/pkg/sys/it/testapp.sql
@@ -1,0 +1,18 @@
+-- Copyright (c) 2024-present unTill Software Development Group B.V.
+-- @author Denis Gribanov
+
+APPLICATION app2();
+
+ALTERABLE WORKSPACE test_wsWS (
+	TYPE GreeterParams (
+		Text varchar
+	);
+
+	TYPE GreeterResult (
+		Res varchar
+	);
+
+	EXTENSION ENGINE BUILTIN (
+		QUERY Greeter(GreeterParams) RETURNS GreeterResult;
+	);
+);

--- a/pkg/vit/shared_cfgs.go
+++ b/pkg/vit/shared_cfgs.go
@@ -29,6 +29,7 @@ const (
 	TestEmail2      = "124@124.com"
 	TestServicePort = 10000
 	app1PkgName     = "app1pkg"
+	app2PkgName     = "app2pkg"
 )
 
 var (
@@ -89,6 +90,7 @@ func ProvideApp2(apis apps.APIs, cfg *istructsmem.AppConfigType, adf appdef.IApp
 		QualifiedPackageName: "github.com/voedger/voedger/pkg/vit/app2pkg",
 		FS:                   SchemaTestApp2FS,
 	}
+	cfg.Resources.Add(istructsmem.NewCommandFunction(appdef.NewQName(app2PkgName, "testCmd"), istructsmem.NullCommandExec))
 	return apps.AppPackages{
 		AppQName: istructs.AppQName_test1_app2,
 		Packages: []parser.PackageFS{sysPackageFS, app2PackageFS},
@@ -178,6 +180,15 @@ func ProvideApp1(apis apps.APIs, cfg *istructsmem.AppConfigType, adf appdef.IApp
 		appdef.NewQName(app1PkgName, "CmdODocTwo"),
 		istructsmem.NullCommandExec,
 	))
+
+	cfg.AddAsyncProjectors(func(istructs.PartitionID) istructs.Projector {
+		return istructs.Projector{
+			Name: appdef.NewQName(app1PkgName, "ProjDummy"),
+			Func: func(event istructs.IPLogEvent, state istructs.IState, intents istructs.IIntents) (err error) {
+				return nil
+			},
+		}
+	})
 
 	app1PackageFS := parser.PackageFS{
 		QualifiedPackageName: "github.com/voedger/voedger/pkg/vit/app1pkg",

--- a/pkg/vvm/provide.go
+++ b/pkg/vvm/provide.go
@@ -245,17 +245,17 @@ func provideSecretKeyJWT(sr isecrets.ISecretReader) (itokensjwt.SecretKeyType, e
 	return sr.ReadSecret(itokensjwt.SecretKeyJWTName)
 }
 
-func provideAppsWSAmounts(vvmApps VVMApps, asp istructs.IAppStructsProvider) map[istructs.AppQName]istructs.AppWSAmount {
+func provideAppsWSAmounts(vvmApps VVMApps, asp istructs.IAppStructsProvider) (map[istructs.AppQName]istructs.AppWSAmount, error) {
 	res := map[istructs.AppQName]istructs.AppWSAmount{}
 	for _, appQName := range vvmApps {
 		as, err := asp.AppStructs(appQName)
 		if err != nil {
 			// notest
-			panic(err)
+			return nil, err
 		}
 		res[appQName] = as.WSAmount()
 	}
-	return res
+	return res, nil
 }
 
 func provideMetricsServicePort(msp MetricsServicePortInitial, vvmIdx VVMIdxType) metrics.MetricsServicePort {


### PR DESCRIPTION
Resolves #1462 VVM: validate if correct execs are provided for funcs and projectors defined in vSQL and vice versa
