### PR TITLE
#2377 ACL: add q.air.GetResellers null auth

### DIFF
--- a/pkg/iauthnzimpl/consts.go
+++ b/pkg/iauthnzimpl/consts.go
@@ -99,6 +99,7 @@ var (
 	qNameWDocLastNumbers                            = appdef.NewQName(airPackage, "LastNumbers")
 	qNameCmdVSqlUpdate                              = appdef.NewQName(clusterPackage, "VSqlUpdate")
 	qNameCmdSaveTap2PayPayment                      = appdef.NewQName(airPackage, "SaveTap2PayPayment")
+	qNameQryGetResellers                            = appdef.NewQName(airPackage, "GetResellers")
 
 	// Air roles
 	qNameRoleResellersAdmin         = appdef.NewQName(airPackage, "ResellersAdmin")

--- a/pkg/iauthnzimpl/impl_acl.go
+++ b/pkg/iauthnzimpl/impl_acl.go
@@ -53,6 +53,8 @@ var defaultACL = ACL{
 				qNameQrySendReceiptByEmail,
 				// https://dev.untill.com/projects/#!698913
 				qNameQryQueryResellerInfo,
+				// https://dev.untill.com/projects/#!700365
+				qNameQryGetResellers,
 			},
 		},
 		policy: ACPolicy_Allow,


### PR DESCRIPTION
Resolves #2377 ACL: add q.air.GetResellers null auth
