### PR TITLE
#2012 bootstrap: skip error on cluster requests during up to 30 seconds

### DIFF
--- a/pkg/btstrp/consts.go
+++ b/pkg/btstrp/consts.go
@@ -8,6 +8,6 @@ package btstrp
 import "time"
 
 const (
-	retryOnHTTPErrorTimeout = 15 * time.Second
+	retryOnHTTPErrorTimeout = 30 * time.Second
 	retryOnHTTPErrorDelay   = time.Second
 )


### PR DESCRIPTION
Resolves #2012 bootstrap: skip error on cluster requests during up to 30 seconds
