### PR TITLE
#2769 CP: use `MapObject.AsObject()` for `args` and `unloggedArgs`

### DIFF
--- a/pkg/processors/query/impl_test.go
+++ b/pkg/processors/query/impl_test.go
@@ -480,7 +480,7 @@ func Test_epsilon(t *testing.T) {
 		}
 		return options
 	}
-	args := func(options map[string]interface{}) interface{} {
+	args := func(options map[string]interface{}) coreutils.MapObject {
 		args := make(map[string]interface{})
 		if options != nil {
 			args["options"] = options

--- a/pkg/processors/query/query-params-impl_test.go
+++ b/pkg/processors/query/query-params-impl_test.go
@@ -169,7 +169,7 @@ func TestWrongTypes(t *testing.T) {
 		{
 			name: "And filter wrong args",
 			body: `{"filters":[{"expr":"and","args":""}]}`,
-			err:  "filters: 'and' filter: field 'args' must be an array: wrong type",
+			err:  "filters: 'and' filter: field 'args' must be an array of objects: wrong type",
 		},
 		{
 			name: "And filter wrong member",
@@ -184,7 +184,7 @@ func TestWrongTypes(t *testing.T) {
 		{
 			name: "Or filter wrong args",
 			body: `{"filters":[{"expr":"or","args":""}]}`,
-			err:  "filters: 'or' filter: field 'args' must be an array: wrong type",
+			err:  "filters: 'or' filter: field 'args' must be an array of objects: wrong type",
 		},
 		{
 			name: "Or filter wrong member",


### PR DESCRIPTION
Resolves #2769 CP: use `MapObject.AsObject()` for `args` and `unloggedArgs`
