### PR TITLE
#1678 voedger: provide additional device authnz processing funcs instead of use air-related stuff in voedger

### DIFF
--- a/cmd/vpm/main_test.go
+++ b/cmd/vpm/main_test.go
@@ -227,7 +227,7 @@ func TestPkgRegistryCompile(t *testing.T) {
 	require := require.New(t)
 
 	wd, err := os.Getwd()
-	pkgDirLocalPath := wd[:strings.LastIndex(wd, "/cmd/vpm")] + "/pkg"
+	pkgDirLocalPath := wd[:strings.LastIndex(wd, filepath.FromSlash("/cmd/vpm"))] + filepath.FromSlash("/pkg")
 
 	require.NoError(err)
 	defer func() {

--- a/pkg/apps/consts.go
+++ b/pkg/apps/consts.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	EPSchemasFS             extensionpoints.EPKey = "SchemasFS"
+	EPIsDeviceAllowedFunc   extensionpoints.EPKey = "IsDeviceAllowedFunc"
 	storageTypeCas1         string                = "cas1"
 	storageTypeCas3         string                = "cas3"
 	storageTypeMem          string                = "mem"

--- a/pkg/iauthnzimpl/impl.go
+++ b/pkg/iauthnzimpl/impl.go
@@ -145,20 +145,24 @@ func (i *implIAuthenticator) Authenticate(requestContext context.Context, as ist
 			QName: iauthnz.QNameRoleWorkspaceDevice,
 		}
 		if !slices.Contains(principals, prnWSDevice) {
-			compRec, _, err := GetComputersRecByDeviceProfileWSID(as, req.RequestWSID, deviceProfileWSID)
-			if err != nil {
-				return nil, principalPayload, err
+			if i.isDeviceAllowed() {
+				principals = append(principals, prnWSDevice)
 			}
-			if compRec.QName() == appdef.NullQName {
-				break
-			}
-			if compRec.AsBool(appdef.SystemField_IsActive) {
-				principals = append(principals, iauthnz.Principal{
-					Kind:  iauthnz.PrincipalKind_Role,
-					WSID:  deviceProfileWSID,
-					QName: iauthnz.QNameRoleWorkspaceDevice,
-				})
-			}
+
+			// compRec, _, err := GetComputersRecByDeviceProfileWSID(as, req.RequestWSID, deviceProfileWSID)
+			// if err != nil {
+			// 	return nil, principalPayload, err
+			// }
+			// if compRec.QName() == appdef.NullQName {
+			// 	break
+			// }
+			// if compRec.AsBool(appdef.SystemField_IsActive) {
+			// 	principals = append(principals, iauthnz.Principal{
+			// 		Kind:  iauthnz.PrincipalKind_Role,
+			// 		WSID:  deviceProfileWSID,
+			// 		QName: iauthnz.QNameRoleWorkspaceDevice,
+			// 	})
+			// }
 		}
 	}
 

--- a/pkg/iauthnzimpl/impl.go
+++ b/pkg/iauthnzimpl/impl.go
@@ -145,24 +145,14 @@ func (i *implIAuthenticator) Authenticate(requestContext context.Context, as ist
 			QName: iauthnz.QNameRoleWorkspaceDevice,
 		}
 		if !slices.Contains(principals, prnWSDevice) {
-			if i.isDeviceAllowed() {
+			isDeviceAllowed := i.isDeviceAllowedFuncs[as.AppQName()]
+			deviceAllowed, err := isDeviceAllowed(as, req.RequestWSID, deviceProfileWSID)
+			if err != nil {
+				return nil, payloads.PrincipalPayload{}, err
+			}
+			if deviceAllowed {
 				principals = append(principals, prnWSDevice)
 			}
-
-			// compRec, _, err := GetComputersRecByDeviceProfileWSID(as, req.RequestWSID, deviceProfileWSID)
-			// if err != nil {
-			// 	return nil, principalPayload, err
-			// }
-			// if compRec.QName() == appdef.NullQName {
-			// 	break
-			// }
-			// if compRec.AsBool(appdef.SystemField_IsActive) {
-			// 	principals = append(principals, iauthnz.Principal{
-			// 		Kind:  iauthnz.PrincipalKind_Role,
-			// 		WSID:  deviceProfileWSID,
-			// 		QName: iauthnz.QNameRoleWorkspaceDevice,
-			// 	})
-			// }
 		}
 	}
 

--- a/pkg/iauthnzimpl/impl_test.go
+++ b/pkg/iauthnzimpl/impl_test.go
@@ -22,9 +22,8 @@ import (
 )
 
 const (
-	alienWSID                 = 3
-	nonInitedWSID             = 4
-	unlinkedDeviceProfileWSID = 5
+	alienWSID     = 3
+	nonInitedWSID = 4
 )
 
 func TestBasicUsage(t *testing.T) {
@@ -48,7 +47,7 @@ func TestBasicUsage(t *testing.T) {
 	token, err := appTokens.IssueToken(time.Minute, &pp)
 	require.NoError(err)
 
-	appStructs := AppStructsWithTestStorage(map[istructs.WSID]map[appdef.QName]map[istructs.RecordID]map[string]interface{}{
+	appStructs := AppStructsWithTestStorage(istructs.AppQName_test1_app1, map[istructs.WSID]map[appdef.QName]map[istructs.RecordID]map[string]interface{}{
 		// WSID 1 is the user profile, not necessary to store docs there
 
 		// workspace owned by the user
@@ -71,7 +70,7 @@ func TestBasicUsage(t *testing.T) {
 			},
 		},
 	})
-	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFunc)
+	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFuncs)
 	authz := NewDefaultAuthorizer()
 	t.Run("authenticate in the profile", func(t *testing.T) {
 		req := iauthnz.AuthnRequest{
@@ -190,13 +189,9 @@ func TestAuthenticate(t *testing.T) {
 	deviceToken, err := appTokens.IssueToken(time.Minute, &pp)
 	require.NoError(err)
 
-	pp.ProfileWSID = unlinkedDeviceProfileWSID
-	unlinkedDeviceToken, err := appTokens.IssueToken(time.Minute, &pp)
-	require.NoError(err)
-
 	qNameCDocComputers := appdef.NewQName("untill", "computers")
 
-	appStructs := AppStructsWithTestStorage(map[istructs.WSID]map[appdef.QName]map[istructs.RecordID]map[string]interface{}{
+	appStructs := AppStructsWithTestStorage(istructs.AppQName_test1_app1, map[istructs.WSID]map[appdef.QName]map[istructs.RecordID]map[string]interface{}{
 		// WSID 1 is the user profile
 		istructs.WSID(1): {
 			qNameViewDeviceProfileWSIDIdx: {
@@ -206,13 +201,6 @@ func TestAuthenticate(t *testing.T) {
 					appdef.SystemField_IsActive: true,
 					field_ComputersID:           istructs.RecordID(2),
 					field_RestaurantComputersID: istructs.RecordID(3),
-				},
-				4: {
-					field_dummy:                 int32(1),
-					field_DeviceProfileWSID:     int64(unlinkedDeviceProfileWSID),
-					appdef.SystemField_IsActive: true,
-					field_ComputersID:           istructs.RecordID(5),
-					field_RestaurantComputersID: istructs.RecordID(6),
 				},
 			},
 			// wrong to store in the user profile wsid, but ok for test
@@ -346,18 +334,6 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc: "unlinked device -> host + device",
-			req: iauthnz.AuthnRequest{
-				Host:        "127.0.0.1",
-				RequestWSID: 1,
-				Token:       unlinkedDeviceToken,
-			},
-			expectedPrincipals: []iauthnz.Principal{
-				{Kind: iauthnz.PrincipalKind_Device, WSID: unlinkedDeviceProfileWSID},
-				{Kind: iauthnz.PrincipalKind_Host, Name: "127.0.0.1"},
-			},
-		},
-		{
 			desc: "ResellerAdmin -> WorkspaceAdmin",
 			req: iauthnz.AuthnRequest{
 				Host:        "127.0.0.1",
@@ -405,14 +381,14 @@ func TestAuthenticate(t *testing.T) {
 	subjectsGetter := func(context.Context, string, istructs.IAppStructs, istructs.WSID) ([]appdef.QName, error) {
 		return *subjects, nil
 	}
-	authn := NewDefaultAuthenticator(subjectsGetter, TestIsDeviceAllowedFunc)
+	authn := NewDefaultAuthenticator(subjectsGetter, TestIsDeviceAllowedFuncs)
 	for _, tc := range testCases {
 		localVarSubjects := &tc.subjects
 		t.Run(tc.desc, func(t *testing.T) {
 			subjects = localVarSubjects
 			principals, _, err := authn.Authenticate(context.Background(), appStructs, appTokens, tc.req)
 			require.NoError(err)
-			require.Equal(tc.expectedPrincipals, principals)
+			require.Equal(tc.expectedPrincipals, principals, tc.desc)
 		})
 	}
 }
@@ -446,13 +422,9 @@ func TestAuthorize(t *testing.T) {
 	deviceToken, err := appTokens.IssueToken(time.Minute, &pp)
 	require.NoError(err)
 
-	pp.ProfileWSID = unlinkedDeviceProfileWSID
-	unlinkedDeviceToken, err := appTokens.IssueToken(time.Minute, &pp)
-	require.NoError(err)
-
 	qNameCDocComputers := appdef.NewQName("untill", "computers")
 
-	appStructs := AppStructsWithTestStorage(map[istructs.WSID]map[appdef.QName]map[istructs.RecordID]map[string]interface{}{
+	appStructs := AppStructsWithTestStorage(istructs.AppQName_test1_app1, map[istructs.WSID]map[appdef.QName]map[istructs.RecordID]map[string]interface{}{
 		// workspace owned by the user
 		istructs.WSID(2): {
 			qNameCDocWorkspaceDescriptor: {
@@ -468,13 +440,6 @@ func TestAuthorize(t *testing.T) {
 					appdef.SystemField_IsActive: true,
 					field_ComputersID:           istructs.RecordID(3),
 					field_RestaurantComputersID: istructs.RecordID(4),
-				},
-				5: {
-					field_dummy:                 int32(1),
-					field_DeviceProfileWSID:     int64(unlinkedDeviceProfileWSID),
-					appdef.SystemField_IsActive: true,
-					field_ComputersID:           istructs.RecordID(6),
-					field_RestaurantComputersID: istructs.RecordID(7),
 				},
 			},
 			// wrong to store in the user profile wsid, but ok for test
@@ -500,7 +465,7 @@ func TestAuthorize(t *testing.T) {
 			},
 		},
 	})
-	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFunc)
+	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFuncs)
 	authz := NewDefaultAuthorizer()
 
 	testCmd := appdef.NewQName(appdef.SysPackage, "testcmd")
@@ -592,18 +557,6 @@ func TestAuthorize(t *testing.T) {
 				Resource:      testCmd,
 			},
 			expected: true,
-		},
-		{
-			desc: "execute in an owned workspace with an unlinked device token -> !ok",
-			reqn: iauthnz.AuthnRequest{
-				RequestWSID: 2,
-				Token:       unlinkedDeviceToken,
-			},
-			reqz: iauthnz.AuthzRequest{
-				OperationKind: iauthnz.OperationKind_EXECUTE,
-				Resource:      testCmd,
-			},
-			expected: false,
 		},
 	}
 
@@ -942,7 +895,7 @@ func TestErrors(t *testing.T) {
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(istructs.AppQName_test1_app1)
 
 	appStructs := &implIAppStructs{}
-	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFunc)
+	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFuncs)
 
 	t.Run("wrong token", func(t *testing.T) {
 		req := iauthnz.AuthnRequest{
@@ -999,7 +952,7 @@ func BenchmarkBasic(b *testing.B) {
 	require.NoError(b, err)
 	var principals []iauthnz.Principal
 	appStructs := &implIAppStructs{}
-	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFunc)
+	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFuncs)
 	authz := NewDefaultAuthorizer()
 	reqn := iauthnz.AuthnRequest{
 		Host:        "127.0.0.1",
@@ -1024,14 +977,15 @@ func BenchmarkBasic(b *testing.B) {
 	}
 }
 
-func AppStructsWithTestStorage(data map[istructs.WSID]map[appdef.QName]map[istructs.RecordID]map[string]interface{}) istructs.IAppStructs {
+func AppStructsWithTestStorage(appQName istructs.AppQName, data map[istructs.WSID]map[appdef.QName]map[istructs.RecordID]map[string]interface{}) istructs.IAppStructs {
 	recs := &implIRecords{data: data}
-	return &implIAppStructs{records: recs, views: &implIViewRecords{records: recs}}
+	return &implIAppStructs{records: recs, views: &implIViewRecords{records: recs}, appQName: appQName}
 }
 
 type implIAppStructs struct {
-	records *implIRecords
-	views   *implIViewRecords
+	records  *implIRecords
+	views    *implIViewRecords
+	appQName istructs.AppQName
 }
 
 func (as *implIAppStructs) AppDef() appdef.IAppDef                             { panic("") }
@@ -1041,7 +995,7 @@ func (as *implIAppStructs) ViewRecords() istructs.IViewRecords                 {
 func (as *implIAppStructs) ObjectBuilder(appdef.QName) istructs.IObjectBuilder { panic("") }
 func (as *implIAppStructs) Resources() istructs.IResources                     { panic("") }
 func (as *implIAppStructs) ClusterAppID() istructs.ClusterAppID                { panic("") }
-func (as *implIAppStructs) AppQName() istructs.AppQName                        { panic("") }
+func (as *implIAppStructs) AppQName() istructs.AppQName                        { return as.appQName }
 func (as *implIAppStructs) IsFunctionRateLimitsExceeded(appdef.QName, istructs.WSID) bool {
 	panic("")
 }

--- a/pkg/iauthnzimpl/impl_test.go
+++ b/pkg/iauthnzimpl/impl_test.go
@@ -71,7 +71,7 @@ func TestBasicUsage(t *testing.T) {
 			},
 		},
 	})
-	authn := NewDefaultAuthenticator(TestSubjectRolesGetter)
+	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFunc)
 	authz := NewDefaultAuthorizer()
 	t.Run("authenticate in the profile", func(t *testing.T) {
 		req := iauthnz.AuthnRequest{
@@ -405,7 +405,7 @@ func TestAuthenticate(t *testing.T) {
 	subjectsGetter := func(context.Context, string, istructs.IAppStructs, istructs.WSID) ([]appdef.QName, error) {
 		return *subjects, nil
 	}
-	authn := NewDefaultAuthenticator(subjectsGetter)
+	authn := NewDefaultAuthenticator(subjectsGetter, TestIsDeviceAllowedFunc)
 	for _, tc := range testCases {
 		localVarSubjects := &tc.subjects
 		t.Run(tc.desc, func(t *testing.T) {
@@ -500,7 +500,7 @@ func TestAuthorize(t *testing.T) {
 			},
 		},
 	})
-	authn := NewDefaultAuthenticator(TestSubjectRolesGetter)
+	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFunc)
 	authz := NewDefaultAuthorizer()
 
 	testCmd := appdef.NewQName(appdef.SysPackage, "testcmd")
@@ -942,7 +942,7 @@ func TestErrors(t *testing.T) {
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(istructs.AppQName_test1_app1)
 
 	appStructs := &implIAppStructs{}
-	authn := NewDefaultAuthenticator(TestSubjectRolesGetter)
+	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFunc)
 
 	t.Run("wrong token", func(t *testing.T) {
 		req := iauthnz.AuthnRequest{
@@ -999,7 +999,7 @@ func BenchmarkBasic(b *testing.B) {
 	require.NoError(b, err)
 	var principals []iauthnz.Principal
 	appStructs := &implIAppStructs{}
-	authn := NewDefaultAuthenticator(TestSubjectRolesGetter)
+	authn := NewDefaultAuthenticator(TestSubjectRolesGetter, TestIsDeviceAllowedFunc)
 	authz := NewDefaultAuthorizer()
 	reqn := iauthnz.AuthnRequest{
 		Host:        "127.0.0.1",

--- a/pkg/iauthnzimpl/provide.go
+++ b/pkg/iauthnzimpl/provide.go
@@ -6,19 +6,22 @@ package iauthnzimpl
 
 import (
 	"github.com/voedger/voedger/pkg/iauthnz"
+	"github.com/voedger/voedger/pkg/istructs"
 )
 
 func NewDefaultAuthorizer() iauthnz.IAuthorizer {
 	return &implIAuthorizer{acl: defaultACL}
 }
 
-func NewDefaultAuthenticator(subjectRolesGetter SubjectGetterFunc, isDeviceAllowedFunc IsDeviceAllowedFunc) iauthnz.IAuthenticator {
+func NewDefaultAuthenticator(subjectRolesGetter SubjectGetterFunc, isDeviceAllowedFuncs IsDeviceAllowedFuncs) iauthnz.IAuthenticator {
 	return &implIAuthenticator{
-		subjectRolesGetter: subjectRolesGetter,
-		isDeviceAllowed:    isDeviceAllowedFunc,
+		subjectRolesGetter:   subjectRolesGetter,
+		isDeviceAllowedFuncs: isDeviceAllowedFuncs,
 	}
 }
 
-func TestIsDeviceAllowedFunc() bool {
-	return true
+var TestIsDeviceAllowedFuncs = IsDeviceAllowedFuncs{
+	istructs.AppQName_test1_app1: func(as istructs.IAppStructs, requestWSID istructs.WSID, deviceProfileWSID istructs.WSID) (ok bool, err error) {
+		return true, nil
+	},
 }

--- a/pkg/iauthnzimpl/provide.go
+++ b/pkg/iauthnzimpl/provide.go
@@ -12,6 +12,13 @@ func NewDefaultAuthorizer() iauthnz.IAuthorizer {
 	return &implIAuthorizer{acl: defaultACL}
 }
 
-func NewDefaultAuthenticator(subjectRolesGetter SubjectGetterFunc) iauthnz.IAuthenticator {
-	return &implIAuthenticator{subjectRolesGetter: subjectRolesGetter}
+func NewDefaultAuthenticator(subjectRolesGetter SubjectGetterFunc, isDeviceAllowedFunc IsDeviceAllowedFunc) iauthnz.IAuthenticator {
+	return &implIAuthenticator{
+		subjectRolesGetter: subjectRolesGetter,
+		isDeviceAllowed:    isDeviceAllowedFunc,
+	}
+}
+
+func TestIsDeviceAllowedFunc() bool {
+	return true
 }

--- a/pkg/iauthnzimpl/types.go
+++ b/pkg/iauthnzimpl/types.go
@@ -18,6 +18,7 @@ type implIAuthorizer struct {
 
 type implIAuthenticator struct {
 	subjectRolesGetter SubjectGetterFunc
+	isDeviceAllowed    func() bool
 }
 
 type ACElem struct {
@@ -38,3 +39,5 @@ type PatternType struct {
 type ACPolicyType int
 
 type SubjectGetterFunc = func(requestContext context.Context, name string, as istructs.IAppStructs, wsid istructs.WSID) ([]appdef.QName, error)
+
+type IsDeviceAllowedFunc func() bool

--- a/pkg/iauthnzimpl/types.go
+++ b/pkg/iauthnzimpl/types.go
@@ -17,8 +17,8 @@ type implIAuthorizer struct {
 }
 
 type implIAuthenticator struct {
-	subjectRolesGetter SubjectGetterFunc
-	isDeviceAllowed    func() bool
+	subjectRolesGetter   SubjectGetterFunc
+	isDeviceAllowedFuncs IsDeviceAllowedFuncs
 }
 
 type ACElem struct {
@@ -40,4 +40,5 @@ type ACPolicyType int
 
 type SubjectGetterFunc = func(requestContext context.Context, name string, as istructs.IAppStructs, wsid istructs.WSID) ([]appdef.QName, error)
 
-type IsDeviceAllowedFunc func() bool
+type IsDeviceAllowedFunc = func(as istructs.IAppStructs, requestWSID istructs.WSID, deviceProfileWSID istructs.WSID) (ok bool, err error)
+type IsDeviceAllowedFuncs map[istructs.AppQName]IsDeviceAllowedFunc

--- a/pkg/processors/command/impl_test.go
+++ b/pkg/processors/command/impl_test.go
@@ -738,7 +738,7 @@ func setUp(t *testing.T, prepare func(appDef appdef.IAppDefBuilder, cfg *istruct
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(testAppName)
 	systemToken, err := payloads.GetSystemPrincipalTokenApp(appTokens)
 	require.NoError(err)
-	cmdProcessorFactory := ProvideServiceFactory(appParts, time.Now, n10nBroker, imetrics.Provide(), "vvm", iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter), iauthnzimpl.NewDefaultAuthorizer(), secretReader)
+	cmdProcessorFactory := ProvideServiceFactory(appParts, time.Now, n10nBroker, imetrics.Provide(), "vvm", iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc), iauthnzimpl.NewDefaultAuthorizer(), secretReader)
 	cmdProcService := cmdProcessorFactory(serviceChannel, testAppPartID)
 
 	go func() {

--- a/pkg/processors/command/impl_test.go
+++ b/pkg/processors/command/impl_test.go
@@ -738,7 +738,7 @@ func setUp(t *testing.T, prepare func(appDef appdef.IAppDefBuilder, cfg *istruct
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(testAppName)
 	systemToken, err := payloads.GetSystemPrincipalTokenApp(appTokens)
 	require.NoError(err)
-	cmdProcessorFactory := ProvideServiceFactory(appParts, time.Now, n10nBroker, imetrics.Provide(), "vvm", iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc), iauthnzimpl.NewDefaultAuthorizer(), secretReader)
+	cmdProcessorFactory := ProvideServiceFactory(appParts, time.Now, n10nBroker, imetrics.Provide(), "vvm", iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFuncs), iauthnzimpl.NewDefaultAuthorizer(), secretReader)
 	cmdProcService := cmdProcessorFactory(serviceChannel, testAppPartID)
 
 	go func() {

--- a/pkg/processors/query/impl_test.go
+++ b/pkg/processors/query/impl_test.go
@@ -359,7 +359,7 @@ func TestBasicUsage_ServiceFactory(t *testing.T) {
 	appParts.DeployApp(appName, appDef, partCount, appEngines)
 	appParts.DeployAppPartitions(appName, []istructs.PartitionID{partID})
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	queryProcessor := ProvideServiceFactory()(
 		serviceChannel,
@@ -1124,7 +1124,7 @@ func TestRateLimiter(t *testing.T) {
 
 	// create aquery processor
 	metrics := imetrics.Provide()
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	queryProcessor := ProvideServiceFactory()(
 		serviceChannel,
@@ -1179,7 +1179,7 @@ func TestAuthnz(t *testing.T) {
 	appParts.DeployApp(appName, appDef, partCount, appEngines)
 	appParts.DeployAppPartitions(appName, []istructs.PartitionID{partID})
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	queryProcessor := ProvideServiceFactory()(
 		serviceChannel,

--- a/pkg/processors/query/impl_test.go
+++ b/pkg/processors/query/impl_test.go
@@ -359,7 +359,7 @@ func TestBasicUsage_ServiceFactory(t *testing.T) {
 	appParts.DeployApp(appName, appDef, partCount, appEngines)
 	appParts.DeployAppPartitions(appName, []istructs.PartitionID{partID})
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFuncs)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	queryProcessor := ProvideServiceFactory()(
 		serviceChannel,
@@ -1124,7 +1124,7 @@ func TestRateLimiter(t *testing.T) {
 
 	// create aquery processor
 	metrics := imetrics.Provide()
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFuncs)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	queryProcessor := ProvideServiceFactory()(
 		serviceChannel,
@@ -1179,7 +1179,7 @@ func TestAuthnz(t *testing.T) {
 	appParts.DeployApp(appName, appDef, partCount, appEngines)
 	appParts.DeployAppPartitions(appName, []istructs.PartitionID{partID})
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFuncs)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	queryProcessor := ProvideServiceFactory()(
 		serviceChannel,

--- a/pkg/processors/query/query-params-impl_test.go
+++ b/pkg/processors/query/query-params-impl_test.go
@@ -31,7 +31,7 @@ func TestWrongTypes(t *testing.T) {
 		}
 	}
 	done := make(chan struct{})
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFuncs)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 
 	appDef, appStructsProvider, appTokens := getTestCfg(require, nil)

--- a/pkg/processors/query/query-params-impl_test.go
+++ b/pkg/processors/query/query-params-impl_test.go
@@ -31,7 +31,7 @@ func TestWrongTypes(t *testing.T) {
 		}
 	}
 	done := make(chan struct{})
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 
 	appDef, appStructsProvider, appTokens := getTestCfg(require, nil)

--- a/pkg/sys/collection/collection_test.go
+++ b/pkg/sys/collection/collection_test.go
@@ -519,7 +519,7 @@ func TestBasicUsage_QueryFunc_Collection(t *testing.T) {
 	serviceChannel := make(iprocbus.ServiceChannel)
 	out := newTestSender()
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFuncs)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, time.Now)
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(test.appQName)
@@ -637,7 +637,7 @@ func TestBasicUsage_QueryFunc_CDoc(t *testing.T) {
 	serviceChannel := make(iprocbus.ServiceChannel)
 	out := newTestSender()
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFuncs)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, time.Now)
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(test.appQName)
@@ -756,7 +756,7 @@ func TestBasicUsage_State(t *testing.T) {
 	serviceChannel := make(iprocbus.ServiceChannel)
 	out := newTestSender()
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFuncs)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, time.Now)
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(test.appQName)
@@ -925,7 +925,7 @@ func TestState_withAfterArgument(t *testing.T) {
 	serviceChannel := make(iprocbus.ServiceChannel)
 	out := newTestSender()
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFuncs)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, time.Now)
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(test.appQName)

--- a/pkg/sys/collection/collection_test.go
+++ b/pkg/sys/collection/collection_test.go
@@ -519,7 +519,7 @@ func TestBasicUsage_QueryFunc_Collection(t *testing.T) {
 	serviceChannel := make(iprocbus.ServiceChannel)
 	out := newTestSender()
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, time.Now)
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(test.appQName)
@@ -637,7 +637,7 @@ func TestBasicUsage_QueryFunc_CDoc(t *testing.T) {
 	serviceChannel := make(iprocbus.ServiceChannel)
 	out := newTestSender()
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, time.Now)
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(test.appQName)
@@ -756,7 +756,7 @@ func TestBasicUsage_State(t *testing.T) {
 	serviceChannel := make(iprocbus.ServiceChannel)
 	out := newTestSender()
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, time.Now)
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(test.appQName)
@@ -925,7 +925,7 @@ func TestState_withAfterArgument(t *testing.T) {
 	serviceChannel := make(iprocbus.ServiceChannel)
 	out := newTestSender()
 
-	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter)
+	authn := iauthnzimpl.NewDefaultAuthenticator(iauthnzimpl.TestSubjectRolesGetter, iauthnzimpl.TestIsDeviceAllowedFunc)
 	authz := iauthnzimpl.NewDefaultAuthorizer()
 	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, time.Now)
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(test.appQName)

--- a/pkg/sys/it/impl_signupin_test.go
+++ b/pkg/sys/it/impl_signupin_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/voedger/voedger/pkg/istructs"
+	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
 	coreutils "github.com/voedger/voedger/pkg/utils"
 	it "github.com/voedger/voedger/pkg/vit"
 )
@@ -149,4 +150,23 @@ func TestSignInErrors(t *testing.T) {
 			login, istructs.AppQName_test1_app1.String())
 		vit.PostApp(istructs.AppQName_sys_registry, pseudoWSID, "q.registry.IssuePrincipalToken", body, coreutils.Expect401()).Println()
 	})
+}
+
+func TestDeviceProfile(t *testing.T) {
+	require := require.New(t)
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+	loginName := vit.NextName()
+	deviceLogin := vit.SignUpDevice(loginName, "123", istructs.AppQName_test1_app1)
+	devicePrn := vit.SignIn(deviceLogin)
+	as, err := vit.AppStructs(istructs.AppQName_test1_app1)
+	require.NoError(err)
+	devicePrnPayload := payloads.PrincipalPayload{}
+	_, err = as.AppTokens().ValidateToken(devicePrn.Token, &devicePrnPayload)
+	require.NoError(err)
+	require.Equal(istructs.SubjectKind_Device, devicePrnPayload.SubjectKind)
+
+	// try to exec a simple operation in device profile
+	body := `{"args":{"Schema":"sys.WorkspaceDescriptor"},"elements":[{"fields":["sys.ID"]}]}`
+	vit.PostProfile(devicePrn, "q.sys.Collection", body)
 }

--- a/pkg/vvm/provide.go
+++ b/pkg/vvm/provide.go
@@ -185,6 +185,14 @@ func ProvideCluster(vvmCtx context.Context, vvmConfig *VVMConfig, vvmIdx VVMIdxT
 	))
 }
 
+func provideIsDevicaAllowedFunc(ep extensionpoints.IExtensionPoint) iauthnzimpl.IsDeviceAllowedFunc {
+	val, ok := ep.Find(apps.EPIsDeviceAllowedFunc)
+	if !ok {
+		return iauthnzimpl.TestIsDeviceAllowedFunc
+	}
+	return val.(iauthnzimpl.IsDeviceAllowedFunc)
+}
+
 func provideBuiltInApps(builtInAppsPackages []BuiltInAppsPackages) []apppartsctl.BuiltInApp {
 	res := make([]apppartsctl.BuiltInApp, len(builtInAppsPackages))
 	for i, pkg := range builtInAppsPackages {


### PR DESCRIPTION
Resolves #1678 voedger: provide additional device authnz processing funcs instead of use air-related stuff in voedger
