### PR TITLE
#1549 VVM: use TestSecretsReader if running tests

### DIFF
--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -76,7 +76,9 @@ func newVit(t *testing.T, vitCfg *VITConfig, useCas bool) *VIT {
 	cfg.MetricsServicePort = 0
 
 	cfg.TimeFunc = coreutils.TimeFunc(func() time.Time { return ts.now() })
-	cfg.SecretsReader = itokensjwt.ProvideTestSecretsReader(cfg.SecretsReader)
+	if !coreutils.IsTest() {
+		cfg.SecretsReader = itokensjwt.ProvideTestSecretsReader(cfg.SecretsReader)
+	}
 
 	emailMessagesChan := make(chan smtptest.Message, 1) // must be buffered
 	cfg.ActualizerStateOpts = append(cfg.ActualizerStateOpts, state.WithEmailMessagesChan(emailMessagesChan))

--- a/pkg/vvm/impl_cfg.go
+++ b/pkg/vvm/impl_cfg.go
@@ -17,8 +17,10 @@ import (
 	"github.com/voedger/voedger/pkg/istorage"
 	"github.com/voedger/voedger/pkg/istorage/mem"
 	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/itokensjwt"
 	commandprocessor "github.com/voedger/voedger/pkg/processors/command"
 	"github.com/voedger/voedger/pkg/router"
+	coreutils "github.com/voedger/voedger/pkg/utils"
 )
 
 func NewVVMDefaultConfig() VVMConfig {
@@ -56,6 +58,9 @@ func NewVVMDefaultConfig() VVMConfig {
 			return mem.Provide(), nil
 		},
 		SecretsReader: isecretsimpl.ProvideSecretReader(),
+	}
+	if coreutils.IsTest() {
+		res.SecretsReader = itokensjwt.ProvideTestSecretsReader(res.SecretsReader)
 	}
 	return res
 }


### PR DESCRIPTION
Resolves #1549 VVM: use TestSecretsReader if running tests
