### PR TITLE
#1806 asp.DeactivateWorkspace: must use IState, not use IAppStructsProvider

### DIFF
--- a/pkg/sys/workspace/provide.go
+++ b/pkg/sys/workspace/provide.go
@@ -44,7 +44,7 @@ func Provide(cfg *istructsmem.AppConfigType, appDefBuilder appdef.IAppDefBuilder
 	provideViewNextWSID(appDefBuilder)
 
 	// deactivate workspace
-	provideDeactivateWorkspace(cfg, tokensAPI, federation, asp)
+	provideDeactivateWorkspace(cfg, tokensAPI, federation)
 
 	// projectors
 	cfg.AddAsyncProjectors(


### PR DESCRIPTION
Resolves #1806 asp.DeactivateWorkspace: must use IState, not use IAppStructsProvider
