### PR TITLE
#2769 CP: use `MapObject.AsObject()` for `args` and `unloggedArgs`

### DIFF
--- a/pkg/coreutils/mapobject.go
+++ b/pkg/coreutils/mapobject.go
@@ -20,7 +20,7 @@ func (m MapObject) AsString(name string) (val string, ok bool, err error) {
 	case string:
 		return v, true, nil
 	default:
-		return "", true, fmt.Errorf("field '%s' must be a string: %w", name, ErrFieldTypeMismatch)
+		return "", true, fmt.Errorf(`field "%s" must be a string: %w`, name, ErrFieldTypeMismatch)
 	}
 }
 
@@ -30,7 +30,7 @@ func (m MapObject) AsStringRequired(name string) (val string, err error) {
 		return "", err
 	}
 	if !ok {
-		return "", fmt.Errorf("field '%s' missing: %w", name, ErrFieldsMissed)
+		return "", fmt.Errorf(`field "%s" missing: %w`, name, ErrFieldsMissed)
 	}
 	return val, nil
 }
@@ -42,7 +42,7 @@ func (m MapObject) AsObject(name string) (val MapObject, ok bool, err error) {
 	case map[string]interface{}:
 		return MapObject(v), true, nil
 	default:
-		return nil, true, fmt.Errorf("field '%s' must be an object: %w", name, ErrFieldTypeMismatch)
+		return nil, true, fmt.Errorf(`field "%s" must be an object: %w`, name, ErrFieldTypeMismatch)
 	}
 }
 
@@ -59,7 +59,7 @@ func (m MapObject) AsInt64(name string) (val int64, ok bool, err error) {
 	case int64:
 		return v, true, nil
 	default:
-		return 0, true, fmt.Errorf("field '%s' must be json.Number: %w", name, ErrFieldTypeMismatch)
+		return 0, true, fmt.Errorf(`field "%s" must be json.Number: %w`, name, ErrFieldTypeMismatch)
 	}
 }
 
@@ -70,7 +70,7 @@ func (m MapObject) AsObjects(name string) (val []interface{}, ok bool, err error
 	case []interface{}:
 		return v, true, nil
 	default:
-		return nil, true, fmt.Errorf("field '%s' must be an array of objects: %w", name, ErrFieldTypeMismatch)
+		return nil, true, fmt.Errorf(`field "%s" must be an array of objects: %w`, name, ErrFieldTypeMismatch)
 	}
 }
 
@@ -85,7 +85,7 @@ func (m MapObject) AsFloat64(name string) (val float64, ok bool, err error) {
 		}
 		return float64Intf.(float64), true, nil
 	default:
-		return 0, true, fmt.Errorf("field '%s' must be json.Number: %w", name, ErrFieldTypeMismatch)
+		return 0, true, fmt.Errorf(`field "%s" must be json.Number: %w`, name, ErrFieldTypeMismatch)
 	}
 }
 
@@ -96,6 +96,6 @@ func (m MapObject) AsBoolean(name string) (val bool, ok bool, err error) {
 	case bool:
 		return v, true, nil
 	default:
-		return false, true, fmt.Errorf("field '%s' must be a boolean: %w", name, ErrFieldTypeMismatch)
+		return false, true, fmt.Errorf(`field "%s" must be a boolean: %w`, name, ErrFieldTypeMismatch)
 	}
 }

--- a/pkg/processors/command/impl.go
+++ b/pkg/processors/command/impl.go
@@ -431,11 +431,11 @@ func getArgsObject(_ context.Context, work pipeline.IWorkpiece) (err error) {
 		return nil
 	}
 	aob := cmd.reb.ArgumentObjectBuilder()
-	if argsIntf, exists := cmd.requestData["args"]; exists {
-		args, ok := argsIntf.(map[string]interface{})
-		if !ok {
-			return errors.New(`"args" field must be an object`)
-		}
+	args, exists, err :=  cmd.requestData.AsObject("args")
+	if err != nil {
+		return err
+	}
+	if exists {
 		aob.FillFromJSON(args)
 	}
 	if cmd.argsObject, err = aob.Build(); err != nil {
@@ -450,11 +450,11 @@ func getUnloggedArgsObject(_ context.Context, work pipeline.IWorkpiece) (err err
 		return nil
 	}
 	auob := cmd.reb.ArgumentUnloggedObjectBuilder()
-	if unloggedArgsIntf, exists := cmd.requestData["unloggedArgs"]; exists {
-		unloggedArgs, ok := unloggedArgsIntf.(map[string]interface{})
-		if !ok {
-			return errors.New(`"unloggedArgs" field must be an object`)
-		}
+	unloggedArgs, exists, err := cmd.requestData.AsObject("unloggedArgs")
+	if err != nil {
+		return err
+	}
+	if exists {
 		auob.FillFromJSON(unloggedArgs)
 	}
 	if cmd.unloggedArgsObject, err = auob.Build(); err != nil {

--- a/pkg/processors/command/impl_test.go
+++ b/pkg/processors/command/impl_test.go
@@ -360,13 +360,13 @@ func Test400BadRequestOnCUDErrors(t *testing.T) {
 		bodyAdd             string
 		expectedMessageLike string
 	}{
-		{"not an object", `"cuds":42`, `'cuds' must be an array of objects`},
+		{"not an object", `"cuds":42`, `field "cuds" must be an array of objects`},
 		{`element is not an object`, `"cuds":[42]`, `cuds[0]: not an object`},
 		{`missing fields`, `"cuds":[{}]`, `cuds[0]: "fields" missing`},
-		{`fields is not an object`, `"cuds":[{"fields":42}]`, `cuds[0]: field 'fields' must be an object`},
+		{`fields is not an object`, `"cuds":[{"fields":42}]`, `cuds[0]: field "fields" must be an object`},
 		{`fields: sys.ID missing`, `"cuds":[{"fields":{"sys.QName":"test.Test"}}]`, `cuds[0]: "sys.ID" missing`},
-		{`fields: sys.ID is not a number (create)`, `"cuds":[{"sys.ID":"wrong","fields":{"sys.QName":"test.Test"}}]`, `cuds[0]: field 'sys.ID' must be json.Number`},
-		{`fields: sys.ID is not a number (update)`, `"cuds":[{"fields":{"sys.ID":"wrong","sys.QName":"test.Test"}}]`, `cuds[0]: field 'sys.ID' must be json.Number`},
+		{`fields: sys.ID is not a number (create)`, `"cuds":[{"sys.ID":"wrong","fields":{"sys.QName":"test.Test"}}]`, `cuds[0]: field "sys.ID" must be json.Number`},
+		{`fields: sys.ID is not a number (update)`, `"cuds":[{"fields":{"sys.ID":"wrong","sys.QName":"test.Test"}}]`, `cuds[0]: field "sys.ID" must be json.Number`},
 		{`fields: wrong qName`, `"cuds":[{"fields":{"sys.ID":1,"sys.QName":"wrong"}},{"fields":{"sys.ID":1,"sys.QName":"test.Test"}}]`, `convert error: string «wrong»`},
 	}
 
@@ -428,12 +428,12 @@ func TestErrors(t *testing.T) {
 		{"bad request body", ibus.Request{Body: []byte("{wrong")}, "failed to unmarshal request body: invalid character 'w' looking for beginning of object key string", http.StatusBadRequest},
 		{"unknown func", ibus.Request{Resource: "c.sys.Unknown"}, "unknown function", http.StatusBadRequest},
 		{"args: field of wrong type provided", ibus.Request{Body: []byte(`{"args":{"Text":42}}`)}, "wrong field type", http.StatusBadRequest},
-		{"args: not an object", ibus.Request{Body: []byte(`{"args":42}`)}, `"args" field must be an object`, http.StatusBadRequest},
+		{"args: not an object", ibus.Request{Body: []byte(`{"args":42}`)}, `field "args" must be an object`, http.StatusBadRequest},
 		{"args: missing at all with a required field", ibus.Request{Body: []byte(`{}`)}, "", http.StatusBadRequest},
-		{"unloggedArgs: not an object", ibus.Request{Body: []byte(`{"unloggedArgs":42,"args":{"Text":"txt"}}`)}, `"unloggedArgs" field must be an object`, http.StatusBadRequest},
+		{"unloggedArgs: not an object", ibus.Request{Body: []byte(`{"unloggedArgs":42,"args":{"Text":"txt"}}`)}, `field "unloggedArgs" must be an object`, http.StatusBadRequest},
 		{"unloggedArgs: field of wrong type provided", ibus.Request{Body: []byte(`{"unloggedArgs":{"Password":42},"args":{"Text":"txt"}}`)}, "wrong field type", http.StatusBadRequest},
 		{"unloggedArgs: missing required field of unlogged args, no unlogged args at all", ibus.Request{Body: []byte(`{"args":{"Text":"txt"}}`)}, "", http.StatusBadRequest},
-		{"cuds: not an object", ibus.Request{Body: []byte(`{"args":{"Text":"hello"},"unloggedArgs":{"Password":"123"},"cuds":42}`)}, `field 'cuds' must be an array of objects`, http.StatusBadRequest},
+		{"cuds: not an object", ibus.Request{Body: []byte(`{"args":{"Text":"hello"},"unloggedArgs":{"Password":"123"},"cuds":42}`)}, `field "cuds" must be an array of objects`, http.StatusBadRequest},
 	}
 
 	for _, c := range cases {

--- a/pkg/processors/query/query-params-impl_test.go
+++ b/pkg/processors/query/query-params-impl_test.go
@@ -59,7 +59,7 @@ func TestWrongTypes(t *testing.T) {
 		{
 			name: "Elements must be an array",
 			body: `{"elements":{}}`,
-			err:  "elements: field 'elements' must be an array of objects: field type mismatch",
+			err:  `elements: field "elements" must be an array of objects: field type mismatch`,
 		},
 		{
 			name: "Element must be an object",
@@ -69,12 +69,12 @@ func TestWrongTypes(t *testing.T) {
 		{
 			name: "Element path is wrong",
 			body: `{"elements":[{"path":45}]}`,
-			err:  "elements: element: field 'path' must be a string: field type mismatch",
+			err:  `elements: element: field "path" must be a string: field type mismatch`,
 		},
 		{
 			name: "Element fields must be an array",
 			body: `{"elements":[{"fields":{}}]}`,
-			err:  "elements: element: field 'fields' must be an array of objects: field type mismatch",
+			err:  `elements: element: field "fields" must be an array of objects: field type mismatch`,
 		},
 		{
 			name: "Element fields must be a string or an array of strings",
@@ -84,37 +84,37 @@ func TestWrongTypes(t *testing.T) {
 		{
 			name: "Element refs must be an array",
 			body: `{"elements":[{"refs":{}}]}`,
-			err:  "elements: element: field 'refs' must be an array of objects: field type mismatch",
+			err:  `elements: element: field "refs" must be an array of objects: field type mismatch`,
 		},
 		{
 			name: "Ref field parameters length must be 2",
 			body: `{"elements":[{"refs":[[]]}]}`,
-			err:  "elements: element: field 'ref' parameters length must be 2 but got 0",
+			err:  `elements: element: field 'ref' parameters length must be 2 but got 0`,
 		},
 		{
 			name: "Ref field parameters type must be a string",
 			body: `{"elements":[{"refs":[["id",1]]}]}`,
-			err:  "elements: element: field 'ref' parameter must a string: wrong type",
+			err:  `elements: element: field 'ref' parameter must a string: wrong type`,
 		},
 		{
 			name: "Ref field parameters type must be a string",
 			body: `{"elements":[{"refs":[[1,1]]}]}`,
-			err:  "elements: element: field 'ref' parameter must a string",
+			err:  `elements: element: field 'ref' parameter must a string`,
 		},
 		{
 			name: "Filters must be an array",
 			body: `{"filters":{}}`,
-			err:  "filters: field 'filters' must be an array of objects: field type mismatch",
+			err:  `filters: field "filters" must be an array of objects: field type mismatch`,
 		},
 		{
 			name: "Filter args not found",
 			body: `{"filters":[{}]}`,
-			err:  "filters: filter: field 'args' must be present: not found",
+			err:  `filters: filter: field 'args' must be present: not found`,
 		},
 		{
 			name: "Filter expr not found",
 			body: `{"filters":[{"args":{}}]}`,
-			err:  "filters: filter: field 'expr' missing: fields are missed",
+			err:  `filters: filter: field "expr" missing: fields are missed`,
 		},
 		{
 			name: "Filter expr is unknown",
@@ -124,7 +124,7 @@ func TestWrongTypes(t *testing.T) {
 		{
 			name: "Filter field must be present",
 			body: `{"filters":[{"expr":"eq","args":{}}]}`,
-			err:  "filters: 'eq' filter: field 'field' missing: fields are missed",
+			err:  `filters: 'eq' filter: field "field" missing: fields are missed`,
 		},
 		{
 			name: "Filter value must be present",
@@ -139,12 +139,12 @@ func TestWrongTypes(t *testing.T) {
 		{
 			name: "Equals filter options must be an object",
 			body: `{"filters":[{"expr":"eq","args":{"field":"id","value":1,"options":[]}}]}`,
-			err:  "filters: 'eq' filter: field 'options' must be an object: field type mismatch",
+			err:  `filters: 'eq' filter: field "options" must be an object: field type mismatch`,
 		},
 		{
 			name: "Equals filter epsilon must be a float64",
 			body: `{"filters":[{"expr":"eq","args":{"field":"id","value":1,"options":{"epsilon":"wrong"}}}]}`,
-			err:  "filters: 'eq' filter: field 'epsilon' must be json.Number: field type mismatch",
+			err:  `filters: 'eq' filter: field "epsilon" must be json.Number: field type mismatch`,
 		},
 		{
 			name: "Not equals filter wrong args",
@@ -154,7 +154,7 @@ func TestWrongTypes(t *testing.T) {
 		{
 			name: "Not equals filter epsilon must be a float64",
 			body: `{"filters":[{"expr":"notEq","args":{"field":"id","value":1,"options":{"epsilon":"wrong"}}}]}`,
-			err:  "filters: 'notEq' filter: field 'epsilon' must be json.Number: field type mismatch",
+			err:  `filters: 'notEq' filter: field "epsilon" must be json.Number: field type mismatch`,
 		},
 		{
 			name: "Greater filter wrong args",
@@ -214,27 +214,27 @@ func TestWrongTypes(t *testing.T) {
 		{
 			name: "OrderBy must be an array",
 			body: `{"orderBy":{}}`,
-			err:  "orderBy: field 'orderBy' must be an array of objects: field type mismatch",
+			err:  `orderBy: field "orderBy" must be an array of objects: field type mismatch`,
 		},
 		{
 			name: "OrderBy field not found",
 			body: `{"orderBy":[{}]}`,
-			err:  "orderBy: orderBy: field 'field' missing: fields are missed",
+			err:  `orderBy: orderBy: field "field" missing: fields are missed`,
 		},
 		{
 			name: "OrderBy desc must be a boolean",
 			body: `{"orderBy":[{"field":"","desc":"wrong"}]}`,
-			err:  "orderBy: orderBy: field 'desc' must be a boolean: field type mismatch",
+			err:  `orderBy: orderBy: field "desc" must be a boolean: field type mismatch`,
 		},
 		{
 			name: "Count must be a int64",
 			body: `{"count":{}}`,
-			err:  "field 'count' must be json.Number: field type mismatch",
+			err:  `field "count" must be json.Number: field type mismatch`,
 		},
 		{
 			name: "StartFrom must be a int64",
 			body: `{"startFrom":{}}`,
-			err:  "field 'startFrom' must be json.Number: field type mismatch",
+			err:  `field "startFrom" must be json.Number: field type mismatch`,
 		},
 		{
 			name: "Root element fields must be present in result fields",
@@ -279,7 +279,7 @@ func TestWrongTypes(t *testing.T) {
 			qm := NewQueryMessage(context.Background(), appName, partID, wsID, nil, []byte(test.body), qNameFunction, "", sysToken)
 			serviceChannel <- qm
 			err := <-errs
-			require.Contains(err.Error(), test.err)
+			require.Contains(err.Error(), test.err, test.name)
 		})
 	}
 	cancel()


### PR DESCRIPTION
Resolves #2769 CP: use `MapObject.AsObject()` for `args` and `unloggedArgs`
