### PR TITLE
#1823 sync actualizer state: should use `AppStructs()` from borrowed partition

### DIFF
--- a/pkg/processors/actualizers/impl.go
+++ b/pkg/processors/actualizers/impl.go
@@ -22,9 +22,6 @@ func syncActualizerFactory(conf SyncActualizerConf, projectors istructs.Projecto
 	if conf.IntentsLimit == 0 {
 		conf.IntentsLimit = defaultIntentsLimit
 	}
-	if conf.WorkToEvent == nil {
-		conf.WorkToEvent = func(work interface{}) istructs.IPLogEvent { return work.(istructs.IPLogEvent) }
-	}
 	service := &eventService{}
 	ss := make([]state.IHostState, 0, len(projectors))
 	bb := make([]pipeline.ForkOperatorOptionFunc, 0, len(projectors))
@@ -36,7 +33,7 @@ func syncActualizerFactory(conf SyncActualizerConf, projectors istructs.Projecto
 	h := &syncErrorHandler{ss: ss}
 	return pipeline.NewSyncPipeline(conf.Ctx, "PartitionSyncActualizer",
 		pipeline.WireFunc("Update event", func(_ context.Context, work pipeline.IWorkpiece) (err error) {
-			service.event = conf.WorkToEvent(work)
+			service.event = work.(interface{ Event() istructs.IPLogEvent }).Event()
 			return nil
 		}),
 		pipeline.WireFunc("Update IAppStructs", func(_ context.Context, work pipeline.IWorkpiece) (err error) {

--- a/pkg/processors/actualizers/interface.go
+++ b/pkg/processors/actualizers/interface.go
@@ -76,16 +76,12 @@ type SyncActualizerConf struct {
 	Ctx          context.Context
 	SecretReader isecrets.ISecretReader
 	Partition    istructs.PartitionID
-	// Fork responsible for cloning work
-	WorkToEvent WorkToEventFunc
 	//IntentsLimit top limit per event, default value is 100
 	IntentsLimit int
 	N10nFunc     state.N10nFunc
 }
 
 type ViewTypeBuilder func(builder appdef.IViewBuilder)
-
-type WorkToEventFunc func(work interface{}) istructs.IPLogEvent
 
 // SyncActualizerFactory returns the Operator<SyncActualizer>
 // Workpiece is ...?

--- a/pkg/processors/actualizers/interface.go
+++ b/pkg/processors/actualizers/interface.go
@@ -74,7 +74,6 @@ type AsyncActualizerMetrics interface {
 
 type SyncActualizerConf struct {
 	Ctx          context.Context
-	AppStructs   state.AppStructsFunc
 	SecretReader isecrets.ISecretReader
 	Partition    istructs.PartitionID
 	// Fork responsible for cloning work

--- a/pkg/processors/actualizers/provide.go
+++ b/pkg/processors/actualizers/provide.go
@@ -44,7 +44,6 @@ func NewSyncActualizerFactoryFactory(actualizerFactory SyncActualizerFactory, se
 		}
 		conf := SyncActualizerConf{
 			Ctx:          context.Background(), // it is needed for sync pipeline and GMP believes it is enough
-			AppStructs:   func() istructs.IAppStructs { return appStructs },
 			SecretReader: secretReader,
 			Partition:    partitionID,
 			WorkToEvent: func(work interface{}) istructs.IPLogEvent {

--- a/pkg/processors/actualizers/provide.go
+++ b/pkg/processors/actualizers/provide.go
@@ -46,9 +46,6 @@ func NewSyncActualizerFactoryFactory(actualizerFactory SyncActualizerFactory, se
 			Ctx:          context.Background(), // it is needed for sync pipeline and GMP believes it is enough
 			SecretReader: secretReader,
 			Partition:    partitionID,
-			WorkToEvent: func(work interface{}) istructs.IPLogEvent {
-				return work.(interface{ Event() istructs.IPLogEvent }).Event()
-			},
 			N10nFunc: func(view appdef.QName, wsid istructs.WSID, offset istructs.Offset) {
 				n10nBroker.Update(in10n.ProjectionKey{
 					App:        appStructs.AppQName(),


### PR DESCRIPTION
Resolves #1823 sync actualizer state: should use `AppStructs()` from borrowed partition
