### PR TITLE
#2599 sidecar app panic: i32.trunc_sat_f64_s invalid as feature "nontrapping-float-to-int-conversion" is disabled

### DIFF
--- a/pkg/iextengine/wazero/impl.go
+++ b/pkg/iextengine/wazero/impl.go
@@ -187,7 +187,7 @@ func (f *wazeroExtEngine) init(ctx context.Context) error {
 		rtConf = wazero.NewRuntimeConfigInterpreter()
 	}
 	rtConf = rtConf.
-		WithCoreFeatures(api.CoreFeatureBulkMemoryOperations | api.CoreFeatureSignExtensionOps).
+		WithCoreFeatures(api.CoreFeatureBulkMemoryOperations | api.CoreFeatureSignExtensionOps | api.CoreFeatureNonTrappingFloatToIntConversion).
 		WithCloseOnContextDone(true).
 		WithMemoryCapacityFromMax(true).
 		WithMemoryLimitPages(uint32(memPages))


### PR DESCRIPTION
Resolves #2599 sidecar app panic: i32.trunc_sat_f64_s invalid as feature "nontrapping-float-to-int-conversion" is disabled
