### PR TITLE
#1992 coreutils: consider non-float64 numbers on coreutils.MapToObject()

### DIFF
--- a/pkg/utils/maps.go
+++ b/pkg/utils/maps.go
@@ -31,6 +31,14 @@ func MapToObject(data map[string]interface{}, rw istructs.IRowWriter) (err error
 		case nil:
 		case float64:
 			rw.PutNumber(fieldName, v)
+		case float32:
+			rw.PutNumber(fieldName, float64(v))
+		case int32:
+			rw.PutNumber(fieldName, float64(v))
+		case int64:
+			rw.PutNumber(fieldName, float64(v))
+		case istructs.RecordID:
+			rw.PutNumber(fieldName, float64(v))
 		case string:
 			rw.PutChars(fieldName, v)
 		case bool:

--- a/pkg/utils/maps_test.go
+++ b/pkg/utils/maps_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/voedger/voedger/pkg/istructs"
 )
 
 func TestBasicUsage_PairsToMap(t *testing.T) {
@@ -55,13 +56,22 @@ func TestMapToObject(t *testing.T) {
 	}
 	require := require.New(t)
 	require.NoError(MapToObject(map[string]interface{}{
-		"float64": float64(42),
-		"str":     "str1",
-		"bool":    true,
-		"any":     nil, // will be ignored
+		"float64":  float64(42),
+		"float32":  float32(43),
+		"int32":    int32(44),
+		"int64":    int64(45),
+		"recordID": istructs.RecordID(46),
+		"str":      "str1",
+		"bool":     true,
+		"any":      nil, // will be ignored
 	}, o))
-	require.Len(o.Data, 3)
+	require.Len(o.Data, 7)
 	require.Equal(float64(42), o.Data["float64"])
+	require.Equal(float64(43), o.Data["float32"])
+	require.Equal(float64(44), o.Data["int32"])
+	require.Equal(float64(45), o.Data["int64"])
+	require.Equal(float64(46), o.Data["recordID"])
+
 	require.Equal("str1", o.Data["str"])
 	v, ok := o.Data["bool"].(bool)
 	require.True(ok)


### PR DESCRIPTION
Resolves #1992 coreutils: consider non-float64 numbers on coreutils.MapToObject()
