### PR TITLE
#2231 StorageResult: invalid memory address issue when using in tests

### DIFF
--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -1062,6 +1062,14 @@ func (c *resultValueBuilder) Equal(src istructs.IStateValueBuilder) bool {
 	return reflect.DeepEqual(o1, o2)
 }
 
+func (c *resultValueBuilder) BuildValue() istructs.IStateValue {
+	o, err := c.resultBuilder.Build()
+	if err != nil {
+		panic(err)
+	}
+	return &objectValue{object: o}
+}
+
 func (c *resultValueBuilder) PutInt32(name string, value int32) {
 	c.resultBuilder.PutInt32(name, value)
 }


### PR DESCRIPTION
Resolves #2231 StorageResult: invalid memory address issue when using in tests
