### PR TITLE
#2597 The `verbose` and `trace` flags do not apply to subcommands

### DIFF
--- a/cmd/ctool/alert.go
+++ b/cmd/ctool/alert.go
@@ -204,6 +204,7 @@ func checkURL(s string) error {
 
 func alertAddDiscord(cmd *cobra.Command, args []string) error {
 
+	currentCmd = cmd
 	cluster := newCluster()
 
 	if cluster.Draft {
@@ -236,7 +237,7 @@ func alertAddDiscord(cmd *cobra.Command, args []string) error {
 }
 
 func alertRemoveDiscord(cmd *cobra.Command, args []string) error {
-
+	currentCmd = cmd
 	cluster := newCluster()
 
 	if cluster.Draft {
@@ -266,6 +267,7 @@ func alertRemoveDiscord(cmd *cobra.Command, args []string) error {
 
 func alertConfigsDownload(cmd *cobra.Command, args []string) error {
 
+	currentCmd = cmd
 	cluster := newCluster()
 
 	if cluster.Draft {
@@ -295,6 +297,7 @@ func alertConfigsDownload(cmd *cobra.Command, args []string) error {
 
 func alertConfigsUpload(cmd *cobra.Command, args []string) error {
 
+	currentCmd = cmd
 	cluster := newCluster()
 
 	if cluster.Draft {

--- a/cmd/ctool/backup.go
+++ b/cmd/ctool/backup.go
@@ -213,6 +213,8 @@ func newBackupErrorEvent(host string, err error) *eventType {
 }
 
 func backupCENode(cmd *cobra.Command, args []string) error {
+
+	currentCmd = cmd
 	cluster := newCluster()
 
 	var err error
@@ -254,6 +256,8 @@ func backupCENode(cmd *cobra.Command, args []string) error {
 }
 
 func backupNode(cmd *cobra.Command, args []string) error {
+
+	currentCmd = cmd
 	cluster := newCluster()
 
 	var err error
@@ -301,6 +305,7 @@ func newBackupFolderName() string {
 }
 
 func backupNow(cmd *cobra.Command, args []string) error {
+	currentCmd = cmd
 	cluster := newCluster()
 
 	if cluster.Draft {
@@ -341,6 +346,8 @@ func backupNow(cmd *cobra.Command, args []string) error {
 }
 
 func backupCron(cmd *cobra.Command, args []string) error {
+
+	currentCmd = cmd
 	cluster := newCluster()
 	if cluster.Draft {
 		return ErrClusterConfNotFound
@@ -415,6 +422,8 @@ func checkBackupFolderOnHost(cluster *clusterType, addr string) error {
 }
 
 func backupList(cmd *cobra.Command, args []string) error {
+
+	currentCmd = cmd
 	cluster := newCluster()
 	if cluster.Draft {
 		return ErrClusterConfNotFound

--- a/cmd/ctool/init.go
+++ b/cmd/ctool/init.go
@@ -94,6 +94,7 @@ func parseDeployArgs(args []string) error {
 // nolint
 func initCE(cmd *cobra.Command, args []string) error {
 
+	currentCmd = cmd
 	cluster := newCluster()
 	var err error
 
@@ -136,6 +137,7 @@ func initCE(cmd *cobra.Command, args []string) error {
 // nolint
 func initSE(cmd *cobra.Command, args []string) error {
 
+	currentCmd = cmd
 	cluster := newCluster()
 	var err error
 	if !cluster.Draft {

--- a/cmd/ctool/main.go
+++ b/cmd/ctool/main.go
@@ -96,7 +96,10 @@ func cursorOn() {
 	cmd.Run()
 }
 
-var rootCmd *cobra.Command
+var (
+	rootCmd    *cobra.Command
+	currentCmd *cobra.Command
+)
 
 // nolint
 func execRootCmd(args []string, ver string) error {

--- a/cmd/ctool/mon.go
+++ b/cmd/ctool/mon.go
@@ -39,6 +39,8 @@ func newMonCmd() *cobra.Command {
 }
 
 func monPassword(cmd *cobra.Command, args []string) error {
+
+	currentCmd = cmd
 	cluster := newCluster()
 	if cluster.Draft {
 		return ErrClusterConfNotFound

--- a/cmd/ctool/repeat.go
+++ b/cmd/ctool/repeat.go
@@ -24,6 +24,8 @@ func newRepeatCmd() *cobra.Command {
 }
 
 func repeat(cmd *cobra.Command, arg []string) error {
+
+	currentCmd = cmd
 	cluster := newCluster()
 	var err error
 

--- a/cmd/ctool/replace.go
+++ b/cmd/ctool/replace.go
@@ -27,6 +27,7 @@ func newReplaceCmd() *cobra.Command {
 
 func replace(cmd *cobra.Command, args []string) error {
 
+	currentCmd = cmd
 	cluster := newCluster()
 	var err error
 

--- a/cmd/ctool/restore.go
+++ b/cmd/ctool/restore.go
@@ -37,6 +37,7 @@ func newRestoreCmd() *cobra.Command {
 
 func restore(cmd *cobra.Command, args []string) error {
 
+	currentCmd = cmd
 	cluster := newCluster()
 
 	var err error

--- a/cmd/ctool/scripts.go
+++ b/cmd/ctool/scripts.go
@@ -70,11 +70,22 @@ func verbose() bool {
 	if dryRun {
 		return true
 	}
-	if rootCmd != nil {
-		b, err := rootCmd.Flags().GetBool("verbose")
-		return err == nil && b
+	if currentCmd != nil {
+
+		b, err := currentCmd.Flags().GetBool("verbose")
+		return b && err == nil
 	}
 	return false
+
+}
+
+func trace() bool {
+	if currentCmd != nil {
+		b, err := currentCmd.Flags().GetBool("trace")
+		return b && err == nil
+	}
+	return false
+
 }
 
 func (se *scriptExecuterType) run(scriptName string, args ...string) error {

--- a/cmd/ctool/upgrade.go
+++ b/cmd/ctool/upgrade.go
@@ -36,6 +36,7 @@ func compareVersions(version1 string, version2 string) int {
 
 func upgrade(cmd *cobra.Command, args []string) error {
 
+	currentCmd = cmd
 	cluster := newCluster()
 	var err error
 

--- a/cmd/ctool/utils.go
+++ b/cmd/ctool/utils.go
@@ -71,12 +71,10 @@ func printLogLine(logLevel logger.TLogLevel, line string) {
 }
 
 func getLoggerLevel() logger.TLogLevel {
-	b, err := rootCmd.Flags().GetBool("trace")
-	if err == nil && b {
+	if trace() {
 		return logger.LogLevelTrace
 	}
-	b, err = rootCmd.Flags().GetBool("verbose")
-	if err == nil && b {
+	if verbose() {
 		return logger.LogLevelVerbose
 	}
 	return logger.LogLevelInfo

--- a/cmd/ctool/validate.go
+++ b/cmd/ctool/validate.go
@@ -21,6 +21,7 @@ func newValidateCmd() *cobra.Command {
 
 func validate(cmd *cobra.Command, arg []string) error {
 
+	currentCmd = cmd
 	cluster := newCluster()
 
 	// nolint

--- a/pkg/goutils/cobrau/rootcmd.go
+++ b/pkg/goutils/cobrau/rootcmd.go
@@ -21,6 +21,17 @@ Persistent flags:
 
 */
 
+func addFlagsToCommands(cmd *cobra.Command) {
+	cmd.Flags().BoolP("verbose", "v", false, "Enable verbose output")
+	cmd.Flags().Bool("trace", false, "Enable extremely verbose output")
+	cmd.InitDefaultHelpFlag()
+	cmd.SilenceErrors = true
+
+	for _, subCmd := range cmd.Commands() {
+		addFlagsToCommands(subCmd)
+	}
+}
+
 func PrepareRootCmd(use string, short string, args []string, version string, cmds ...*cobra.Command) *cobra.Command {
 
 	var rootCmd = &cobra.Command{
@@ -48,13 +59,10 @@ func PrepareRootCmd(use string, short string, args []string, version string, cmd
 
 	rootCmd.SetArgs(args[1:])
 	rootCmd.AddCommand(cmds...)
-	for _, cmd := range cmds {
-		cmd.Flags().BoolP("verbose", "v", false, "Enable verbose output")
-		cmd.Flags().Bool("trace", false, "Enable extremely verbose output")
-		cmd.InitDefaultCompletionCmd()
-		cmd.InitDefaultHelpFlag()
-		cmd.SilenceErrors = true
-	}
+
+	rootCmd.InitDefaultCompletionCmd()
+	addFlagsToCommands(rootCmd)
+
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.SilenceUsage = true
 	return rootCmd


### PR DESCRIPTION
Resolves #2597 The `verbose` and `trace` flags do not apply to subcommands
