### PR TITLE
#1725 VIT: fix delay on IAppStorage.Get()

### DIFF
--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -492,9 +492,9 @@ func (vit *VIT) CaptureEmail() (msg smtptest.Message) {
 // will be automatically reset to 0 on TearDown
 func (vit *VIT) SetMemStorageGetDelay(delay time.Duration) {
 	vit.T.Helper()
-	vit.getStorageDelaySetter().SetTestDelayPut(delay)
+	vit.getStorageDelaySetter().SetTestDelayGet(delay)
 	vit.cleanups = append(vit.cleanups, func(vit *VIT) {
-		vit.getStorageDelaySetter().SetTestDelayPut(0)
+		vit.getStorageDelaySetter().SetTestDelayGet(0)
 	})
 }
 


### PR DESCRIPTION
Resolves #1725 VIT: fix delay on IAppStorage.Get()
