### PR TITLE
#2638 c.sys.InitChildWorkspace: make WSClusterID not required

### DIFF
--- a/pkg/sys/it/impl_workspace_test.go
+++ b/pkg/sys/it/impl_workspace_test.go
@@ -132,6 +132,18 @@ func TestBasicUsage_Workspace(t *testing.T) {
 	})
 }
 
+func TestCurrentClusterIDOnMissingWSClusterID(t *testing.T) {
+	require := require.New(t)
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+	wsName := vit.NextName()
+	body := fmt.Sprintf(`{"args":{"WSName":%q,"WSKind":"app1pkg.test_ws","WSKindInitializationData":"{\"IntFld\": 10}"}}`, wsName)
+	prn := vit.GetPrincipal(istructs.AppQName_test1_app1, "login")
+	vit.PostProfile(prn, "c.sys.InitChildWorkspace", body)
+	ws := vit.WaitForWorkspace(wsName, prn)
+	require.Equal(istructs.ClusterID(1), ws.WSID.ClusterID())
+}
+
 func TestWorkspaceAuthorization(t *testing.T) {
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()

--- a/pkg/sys/workspace.vsql
+++ b/pkg/sys/workspace.vsql
@@ -314,7 +314,7 @@ ABSTRACT WORKSPACE Workspace (
 		WSName text NOT NULL,
 		WSKind qname NOT NULL,
 		WSKindInitializationData varchar(1024),
-		WSClusterID int32 NOT NULL,
+		WSClusterID int32,
 		TemplateName text,
 		TemplateParams text
 	);

--- a/pkg/sys/workspace/impl_childworkspace.go
+++ b/pkg/sys/workspace/impl_childworkspace.go
@@ -44,6 +44,9 @@ func execCmdInitChildWorkspace(args istructs.ExecCommandArgs) (err error) {
 	wsKindInitializationData := args.ArgumentObject.AsString(authnz.Field_WSKindInitializationData)
 	templateName := args.ArgumentObject.AsString(field_TemplateName)
 	wsClusterID := args.ArgumentObject.AsInt32(authnz.Field_WSClusterID)
+	if wsClusterID == 0 {
+		wsClusterID = int32(istructs.CurrentClusterID())
+	}
 	templateParams := args.ArgumentObject.AsString(Field_TemplateParams)
 
 	// Create cdoc.sys.ChildWorkspace


### PR DESCRIPTION
Resolves #2638 c.sys.InitChildWorkspace: make WSClusterID not required
