### PR TITLE
#1974 VVM APIs: eliminate `vvm.VVM.IAppStorageFactory`

### DIFF
--- a/pkg/cluster/impl_deployapp.go
+++ b/pkg/cluster/impl_deployapp.go
@@ -74,8 +74,11 @@ func provideExecDeployApp(asp istructs.IAppStructsProvider, timeFunc coreutils.T
 			// notest
 			return err
 		}
-		_, err = InitAppWSes(as, numAppWorkspaces, numAppPartitions, istructs.UnixMilli(timeFunc().UnixMilli()))
-		return err
+		if _, err = InitAppWSes(as, numAppWorkspaces, numAppPartitions, istructs.UnixMilli(timeFunc().UnixMilli())); err != nil {
+			return fmt.Errorf("failed to deploy %s: %w", appQName, err)
+		}
+		logger.Info(fmt.Sprintf("app %s successfully deployed: NumPartitions=%d, NumAppWorkspaces=%d", appQName, numAppPartitions, numAppWorkspaces))
+		return nil
 	}
 }
 

--- a/pkg/vvm/types.go
+++ b/pkg/vvm/types.go
@@ -111,7 +111,6 @@ type VVM struct {
 	ServicePipeline
 	apps.APIs
 	appparts.IAppPartitions
-	istorage.IAppStorageFactory
 	AppsExtensionPoints map[istructs.AppQName]extensionpoints.IExtensionPoint
 	MetricsServicePort  func() metrics.MetricsServicePort
 	BuiltInAppsPackages []BuiltInAppPackages

--- a/pkg/vvm/wire_gen.go
+++ b/pkg/vvm/wire_gen.go
@@ -183,7 +183,6 @@ func ProvideCluster(vvmCtx context.Context, vvmConfig *VVMConfig, vvmIdx VVMIdxT
 		ServicePipeline:     servicePipeline,
 		APIs:                apIs,
 		IAppPartitions:      iAppPartitions,
-		IAppStorageFactory:  iAppStorageFactory,
 		AppsExtensionPoints: v7,
 		MetricsServicePort:  v8,
 		BuiltInAppsPackages: v9,


### PR DESCRIPTION
Resolves #1974 VVM APIs: eliminate `vvm.VVM.IAppStorageFactory`
