### PR TITLE
#2217 workspace creation: `WSName` is not escaped

### DIFF
--- a/pkg/sys/invite/impl_applyjoinworkspace.go
+++ b/pkg/sys/invite/impl_applyjoinworkspace.go
@@ -74,7 +74,7 @@ func applyJoinWorkspace(timeFunc coreutils.TimeFunc, federation federation.IFede
 		}
 		_, err = federation.Func(
 			fmt.Sprintf("api/%s/%d/c.sys.CreateJoinedWorkspace", appQName, svCDocInvite.AsInt64(field_InviteeProfileWSID)),
-			fmt.Sprintf(`{"args":{"Roles":"%s","InvitingWorkspaceWSID":%d,"WSName":"%s"}}`,
+			fmt.Sprintf(`{"args":{"Roles":"%s","InvitingWorkspaceWSID":%d,"WSName":%q}}`,
 				svCDocInvite.AsString(Field_Roles), event.Workspace(), svCDocWorkspaceDescriptor.AsString(authnz.Field_WSName)),
 			coreutils.WithAuthorizeBy(token),
 			coreutils.WithDiscardResponse(),

--- a/pkg/sys/it/impl_childworkspace_test.go
+++ b/pkg/sys/it/impl_childworkspace_test.go
@@ -31,7 +31,7 @@ func TestBasicUsage_ChildWorkspaces(t *testing.T) {
 		body := fmt.Sprintf(`
 			{
 				"args": {
-					"WSName": "%s"
+					"WSName": %q
 				},
 				"elements":[
 					{
@@ -51,7 +51,7 @@ func TestBasicUsage_ChildWorkspaces(t *testing.T) {
 		body := fmt.Sprintf(`
 			{
 				"args": {
-					"WSName": "%s",
+					"WSName": %q,
 					"WSKind": "app1pkg.test_ws",
 					"WSKindInitializationData": "{\"IntFld\": 10}",
 					"TemplateName": "test_template",
@@ -70,7 +70,7 @@ func TestBasicUsage_ChildWorkspaces(t *testing.T) {
 		require.Equal(istructs.ClusterID(1), childWS.WSID.ClusterID())
 
 		t.Run("create a new workspace with an existing name -> 409 conflict", func(t *testing.T) {
-			body := fmt.Sprintf(`{"args": {"WSName": "%s","WSKind": "app1pkg.test_ws","WSKindInitializationData": "{\"WorkStartTime\": \"10\"}","TemplateName": "test","WSClusterID": 1}}`, wsName)
+			body := fmt.Sprintf(`{"args": {"WSName": %q,"WSKind": "app1pkg.test_ws","WSKindInitializationData": "{\"WorkStartTime\": \"10\"}","TemplateName": "test","WSClusterID": 1}}`, wsName)
 			resp := vit.PostWS(parentWS, "c.sys.InitChildWorkspace", body, coreutils.Expect409())
 			resp.Println()
 		})
@@ -99,7 +99,7 @@ func TestForeignAuthorization(t *testing.T) {
 	wsName := vit.NextName()
 
 	// init child workspace
-	body := fmt.Sprintf(`{"args": {"WSName": "%s","WSKind": "app1pkg.test_ws","WSKindInitializationData": "{\"IntFld\": 10}","TemplateName": "test_template","WSClusterID": 42}}`, wsName)
+	body := fmt.Sprintf(`{"args": {"WSName": %q,"WSKind": "app1pkg.test_ws","WSKindInitializationData": "{\"IntFld\": 10}","TemplateName": "test_template","WSClusterID": 42}}`, wsName)
 	vit.PostWS(parentWS, "c.sys.InitChildWorkspace", body)
 
 	// wait for finish

--- a/pkg/sys/it/impl_workspace_test.go
+++ b/pkg/sys/it/impl_workspace_test.go
@@ -37,7 +37,7 @@ func TestBasicUsage_Workspace(t *testing.T) {
 		body := fmt.Sprintf(`
 			{
 				"args": {
-					"WSName": "%s"
+					"WSName": %q
 				},
 				"elements":[
 					{
@@ -53,7 +53,7 @@ func TestBasicUsage_Workspace(t *testing.T) {
 		body := fmt.Sprintf(`
 		{
 			"args": {
-				"WSName": "%s",
+				"WSName": %q,
 				"WSKind": "app1pkg.test_ws",
 				"WSKindInitializationData": "{\"IntFld\": 10}",
 				"TemplateName": "test_template",
@@ -114,7 +114,7 @@ func TestBasicUsage_Workspace(t *testing.T) {
 	})
 
 	t.Run("create a new workspace with an existing name -> 409 conflict", func(t *testing.T) {
-		body := fmt.Sprintf(`{"args": {"WSName": "%s","WSKind": "app1pkg.test_ws","WSKindInitializationData": "{\"WorkStartTime\": \"10\"}","TemplateName": "test","WSClusterID": 1}}`, wsName)
+		body := fmt.Sprintf(`{"args": {"WSName": %q,"WSKind": "app1pkg.test_ws","WSKindInitializationData": "{\"WorkStartTime\": \"10\"}","TemplateName": "test","WSClusterID": 1}}`, wsName)
 		resp := vit.PostProfile(prn, "c.sys.InitChildWorkspace", body, coreutils.Expect409())
 		resp.Println()
 	})
@@ -127,7 +127,7 @@ func TestBasicUsage_Workspace(t *testing.T) {
 
 	t.Run("400 bad request on create a workspace with kind that is not a QName of a workspace descriptor", func(t *testing.T) {
 		wsName := vit.NextName()
-		body := fmt.Sprintf(`{"args": {"WSName": "%s","WSKind": "app1pkg.articles","WSKindInitializationData": "{\"WorkStartTime\": \"10\"}","TemplateName": "test","WSClusterID": 1}}`, wsName)
+		body := fmt.Sprintf(`{"args": {"WSName": %q,"WSKind": "app1pkg.articles","WSKindInitializationData": "{\"WorkStartTime\": \"10\"}","TemplateName": "test","WSClusterID": 1}}`, wsName)
 		resp := vit.PostProfile(prn, "c.sys.InitChildWorkspace", body, coreutils.Expect400())
 		resp.Println()
 	})
@@ -295,4 +295,17 @@ func checkDemoAndDemoMinBLOBs(vit *it.VIT, templateName string, ep extensionpoin
 		rowIdx++
 	}
 	require.Empty(blobsMap)
+}
+
+func TestWSNameEscaping(t *testing.T) {
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	prn := vit.GetPrincipal(istructs.AppQName_test1_app1, "login")
+
+	// \f;jf;GJ specified in frontend -> "\\f;jf;GJ" in json
+	body := `{"args":{"WSName":"\\f;jf;GJ","WSKind":"app1pkg.test_ws","WSKindInitializationData":"{\"StrFld\":\"\\\\f;jf;GJ\",\"IntFld\": 10}","WSClusterID":1}}`
+	vit.PostProfile(prn, "c.sys.InitChildWorkspace", body)
+
+	vit.WaitForWorkspace(`\f;jf;GJ`, prn)
 }

--- a/pkg/sys/workspace/impl.go
+++ b/pkg/sys/workspace/impl.go
@@ -68,7 +68,7 @@ func ApplyInvokeCreateWorkspaceID(federation federation.IFederation, appQName is
 	wsKindInitializationData := ownerDoc.AsString(authnz.Field_WSKindInitializationData)
 	createWSIDCmdURL := fmt.Sprintf("api/%s/%d/c.sys.CreateWorkspaceID", targetApp, wsidToCallCreateWSIDAt)
 	logger.Info("aproj.sys.InvokeCreateWorkspaceID: request to " + createWSIDCmdURL)
-	body := fmt.Sprintf(`{"args":{"OwnerWSID":%d,"OwnerQName2":"%s","OwnerID":%d,"OwnerApp":"%s","WSName":"%s","WSKind":"%s","WSKindInitializationData":%q,"TemplateName":"%s","TemplateParams":%q}}`,
+	body := fmt.Sprintf(`{"args":{"OwnerWSID":%d,"OwnerQName2":"%s","OwnerID":%d,"OwnerApp":"%s","WSName":%q,"WSKind":"%s","WSKindInitializationData":%q,"TemplateName":"%s","TemplateParams":%q}}`,
 		ownerWSID, ownerQName.String(), ownerID, ownerApp, wsName, wsKind.String(), wsKindInitializationData, templateName, templateParams)
 	targetAppQName, err := istructs.ParseAppQName(targetApp)
 	if err != nil {
@@ -201,7 +201,7 @@ func invokeCreateWorkspaceProjector(federation federation.IFederation, tokensAPI
 			ownerID := rec.AsInt64(Field_OwnerID)
 			ownerApp := rec.AsString(Field_OwnerApp)
 			templateParams := rec.AsString(Field_TemplateParams)
-			body := fmt.Sprintf(`{"args":{"OwnerWSID":%d,"OwnerQName2":"%s","OwnerID":%d,"OwnerApp":"%s","WSName":"%s","WSKind":"%s","WSKindInitializationData":%q,"TemplateName":"%s","TemplateParams":%q}}`,
+			body := fmt.Sprintf(`{"args":{"OwnerWSID":%d,"OwnerQName2":"%s","OwnerID":%d,"OwnerApp":"%s","WSName":%q,"WSKind":"%s","WSKindInitializationData":%q,"TemplateName":"%s","TemplateParams":%q}}`,
 				ownerWSID, ownerQName, ownerID, ownerApp, wsName, wsKind.String(), wsKindInitializationData, templateName, templateParams)
 			appQName := s.App()
 			createWSCmdURL := fmt.Sprintf("api/%s/%d/c.sys.CreateWorkspace", appQName.String(), newWSID)

--- a/pkg/sys/workspace/impl_deactivate.go
+++ b/pkg/sys/workspace/impl_deactivate.go
@@ -232,7 +232,7 @@ func projectorApplyDeactivateWorkspace(federation federation.IFederation, tokens
 
 		// currentApp/ApplicationWS/c.sys.OnWorkspaceDeactivated(OnwerWSID, WSName)
 		wsName := wsDesc.AsString(authnz.Field_WSName)
-		body := fmt.Sprintf(`{"args":{"OwnerWSID":%d, "WSName":"%s"}}`, ownerWSID, wsName)
+		body := fmt.Sprintf(`{"args":{"OwnerWSID":%d, "WSName":%q}}`, ownerWSID, wsName)
 		cdocWorkspaceIDWSID := coreutils.GetPseudoWSID(istructs.WSID(ownerWSID), wsName, event.Workspace().ClusterID())
 		if _, err := federation.Func(fmt.Sprintf("api/%s/%d/c.sys.OnWorkspaceDeactivated", ownerApp, cdocWorkspaceIDWSID), body,
 			coreutils.WithDiscardResponse(), coreutils.WithAuthorizeBy(sysToken)); err != nil {

--- a/pkg/vit/utils.go
+++ b/pkg/vit/utils.go
@@ -154,7 +154,7 @@ func (vit *VIT) waitForWorkspace(wsName string, owner *Principal, respGetter fun
 		body := fmt.Sprintf(`
 			{
 				"args": {
-					"WSName": "%s"
+					"WSName": %q
 				},
 				"elements":[
 					{
@@ -264,7 +264,7 @@ func (vit *VIT) InitChildWorkspace(wsd WSParams, ownerIntf interface{}, opts ...
 	vit.T.Helper()
 	body := fmt.Sprintf(`{
 		"args": {
-			"WSName": "%s",
+			"WSName": %q,
 			"WSKind": "%s",
 			"WSKindInitializationData": %q,
 			"TemplateName": "%s",


### PR DESCRIPTION
Resolves #2217 workspace creation: `WSName` is not escaped
