### PR TITLE
#2498 sqlquery: select * from <wsid>.wlog returns the first record only

### DIFF
--- a/pkg/dml/types.go
+++ b/pkg/dml/types.go
@@ -26,5 +26,5 @@ type Op struct {
 	Workspace             Workspace
 	EntityID              istructs.IDType // offset or RecordID
 	CleanSQL              string
-	VSQLWithoutAppAndWSID string
+	VSQLWithoutAppAndWSID string // need to forward the query to the target app and\or WSID
 }

--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -530,4 +530,12 @@ func TestReadFromAnDifferentLocations(t *testing.T) {
 		loginHash := registry.GetLoginHash(prn.Login.Name)
 		require.Contains(resp.SectionRow()[0].(string), fmt.Sprintf(`"LoginHash":"%s"`, loginHash))
 	})
+
+	t.Run("query forwarding", func(t *testing.T) {
+		wsAnother := vit.WS(istructs.AppQName_test1_app1, "test_ws_another")
+		ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
+		body := fmt.Sprintf(`{"args":{"Query":"select * from %d.sys.wlog"},"elements":[{"fields":["Result"]}]}`, ws.WSID)
+		resp := vit.PostWS(wsAnother, "q.sys.SqlQuery", body)
+		require.GreaterOrEqual(resp.NumRows(), 2)
+	})
 }

--- a/pkg/sys/sqlquery/impl.go
+++ b/pkg/sys/sqlquery/impl.go
@@ -71,7 +71,13 @@ func provideEexecQrySqlQuery(federation federation.IFederation, itokens itokens.
 			if err != nil {
 				return err
 			}
-			return callback(&result{value: resp.SectionRow()[0].(string)})
+			for i := 0; i < resp.NumRows(); i++ {
+				if err := callback(&result{value: resp.SectionRow(i)[0].(string)}); err != nil {
+					// notest
+					return err
+				}
+			}
+			return nil
 		}
 
 		stmt, err := sqlparser.Parse(op.CleanSQL)

--- a/pkg/utils/http.go
+++ b/pkg/utils/http.go
@@ -462,6 +462,10 @@ func discardRespBody(resp *http.Response) error {
 	return nil
 }
 
+func (resp *FuncResponse) NumRows() int {
+	return len(resp.Sections[0].Elements)
+}
+
 func (resp *FuncResponse) SectionRow(rowIdx ...int) []interface{} {
 	if len(rowIdx) > 1 {
 		panic("must be 0 or 1 rowIdx'es")


### PR DESCRIPTION
Resolves #2498 sqlquery: select * from <wsid>.wlog returns the first record only
