### PR TITLE
#1720 fix TestInvite_BasicUsage()

### DIFF
--- a/pkg/sys/it/impl_invite_test.go
+++ b/pkg/sys/it/impl_invite_test.go
@@ -202,8 +202,8 @@ func TestInvite_BasicUsage(t *testing.T) {
 	initiateUpdateInviteRoles(inviteID)
 	initiateUpdateInviteRoles(inviteID2)
 
-	WaitForInviteState(vit, ws, inviteID, invite.State_ToUpdateRoles)
-	WaitForInviteState(vit, ws, inviteID2, invite.State_ToUpdateRoles)
+	WaitForInviteState(vit, ws, inviteID, invite.State_Joined, invite.State_ToUpdateRoles)
+	WaitForInviteState(vit, ws, inviteID2, invite.State_Joined, invite.State_ToUpdateRoles)
 	cDocInvite = findCDocInviteByID(inviteID)
 
 	require.Equal(float64(vit.Now().UnixMilli()), cDocInvite[8])


### PR DESCRIPTION
Resolves #1720 fix TestInvite_BasicUsage()
