### PR TITLE
#2302 Dedicated error for "qname is not defined in the workspace"

### DIFF
--- a/pkg/state/errors.go
+++ b/pkg/state/errors.go
@@ -34,6 +34,7 @@ var errWorkspaceDescriptorNotFound = errors.New("WorkspaceDescriptor not found i
 var errDescriptorForUndefinedWorkspace = errors.New("workspace descriptor for undefined workspace")
 var errCommandNotSpecified = errors.New("command not specified")
 var errBlobIDNotSpecified = errors.New("blob ID not specified")
+var ErrQNameIsNotDefinedInWorkspace = errors.New("qname is not defined in workspace")
 
 func errUnexpectedType(actual interface{}) error {
 	return fmt.Errorf("unexpected type: %v", actual)
@@ -48,5 +49,5 @@ func errIndexOutOfBounds(index int) error {
 }
 
 func typeIsNotDefinedInWorkspaceWithDescriptor(typ, ws appdef.QName) error {
-	return fmt.Errorf("%s is not available in workspace with descriptor %s", typ.String(), ws.String())
+	return fmt.Errorf("%s %w %s", typ.String(), ErrQNameIsNotDefinedInWorkspace, ws.String())
 }

--- a/pkg/sys/it/impl_test.go
+++ b/pkg/sys/it/impl_test.go
@@ -285,7 +285,7 @@ func TestTakeQNamesFromWorkspace(t *testing.T) {
 			}
 			body := `{"args":{"Input":"Str"}}`
 			ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
-			vit.PostWS(ws, "c.app1pkg.MockCmd", body, coreutils.WithExpectedCode(500, "app1pkg.docInAnotherWS is not available in workspace with descriptor app1pkg.test_ws"))
+			vit.PostWS(ws, "c.app1pkg.MockCmd", body, coreutils.WithExpectedCode(500, "app1pkg.docInAnotherWS qname is not defined in workspace app1pkg.test_ws"))
 		})
 	})
 }


### PR DESCRIPTION
Resolves #2302 Dedicated error for "qname is not defined in the workspace"
