### PR TITLE
#1799 coreutils: rename Marshal() -> MapToObject()

### DIFF
--- a/pkg/processors/command/impl.go
+++ b/pkg/processors/command/impl.go
@@ -685,14 +685,14 @@ func (cmdProc *cmdProc) authorizeCUDs(_ context.Context, work interface{}) (err 
 func (cmdProc *cmdProc) writeCUDs(_ context.Context, work interface{}) (err error) {
 	cmd := work.(*cmdWorkpiece)
 	for _, parsedCUD := range cmd.parsedCUDs {
-		var rowWriter istructs.IRowWriter
+		var cud istructs.IRowWriter
 		if parsedCUD.opKind == iauthnz.OperationKind_INSERT {
-			rowWriter = cmd.reb.CUDBuilder().Create(parsedCUD.qName)
-			rowWriter.PutRecordID(appdef.SystemField_ID, istructs.RecordID(parsedCUD.id))
+			cud = cmd.reb.CUDBuilder().Create(parsedCUD.qName)
+			cud.PutRecordID(appdef.SystemField_ID, istructs.RecordID(parsedCUD.id))
 		} else {
-			rowWriter = cmd.reb.CUDBuilder().Update(parsedCUD.existingRecord)
+			cud = cmd.reb.CUDBuilder().Update(parsedCUD.existingRecord)
 		}
-		if err := coreutils.Marshal(rowWriter, parsedCUD.fields); err != nil {
+		if err := coreutils.MapToObject(parsedCUD.fields, cud); err != nil {
 			return parsedCUD.xPath.Error(err)
 		}
 	}

--- a/pkg/sys/workspace/impl.go
+++ b/pkg/sys/workspace/impl.go
@@ -286,7 +286,7 @@ func execCmdCreateWorkspace(now coreutils.TimeFunc, asp istructs.IAppStructsProv
 				return err
 			}
 			cdocWSKind.PutRecordID(appdef.SystemField_ID, 2)
-			return coreutils.Marshal(cdocWSKind, wsKindInitializationData) // validated already in func()
+			return coreutils.MapToObject(wsKindInitializationData, cdocWSKind) // validated already in func()
 		}
 		return nil
 	}

--- a/pkg/sys/workspace/utils.go
+++ b/pkg/sys/workspace/utils.go
@@ -24,7 +24,7 @@ func validateWSKindInitializationData(as istructs.IAppStructs, data map[string]i
 	aob := reb.ArgumentObjectBuilder()
 	aob.PutQName(appdef.SystemField_QName, t.QName())
 	aob.PutRecordID(appdef.SystemField_ID, 1)
-	if err = coreutils.Marshal(aob, data); err != nil {
+	if err = coreutils.MapToObject(data, aob); err != nil {
 		return err
 	}
 	_, err = aob.Build()

--- a/pkg/utils/maps.go
+++ b/pkg/utils/maps.go
@@ -25,7 +25,7 @@ func PairsToMap(pairs []string, m map[string]string) error {
 	return nil
 }
 
-func Marshal(rw istructs.IRowWriter, data map[string]interface{}) (err error) {
+func MapToObject(data map[string]interface{}, rw istructs.IRowWriter) (err error) {
 	for fieldName, vIntf := range data {
 		switch v := vIntf.(type) {
 		case nil:
@@ -36,7 +36,7 @@ func Marshal(rw istructs.IRowWriter, data map[string]interface{}) (err error) {
 		case bool:
 			rw.PutBool(fieldName, v)
 		default:
-			return fmt.Errorf("field %s: marshal unsupported value type %#v", fieldName, vIntf)
+			return fmt.Errorf("field %s: unsupported value type %#v", fieldName, vIntf)
 		}
 	}
 	return nil

--- a/pkg/utils/maps_test.go
+++ b/pkg/utils/maps_test.go
@@ -49,17 +49,17 @@ func TestPairsToMapErrors(t *testing.T) {
 	}
 }
 
-func TestMarshal(t *testing.T) {
+func TestMapToObject(t *testing.T) {
 	o := &TestObject{
 		Data: map[string]interface{}{},
 	}
 	require := require.New(t)
-	require.NoError(Marshal(o, map[string]interface{}{
+	require.NoError(MapToObject(map[string]interface{}{
 		"float64": float64(42),
 		"str":     "str1",
 		"bool":    true,
 		"any":     nil, // will be ignored
-	}))
+	}, o))
 	require.Len(o.Data, 3)
 	require.Equal(float64(42), o.Data["float64"])
 	require.Equal("str1", o.Data["str"])
@@ -67,5 +67,5 @@ func TestMarshal(t *testing.T) {
 	require.True(ok)
 	require.True(v)
 
-	require.Error(Marshal(o, map[string]interface{}{"fld": 42}))
+	require.Error(MapToObject(map[string]interface{}{"fld": 42}, o))
 }


### PR DESCRIPTION
Resolves #1799 coreutils: rename Marshal() -> MapToObject()
