### PR TITLE
#1757 VVM: make so metrics service will not start to listen on Provide(). Listen on Prepare() instead

### DIFF
--- a/pkg/vvm/metrics/impl.go
+++ b/pkg/vvm/metrics/impl.go
@@ -14,7 +14,13 @@ import (
 	"github.com/untillpro/goutils/logger"
 
 	imetrics "github.com/voedger/voedger/pkg/metrics"
+	coreutils "github.com/voedger/voedger/pkg/utils"
 )
+
+func (ms *metricsService) Prepare(interface{}) (err error) {
+	ms.listener, err = net.Listen("tcp", coreutils.ServerAddress(ms.port))
+	return err
+}
 
 func (ms *metricsService) Run(_ context.Context) {
 	logger.Info("Starting Metrics Service on", ms.listener.Addr().(*net.TCPAddr).String())

--- a/pkg/vvm/metrics/provide.go
+++ b/pkg/vvm/metrics/provide.go
@@ -12,15 +12,9 @@ import (
 
 	imetrics "github.com/voedger/voedger/pkg/metrics"
 	router2 "github.com/voedger/voedger/pkg/router"
-	coreutils "github.com/voedger/voedger/pkg/utils"
 )
 
 func ProvideMetricsService(vvmCtx context.Context, metricsServicePort MetricsServicePort, imetrics imetrics.IMetrics) MetricsService {
-	listener, err := net.Listen("tcp", coreutils.ServerAddress(int(metricsServicePort)))
-	if err != nil {
-		panic(err)
-	}
-
 	return &metricsService{
 		Server: &http.Server{
 			Handler: provideHandler(imetrics),
@@ -29,6 +23,6 @@ func ProvideMetricsService(vvmCtx context.Context, metricsServicePort MetricsSer
 			},
 			ReadHeaderTimeout: router2.DefaultRouterReadTimeout * time.Second, // avoiding potential Slowloris attack (G112 linter rule)
 		},
-		listener: listener,
+		port: int(metricsServicePort),
 	}
 }

--- a/pkg/vvm/metrics/types.go
+++ b/pkg/vvm/metrics/types.go
@@ -18,4 +18,5 @@ type metricsService struct {
 	pipeline.NOPService
 	*http.Server
 	listener net.Listener
+	port     int
 }


### PR DESCRIPTION
Resolves #1757 VVM: make so metrics service will not start to listen on Provide(). Listen on Prepare() instead
