### PR TITLE
#2589 QueryProcessorState: FindIntent doesn't work for sys.Result

### DIFF
--- a/pkg/state/stateprovide/impl_query_processor_state.go
+++ b/pkg/state/stateprovide/impl_query_processor_state.go
@@ -56,6 +56,13 @@ func (s *queryProcessorState) NewValue(key istructs.IStateKeyBuilder) (eb istruc
 	return s.hostState.NewValue(key)
 }
 
+func (s *queryProcessorState) FindIntent(key istructs.IStateKeyBuilder) istructs.IStateValueBuilder {
+	if key.Storage() == sys.Storage_Result {
+		return s.resultValueBuilder
+	}
+	return s.hostState.FindIntent(key)
+}
+
 func (s *queryProcessorState) ApplyIntents() (err error) {
 	err = s.sendPrevQueryObject()
 	if err != nil {

--- a/pkg/state/stateprovide/impl_query_processor_state_test.go
+++ b/pkg/state/stateprovide/impl_query_processor_state_test.go
@@ -37,6 +37,10 @@ func TestQueryProcessorState(t *testing.T) {
 		require.NoError(err)
 		require.NotNil(vb)
 	}
+
+	intent := qps.FindIntent(kb)
+	require.NotNil(intent)
+
 	err = qps.ApplyIntents()
 	require.NoError(err)
 	require.Len(sentObjects, rows)


### PR DESCRIPTION
Resolves #2589 QueryProcessorState: FindIntent doesn't work for sys.Result
