### PR TITLE
#2749 eliminate annoying `http: TLS handshake error from 10.0.0.2:31842: tls: first record does not look like a TLS handshake` log messages

### DIFF
--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -6,9 +6,11 @@
 package router
 
 import (
+	"io"
 	"log"
 	"net/http"
 	"runtime/debug"
+	"strings"
 
 	"github.com/voedger/voedger/pkg/coreutils"
 )
@@ -36,4 +38,15 @@ func writeResponse(w http.ResponseWriter, data string) bool {
 
 func writeUnauthorized(rw http.ResponseWriter) {
 	WriteTextResponse(rw, "not authorized", http.StatusUnauthorized)
+}
+
+type filteringWriter struct {
+	w io.Writer
+}
+
+func (fw *filteringWriter) Write(p []byte) (n int, err error) {
+	if strings.Contains(string(p), "TLS handshake error") {
+		return len(p), nil
+	}
+	return fw.w.Write(p)
 }


### PR DESCRIPTION
Resolves #2749 eliminate annoying `http: TLS handshake error from 10.0.0.2:31842: tls: first record does not look like a TLS handshake` log messages
