### PR TITLE
#2602 sidecar app panic: "hostRowWriterPutIntBool" is not exported in module "env"

### DIFF
--- a/pkg/exttinygo/internal/impl_tinygo.go
+++ b/pkg/exttinygo/internal/impl_tinygo.go
@@ -27,7 +27,7 @@ func hostRowWriterPutBytes(id uint64, typ uint32, namePtr, nameSize, valuePtr, v
 //export hostRowWriterPutQName
 func hostRowWriterPutQName(id uint64, typ uint32, namePtr, nameSize, pkgPtr, pkgSize, entityPtr, entitySize uint32)
 
-//export hostRowWriterPutIntBool
+//export hostRowWriterPutBool
 func hostRowWriterPutBool(id uint64, typ uint32, namePtr, nameSize, value uint32)
 
 //export hostRowWriterPutInt32


### PR DESCRIPTION
Resolves #2602 sidecar app panic: "hostRowWriterPutIntBool" is not exported in module "env"
