### PR TITLE
#2468 authnz: emit user principal with `sys.Guest` login if token is not provided

### DIFF
--- a/pkg/iauthnzimpl/consts.go
+++ b/pkg/iauthnzimpl/consts.go
@@ -124,6 +124,8 @@ const (
 
 	// avoiding import cycle: collection->iauthnzimpl->registry->workspace->collection
 	registryPackage = "registry"
+
+	SysGuestLogin = "sys.Guest"
 )
 
 const (

--- a/pkg/iauthnzimpl/consts.go
+++ b/pkg/iauthnzimpl/consts.go
@@ -124,8 +124,6 @@ const (
 
 	// avoiding import cycle: collection->iauthnzimpl->registry->workspace->collection
 	registryPackage = "registry"
-
-	SysGuestLogin = "sys.Guest"
 )
 
 const (

--- a/pkg/iauthnzimpl/impl.go
+++ b/pkg/iauthnzimpl/impl.go
@@ -25,6 +25,11 @@ func (i *implIAuthenticator) Authenticate(requestContext context.Context, as ist
 		}
 	}()
 	if len(req.Token) == 0 {
+		principals = append(principals, iauthnz.Principal{
+			Kind: iauthnz.PrincipalKind_User,
+			WSID: istructs.GuestWSID,
+			Name: SysGuestLogin,
+		})
 		return
 	}
 

--- a/pkg/iauthnzimpl/impl.go
+++ b/pkg/iauthnzimpl/impl.go
@@ -28,7 +28,7 @@ func (i *implIAuthenticator) Authenticate(requestContext context.Context, as ist
 		principals = append(principals, iauthnz.Principal{
 			Kind: iauthnz.PrincipalKind_User,
 			WSID: istructs.GuestWSID,
-			Name: SysGuestLogin,
+			Name: istructs.SysGuestLogin,
 		})
 		return
 	}

--- a/pkg/iauthnzimpl/impl_test.go
+++ b/pkg/iauthnzimpl/impl_test.go
@@ -249,12 +249,13 @@ func TestAuthenticate(t *testing.T) {
 		subjects           []appdef.QName
 	}{
 		{
-			desc: "no auth -> host only",
+			desc: "no auth -> host + Guest user",
 			req: iauthnz.AuthnRequest{
 				Host:        "127.0.0.1",
 				RequestWSID: 1,
 			},
 			expectedPrincipals: []iauthnz.Principal{
+				{Kind: iauthnz.PrincipalKind_User, Name: SysGuestLogin, WSID: istructs.GuestWSID},
 				{Kind: iauthnz.PrincipalKind_Host, Name: "127.0.0.1"},
 			},
 		},

--- a/pkg/iauthnzimpl/impl_test.go
+++ b/pkg/iauthnzimpl/impl_test.go
@@ -255,7 +255,7 @@ func TestAuthenticate(t *testing.T) {
 				RequestWSID: 1,
 			},
 			expectedPrincipals: []iauthnz.Principal{
-				{Kind: iauthnz.PrincipalKind_User, Name: SysGuestLogin, WSID: istructs.GuestWSID},
+				{Kind: iauthnz.PrincipalKind_User, Name: istructs.SysGuestLogin, WSID: istructs.GuestWSID},
 				{Kind: iauthnz.PrincipalKind_Host, Name: "127.0.0.1"},
 			},
 		},

--- a/pkg/istructs/consts.go
+++ b/pkg/istructs/consts.go
@@ -196,3 +196,5 @@ const (
 )
 
 const DefaultNumAppWorkspaces = NumAppWorkspaces(10)
+
+const SysGuestLogin = appdef.SysPackage + ".Guest"


### PR DESCRIPTION
Resolves #2468 authnz: emit user principal with `sys.Guest` login if token is not provided
