### PR TITLE
2587 wsid for commandprocessor kind returns 0 in tests using exttinygotestsnewtestapi

### DIFF
--- a/pkg/state/teststate/impl.go
+++ b/pkg/state/teststate/impl.go
@@ -91,6 +91,11 @@ func (ts *testState) WSID() istructs.WSID {
 	case ProcKind_QueryProcessor:
 		return ts.queryWsid
 	case ProcKind_CommandProcessor:
+		// for command processor kind first look for WSID in event field
+		if ts.event != nil {
+			return ts.event.Workspace()
+		}
+
 		return ts.commandWSID
 	default:
 		if ts.event != nil {


### PR DESCRIPTION
fix #2587 