### PR TITLE
#2295 deny `cuds` JSON field for all commands except `c.sys.CUD`

### DIFF
--- a/pkg/processors/command/impl.go
+++ b/pkg/processors/command/impl.go
@@ -608,6 +608,14 @@ func parseCUDs(_ context.Context, work interface{}) (err error) {
 	return err
 }
 
+func checkCUDsAllowed(_ context.Context, work interface{}) (err error) {
+	cmd := work.(*cmdWorkpiece)
+	if len(cmd.parsedCUDs) > 0 && cmd.cmdMes.QName() != istructs.QNameCommandCUD && cmd.cmdMes.QName() != builtin.QNameCommandInit {
+		return errors.New("CUDs allowed for c.sys.CUD command only")
+	}
+	return nil
+}
+
 func checkArgsRefIntegrity(_ context.Context, work interface{}) (err error) {
 	cmd := work.(*cmdWorkpiece)
 	if cmd.argsObject != nil {

--- a/pkg/processors/command/impl_test.go
+++ b/pkg/processors/command/impl_test.go
@@ -50,7 +50,6 @@ var (
 func TestBasicUsage(t *testing.T) {
 	require := require.New(t)
 	check := make(chan interface{}, 1)
-	cudsCheck := make(chan interface{})
 
 	testCmdQName := appdef.NewQName(appdef.SysPackage, "Test")
 	// схема параметров тестовой команды
@@ -70,13 +69,6 @@ func TestBasicUsage(t *testing.T) {
 
 		// сама тестовая команда
 		testExec := func(args istructs.ExecCommandArgs) (err error) {
-			cuds := args.Workpiece.(*cmdWorkpiece).parsedCUDs
-			if len(cuds) > 0 {
-				require.Len(cuds, 1)
-				require.Equal(float64(1), cuds[0].fields[appdef.SystemField_ID])
-				require.Equal(testCDoc.String(), cuds[0].fields[appdef.SystemField_QName])
-				close(cudsCheck)
-			}
 			require.Equal(istructs.WSID(1), args.PrepareArgs.WSID)
 			require.NotNil(args.State)
 
@@ -116,7 +108,7 @@ func TestBasicUsage(t *testing.T) {
 	t.Run("basic usage", func(t *testing.T) {
 		// command processor работает через ibus.SendResponse -> нам нужен sender -> тестируем через ibus.SendRequest2()
 		request := ibus.Request{
-			Body:     []byte(`{"args":{"Text":"hello"},"unloggedArgs":{"Password":"pass"},"cuds":[{"fields":{"sys.ID":1,"sys.QName":"test.TestCDoc"}}]}`),
+			Body:     []byte(`{"args":{"Text":"hello"},"unloggedArgs":{"Password":"pass"}}`),
 			AppQName: istructs.AppQName_untill_airs_bp.String(),
 			WSID:     1,
 			Resource: "c.sys.Test",
@@ -133,9 +125,6 @@ func TestBasicUsage(t *testing.T) {
 		// убедимся, что команда действительно отработала и нотификации отправились
 		<-check
 		<-check
-
-		// убедимся, что CUD'ы проверились
-		<-cudsCheck
 	})
 
 	t.Run("500 internal server error command exec error", func(t *testing.T) {
@@ -484,8 +473,10 @@ func TestAuthnz(t *testing.T) {
 		appDef.AddCDoc(qNameTestDeniedCDoc)
 		appDef.AddCommand(qNameAllowedCmd)
 		appDef.AddCommand(qNameDeniedCmd)
+		appDef.AddCommand(istructs.QNameCommandCUD)
 		cfg.Resources.Add(istructsmem.NewCommandFunction(qNameAllowedCmd, istructsmem.NullCommandExec))
 		cfg.Resources.Add(istructsmem.NewCommandFunction(qNameDeniedCmd, istructsmem.NullCommandExec))
+		cfg.Resources.Add(istructsmem.NewCommandFunction(istructs.QNameCommandCUD, istructsmem.NullCommandExec))
 	})
 	defer tearDown(app)
 
@@ -518,7 +509,7 @@ func TestAuthnz(t *testing.T) {
 				Body:     []byte(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"sys.TestDeniedCDoc"}}]}`),
 				AppQName: istructs.AppQName_untill_airs_bp.String(),
 				WSID:     1,
-				Resource: "c.sys.TestAllowedCmd",
+				Resource: "c.sys.CUD",
 				Header:   getAuthHeader(token),
 			},
 			expectedStatusCode: http.StatusForbidden,
@@ -541,7 +532,7 @@ func TestAuthnz(t *testing.T) {
 			require.Nil(secErr, secErr)
 			require.Nil(sections)
 			log.Println(string(resp.Data))
-			require.Equal(c.expectedStatusCode, resp.StatusCode)
+			require.Equal(c.expectedStatusCode, resp.StatusCode, c.desc, string(resp.Data))
 		})
 	}
 }

--- a/pkg/processors/command/provide.go
+++ b/pkg/processors/command/provide.go
@@ -117,6 +117,7 @@ func ProvideServiceFactory(appParts appparts.IAppPartitions, now coreutils.TimeF
 				pipeline.WireFunc("getUnloggedArgsObject", getUnloggedArgsObject),
 				pipeline.WireFunc("checkArgsRefIntegrity", checkArgsRefIntegrity),
 				pipeline.WireFunc("parseCUDs", parseCUDs),
+				pipeline.WireFunc("checkCUDsAllowed", checkCUDsAllowed),
 				pipeline.WireSyncOperator("wrongArgsCatcher", &wrongArgsCatcher{}), // any error before -> wrap error into bad request http error
 				pipeline.WireFunc("authorizeCUDs", cmdProc.authorizeCUDs),
 				pipeline.WireFunc("checkIsActiveinCUDs", checkIsActiveInCUDs),


### PR DESCRIPTION
Resolves #2295 deny `cuds` JSON field for all commands except `c.sys.CUD`
