### PR TITLE
#2734 IAppPartition may be not returned to the pool

### DIFF
--- a/pkg/appparts/impl_app.go
+++ b/pkg/appparts/impl_app.go
@@ -172,6 +172,7 @@ func (p *appPartitionRT) borrow(proc ProcessorKind) (*borrowedPartition, error) 
 	b := newBorrowedPartition(p)
 
 	if err := b.borrow(proc); err != nil {
+		b.Release()
 		return nil, err
 	}
 

--- a/pkg/objcache/provide.go
+++ b/pkg/objcache/provide.go
@@ -16,7 +16,7 @@ import lru "github.com/hashicorp/golang-lru/v2"
 func New[K comparable, V any](size int) ICache[K, V] {
 	var err error
 	c := &cache[K, V]{}
-	c.lru, err = lru.NewWithEvict[K, V](size, c.evicted)
+	c.lru, err = lru.NewWithEvict(size, c.evicted)
 	if err != nil {
 		// notest
 		panic(err)


### PR DESCRIPTION
Resolves #2734 IAppPartition may be not returned to the pool
