### PR TITLE
#1563 revert: do not allow to create workspaces with kind that is not QName of descriptor

### DIFF
--- a/pkg/sys/it/impl_workspace_test.go
+++ b/pkg/sys/it/impl_workspace_test.go
@@ -125,13 +125,6 @@ func TestBasicUsage_Workspace(t *testing.T) {
 		// whereas appdef.QName.MarshalJSON() func has pointer receiver
 		resp.Println()
 	})
-
-	t.Run("400 bad request on create a workspace with kind that is not a QName of a workspace descriptor", func(t *testing.T) {
-		wsName := vit.NextName()
-		body := fmt.Sprintf(`{"args": {"WSName": "%s","WSKind": "app1pkg.articles","WSKindInitializationData": "{\"WorkStartTime\": \"10\"}","TemplateName": "test","WSClusterID": 1}}`, wsName)
-		resp := vit.PostProfile(prn, "c.sys.InitChildWorkspace", body, coreutils.Expect400())
-		resp.Println()
-	})
 }
 
 func TestWorkspaceAuthorization(t *testing.T) {

--- a/pkg/sys/workspace/provide.go
+++ b/pkg/sys/workspace/provide.go
@@ -19,7 +19,7 @@ func Provide(cfg *istructsmem.AppConfigType, appDefBuilder appdef.IAppDefBuilder
 	// c.sys.InitChildWorkspace
 	cfg.Resources.Add(istructsmem.NewCommandFunction(
 		authnz.QNameCommandInitChildWorkspace,
-		provideExecCmdInitChildWorkspace(appDefBuilder),
+		execCmdInitChildWorkspace,
 	))
 
 	// c.sys.CreateWorkspaceID


### PR DESCRIPTION
Resolves #1563 revert: do not allow to create workspaces with kidn that is not QName of descriptor
