### PR TITLE
#2583 testapi: return back IIntentAssertions.NotExists()

### DIFF
--- a/pkg/state/teststate/interface.go
+++ b/pkg/state/teststate/interface.go
@@ -53,4 +53,5 @@ type IIntentAssertions interface {
 	Exists()
 	Equal(vb ValueBuilderCallback)
 	Assert(cb IntentAssertionsCallback)
+	NotExists()
 }


### PR DESCRIPTION
Resolves #2583 testapi: return back IIntentAssertions.NotExists()
