### PR TITLE
queryprocessor: improve equals filter

### DIFF
--- a/pkg/processors/query/filter-equals-impl.go
+++ b/pkg/processors/query/filter-equals-impl.go
@@ -33,6 +33,8 @@ func (f EqualsFilter) IsMatch(fk FieldsKinds, outputRow IOutputRow) (bool, error
 		return outputRow.Value(f.field).(bool) == f.value.(bool), nil
 	case appdef.DataKind_RecordID:
 		return outputRow.Value(f.field).(istructs.RecordID) == istructs.RecordID(int64(f.value.(float64))), nil
+	case appdef.DataKind_QName:
+		return outputRow.Value(f.field).(string) == f.value.(string), nil
 	case appdef.DataKind_null:
 		return false, nil
 	default:

--- a/pkg/processors/query/filter-equals-impl_test.go
+++ b/pkg/processors/query/filter-equals-impl_test.go
@@ -175,4 +175,54 @@ func TestEqualsFilter_IsMatch(t *testing.T) {
 			require.False(t, match(ageFilter(45).IsMatch(fk, row(42))))
 		})
 	})
+	t.Run("Compare appdef.QName", func(t *testing.T) {
+		row := func(name string) IOutputRow {
+			r := &testOutputRow{fields: []string{"sys.QName"}}
+			r.Set("sys.QName", name)
+			return r
+		}
+		fk := FieldsKinds{"sys.QName": appdef.DataKind_QName}
+		nameFilter := func(name string) IFilter {
+			return &EqualsFilter{
+				field: "sys.QName",
+				value: name,
+			}
+		}
+		tests := []struct {
+			name     string
+			qNameOne string
+			qNameTwo string
+			want     bool
+		}{
+			{
+				name:     "Should match",
+				qNameOne: "pkg.Entity",
+				qNameTwo: "pkg.Entity",
+				want:     true,
+			},
+			{
+				name:     "Should not match",
+				qNameOne: "pkg.Entity",
+				qNameTwo: "pkg1.Entity",
+				want:     false,
+			},
+			{
+				name:     "Should not match",
+				qNameOne: "pkg.Entity",
+				qNameTwo: "pkg.Entity1",
+				want:     false,
+			},
+			{
+				name:     "Should not match",
+				qNameOne: "pkg.Entity",
+				qNameTwo: "pkg1.Entity1",
+				want:     false,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				require.Equal(t, test.want, match(nameFilter(test.qNameOne).IsMatch(fk, row(test.qNameTwo))))
+			})
+		}
+	})
 }


### PR DESCRIPTION
https://dev.untill.com/projects/#!691710