### PR TITLE
#2510 workspaces: fix WSKindInitializationData field length in cmd args

### DIFF
--- a/pkg/sys/workspace.vsql
+++ b/pkg/sys/workspace.vsql
@@ -190,7 +190,7 @@ ABSTRACT WORKSPACE Workspace (
 		OwnerApp text NOT NULL,
 		WSName text NOT NULL,
 		WSKind qname NOT NULL,
-		WSKindInitializationData text,
+		WSKindInitializationData varchar(1024),
 		TemplateName text,
 		TemplateParams text,
 		OwnerQName2 text
@@ -203,7 +203,7 @@ ABSTRACT WORKSPACE Workspace (
 		OwnerApp text NOT NULL,
 		WSName text NOT NULL,
 		WSKind qname NOT NULL,
-		WSKindInitializationData text,
+		WSKindInitializationData varchar(1024),
 		TemplateName text,
 		TemplateParams text,
 		OwnerQName2 text
@@ -313,7 +313,7 @@ ABSTRACT WORKSPACE Workspace (
 	TYPE InitChildWorkspaceParams (
 		WSName text NOT NULL,
 		WSKind qname NOT NULL,
-		WSKindInitializationData text,
+		WSKindInitializationData varchar(1024),
 		WSClusterID int32 NOT NULL,
 		TemplateName text,
 		TemplateParams text

--- a/pkg/vit/schemaTestApp1.vsql
+++ b/pkg/vit/schemaTestApp1.vsql
@@ -17,7 +17,7 @@ ALTERABLE WORKSPACE test_wsWS (
 
 	DESCRIPTOR test_ws (
 		IntFld int32 NOT NULL,
-		StrFld varchar
+		StrFld varchar(1024)
 	);
 
 	TABLE articles INHERITS CDoc (


### PR DESCRIPTION
Resolves #2510 workspaces: fix WSKindInitializationData field length in cmd args
