### PR TITLE
#1619 async actualizers: log error if failed to init in 30 seconds

### DIFF
--- a/pkg/projectors/consts.go
+++ b/pkg/projectors/consts.go
@@ -37,6 +37,7 @@ const (
 	actualizerErrorDelay         = time.Second * 30
 	n10nChannelDuration          = 100 * 365 * 24 * time.Hour
 	borrowRetryDelay             = 50 * time.Millisecond
+	initFailureErrorLogInterval  = 30 * time.Second
 )
 
 var PLogUpdatesQName = appdef.NewQName(appdef.SysPackage, "PLogUpdates")


### PR DESCRIPTION
Resolves #1619 async actualizers: log error if failed to init in 30 seconds
