### PR TITLE
#2529 refactor `HTTPResponse.Println()`

### DIFF
--- a/pkg/utils/http.go
+++ b/pkg/utils/http.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -422,7 +423,7 @@ func (resp *HTTPResponse) ExpectedHTTPCodes() []int {
 }
 
 func (resp *HTTPResponse) Println() {
-	logger.Info(resp.Body)
+	log.Println(resp.Body)
 }
 
 func (resp *HTTPResponse) getError(t *testing.T) map[string]interface{} {


### PR DESCRIPTION
Resolves #2529 refactor `HTTPResponse.Println()`
