### PR TITLE
#2027 return back rate limit on `c.sys.InitiateEmailVerification`

### DIFF
--- a/pkg/sys/it/impl_resetpassword_test.go
+++ b/pkg/sys/it/impl_resetpassword_test.go
@@ -98,7 +98,6 @@ func TestIssueResetPasswordTokenErrors(t *testing.T) {
 }
 
 func TestResetPasswordLimits(t *testing.T) {
-	t.Skip("wait for https://github.com/voedger/voedger/issues/2027")
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
 	prn := vit.GetPrincipal(istructs.AppQName_test1_app1, it.TestEmail)

--- a/pkg/sys/verifier/impl.go
+++ b/pkg/sys/verifier/impl.go
@@ -33,11 +33,10 @@ func provideQryInitiateEmailVerification(cfg *istructsmem.AppConfigType, itokens
 		QNameQueryInitiateEmailVerification,
 		provideIEVExec(cfg.Name, itokens, asp, federation),
 	))
-	// https://github.com/voedger/voedger/issues/2026, will be retuned back in https://github.com/voedger/voedger/issues/2027
-	// cfg.FunctionRateLimits.AddWorkspaceLimit(QNameQueryInitiateEmailVerification, istructs.RateLimit{
-	// 	Period:                InitiateEmailVerification_Period,
-	// 	MaxAllowedPerDuration: InitiateEmailVerification_MaxAllowed,
-	// })
+	cfg.FunctionRateLimits.AddWorkspaceLimit(QNameQueryInitiateEmailVerification, istructs.RateLimit{
+		Period:                InitiateEmailVerification_Period,
+		MaxAllowedPerDuration: InitiateEmailVerification_MaxAllowed,
+	})
 }
 
 // q.sys.InitiateEmailVerification


### PR DESCRIPTION
Resolves #2027 return back rate limit on `c.sys.InitiateEmailVerification`
