### PR TITLE
#2525 VIT: keyspace names must be unique among Own VIT Configs

### DIFF
--- a/pkg/istorage/provider/provide.go
+++ b/pkg/istorage/provider/provide.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/istorage"
+	coreutils "github.com/voedger/voedger/pkg/utils"
 )
 
 // keyspaceNameSuffix is used in tests only
@@ -18,10 +19,12 @@ func Provide(asf istorage.IAppStorageFactory, keyspaceNameSuffix ...string) isto
 		asf:   asf,
 		cache: map[appdef.AppQName]istorage.IAppStorage{},
 	}
-	if len(keyspaceNameSuffix) > 0 {
-		res.suffix = keyspaceNameSuffix[0]
-	} else {
-		res.suffix = uuid.NewString()
+	if coreutils.IsTest() {
+		if len(keyspaceNameSuffix) > 0 && len(keyspaceNameSuffix[0]) > 0 {
+			res.suffix = keyspaceNameSuffix[0]
+		} else {
+			res.suffix = uuid.NewString()
+		}
 	}
 	return res
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	"syscall"
+	"testing"
 	"time"
 )
 
@@ -30,7 +31,7 @@ func ResetTimer(t *time.Timer, timeout time.Duration) {
 	t.Reset(timeout)
 }
 func IsTest() bool {
-	return strings.Contains(os.Args[0], ".test") || IsDebug()
+	return testing.Testing() || IsDebug()
 }
 
 func IsDebug() bool {

--- a/pkg/vvm/types.go
+++ b/pkg/vvm/types.go
@@ -146,19 +146,22 @@ type VVMConfig struct {
 	MaxPrepareQueries          MaxPrepareQueriesType
 	StorageCacheSize           StorageCacheSizeType
 	processorsChannels         []ProcesorChannel
+	ActualizerStateOpts        []state.StateOptFunc
+	SecretsReader              isecrets.ISecretReader
+	SmtpConfig                 smtp.Cfg
+	WSPostInitFunc             workspace.WSPostInitFunc
+	DataPath                   string
+	MetricsServicePort         MetricsServicePortInitial
+
 	// 0 -> dynamic port will be used, new on each vvmIdx
 	// >0 -> vVMPort+vvmIdx will be actually used
-	VVMPort            VVMPortType
-	MetricsServicePort MetricsServicePortInitial
+	VVMPort VVMPortType
+
 	// test and FederationURL contains port -> the port will be relaced with the actual VVMPort
-	FederationURL       *url.URL
-	ActualizerStateOpts []state.StateOptFunc
-	SecretsReader       isecrets.ISecretReader
+	FederationURL *url.URL
+
 	// used in tests only
 	KeyspaceNameSuffix string
-	SmtpConfig         smtp.Cfg
-	WSPostInitFunc     workspace.WSPostInitFunc
-	DataPath           string
 }
 
 type resultSenderErrorFirst struct {


### PR DESCRIPTION
Resolves #2525 VIT: keyspace names must be unique among Own VIT Configs
