### PR TITLE
#2184 teststate: cdoc.ChildWorkspace not available

### DIFF
--- a/pkg/state/teststate/testsys/system.sql
+++ b/pkg/state/teststate/testsys/system.sql
@@ -10,6 +10,16 @@ ABSTRACT TABLE ODoc INHERITS ORecord();
 ABSTRACT TABLE WDoc INHERITS WRecord();
 ABSTRACT TABLE CSingleton INHERITS CDoc();
 ABSTRACT WORKSPACE Workspace(
+	TABLE ChildWorkspace INHERITS CDoc (
+		WSName varchar NOT NULL,
+		WSKind qname NOT NULL,
+		WSKindInitializationData varchar(1024),
+		TemplateName varchar,
+		TemplateParams varchar(1024),
+		WSClusterID int32 NOT NULL,
+		WSID int64,           -- to be updated afterwards
+		WSError varchar(1024) -- to be updated afterwards
+	);
 );
 ALTERABLE WORKSPACE Profile();
 


### PR DESCRIPTION
Resolves #2184 teststate: cdoc.ChildWorkspace not available
