### PR TITLE
#2784 CP: do not allow `null` values in requests

### DIFF
--- a/pkg/istructsmem/errors.go
+++ b/pkg/istructsmem/errors.go
@@ -63,6 +63,8 @@ var ErrNumAppWorkspacesNotSet = errors.New("NumAppWorkspaces is not set")
 
 var ErrCorruptedData = errors.New("corrupted data")
 
+var ErrNullNotAllowed = errors.New("null value is not allowed")
+
 const errTypedFieldNotFoundWrap = "%s-type field «%s» is not found in %v: %w" // int32-type field «myField» is not found …
 
 const errFieldNotFoundWrap = "field «%s» is not found in %v: %w" // int32-type field «myField» is not found …

--- a/pkg/istructsmem/event-types.go
+++ b/pkg/istructsmem/event-types.go
@@ -895,6 +895,7 @@ func (o *objectType) FillFromJSON(data map[string]any) {
 	for n, v := range data {
 		switch fv := v.(type) {
 		case nil:
+			o.collectErrorf(`field "%s": %w`, n, ErrNullNotAllowed)
 		case float64:
 			o.PutFloat64(n, fv)
 		case istructs.RecordID:

--- a/pkg/istructsmem/event-types_test.go
+++ b/pkg/istructsmem/event-types_test.go
@@ -2036,12 +2036,11 @@ func Test_objectType_FillFromJSON(t *testing.T) {
 				require.Equal(test.testObj, o.QName())
 				require.EqualValues(0, o.AsInt32("int32"))
 			}},
-		{"should be ok to fill from JSON with nil values even for unknown fields",
-			`{"int32": null, "unknown": null}`,
+		{"should be error on fill from JSON with nil values even for unknown fields",
+			`{"unknown": null}`,
 			func(o istructs.IObject, err error) {
-				require.NoError(err)
-				require.Equal(test.testObj, o.QName())
-				require.EqualValues(0, o.AsInt32("int32"))
+				require.ErrorIs(err, ErrNullNotAllowed)
+				require.ErrorContains(err, "unknown")
 			}},
 		{"should be ok to fill fields from JSON",
 			`{"int32": 1, "int64": 2, "float32": 3.3, "float64": 4.4, "bool": true, "string": "test", "bytes": "AQID"}`,
@@ -2071,15 +2070,14 @@ func Test_objectType_FillFromJSON(t *testing.T) {
 					return cnt
 				}())
 			}},
-		{"should be ok to fill with nil values",
+		{"should be error on fill with nil values",
 			`{"int32": null, "bool": null, "string": null, "bytes": null}`,
 			func(o istructs.IObject, err error) {
-				require.NoError(err)
-				require.Equal(test.testObj, o.QName())
-				require.Zero(o.AsInt32("int32"))
-				require.Zero(o.AsBool("bool"))
-				require.Zero(o.AsString("string"))
-				require.Zero(o.AsBytes("bytes"))
+				require.ErrorIs(err, ErrNullNotAllowed)
+				require.ErrorContains(err, "int32")
+				require.ErrorContains(err, "bool")
+				require.ErrorContains(err, "string")
+				require.ErrorContains(err, "bytes")
 			}},
 		{"should be error if unknown field in JSON",
 			`{"unknown": 1}`,

--- a/pkg/processors/command/provide.go
+++ b/pkg/processors/command/provide.go
@@ -112,7 +112,7 @@ func ProvideServiceFactory(appParts appparts.IAppPartitions, tm coreutils.ITime,
 				pipeline.WireFunc("getUnloggedArgsObject", getUnloggedArgsObject),
 				pipeline.WireFunc("checkArgsRefIntegrity", checkArgsRefIntegrity),
 				pipeline.WireFunc("parseCUDs", parseCUDs),
-				pipeline.WireFunc("checkCUDsAllowed", checkCUDsAllowed),
+				pipeline.WireFunc("checkCUDsInCUDCmdOnly", checkCUDsInCUDCmdOnly),
 				pipeline.WireSyncOperator("wrongArgsCatcher", &wrongArgsCatcher{}), // any error before -> wrap error into bad request http error
 				pipeline.WireFunc("authorizeCUDs", cmdProc.authorizeCUDs),
 				pipeline.WireFunc("checkIsActiveinCUDs", checkIsActiveInCUDs),

--- a/pkg/sys/it/impl_test.go
+++ b/pkg/sys/it/impl_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/istructsmem"
 	"github.com/voedger/voedger/pkg/sys"
 	it "github.com/voedger/voedger/pkg/vit"
 )
@@ -424,4 +425,41 @@ func TestNullability_SetEmptyObject(t *testing.T) {
 	require.Len(fields, 2)
 	require.EqualValues(expectedNestedDocID, fields["id_air_table_plan"])
 	require.EqualValues(15, fields["form"])
+}
+
+func TestNullsNotAllowed(t *testing.T) {
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
+
+	t.Run("insert", func(t *testing.T) {
+		t.Run("CUD", func(t *testing.T) {
+			body := `{"cuds": [{"fields": {"sys.ID": 1,"sys.QName": "app1pkg.air_table_plan", "name":null}}]}`
+			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect400(`field "name"`, istructsmem.ErrNullNotAllowed.Error()))
+		})
+		t.Run("ODoc", func(t *testing.T) {
+			body := `{"args":{"sys.ID": 1,"fld1":null}}`
+			vit.PostWS(ws, "c.app1pkg.CmdODocThree", body, coreutils.Expect400(`field "fld1"`, istructsmem.ErrNullNotAllowed.Error()))
+		})
+	})
+
+	t.Run("args", func(t *testing.T) {
+		t.Run("command", func(t *testing.T) {
+			body := `{"args":{"Arg1":null}}`
+			vit.PostWS(ws, "c.app1pkg.TestCmd", body, coreutils.Expect400(`field "Arg1"`, istructsmem.ErrNullNotAllowed.Error()))
+		})
+
+		t.Run("query", func(t *testing.T) {
+			body := `{"args": {"StatusCodeToReturn": null},"elements":[{"fields":["Dummy"]}]}`
+			vit.PostWS(ws, "q.app1pkg.QryWithResponseIntent", body, coreutils.Expect400(`field "StatusCodeToReturn"`, istructsmem.ErrNullNotAllowed.Error()))
+		})
+	})
+	t.Run("update", func(t *testing.T) {
+		body := `{"cuds": [{"fields": {"sys.ID": 1,"sys.QName": "app1pkg.air_table_plan", "name":"some name"}}]}`
+		id := vit.PostWS(ws, "c.sys.CUD", body).NewID()
+
+		body = fmt.Sprintf(`{"cuds": [{"sys.ID": %d, "fields": {"name":null}}]}`, id)
+		vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect400(`field "name"`, istructsmem.ErrNullNotAllowed.Error()))
+	})
 }

--- a/pkg/sys/it/impl_uniques_test.go
+++ b/pkg/sys/it/impl_uniques_test.go
@@ -454,7 +454,8 @@ func TestNullFields(t *testing.T) {
 	body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.DocConstraints","Int":0,"Str":"str","Bool":true,"Bytes":"%s"}}]}`, bts)
 	vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect409(fmt.Sprintf("unique constraint violation with ID %d", expectedRecID)))
 
-	// null for Int field -> conflict
-	body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.DocConstraints","Int":null,"Str":"str","Bool":true,"Bytes":"%s"}}]}`, bts)
+	// no value for Int field -> conflict
+	// because it is interpreted as zero value: before->ok on inert new, and now->conflict on insert the same record with zero value for Int field
+	body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.DocConstraints","Str":"str","Bool":true,"Bytes":"%s"}}]}`, bts)
 	vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect409(fmt.Sprintf("unique constraint violation with ID %d", expectedRecID)))
 }

--- a/pkg/vit/schemaTestApp1.vsql
+++ b/pkg/vit/schemaTestApp1.vsql
@@ -478,6 +478,10 @@ ALTERABLE WORKSPACE test_wsWS (
 		refToCDoc1OrODoc1 ref(cdoc1, odoc1)
 	);
 
+	TABLE odoc3 INHERITS ODoc (
+		fld1 int32
+	);
+
 	TYPE RatedQryParams (
 		Fld text
 	);
@@ -503,7 +507,7 @@ ALTERABLE WORKSPACE test_wsWS (
 	);
 
 	TYPE TestCmdParams (
-		Arg1 int32 NOT NULL
+		Arg1 int32
 	);
 
 	TYPE TestCmdResult (
@@ -531,7 +535,7 @@ ALTERABLE WORKSPACE test_wsWS (
 	);
 
 	TYPE WithResponseIntentParams (
-		StatusCodeToReturn int32 NOT NULL
+		StatusCodeToReturn int32
 	);
 
 	TYPE QryWithResponseIntentResult (
@@ -553,6 +557,7 @@ ALTERABLE WORKSPACE test_wsWS (
 
 		COMMAND CmdODocOne(odoc1);
 		COMMAND CmdODocTwo(odoc2, UNLOGGED odoc2);
+		COMMAND CmdODocThree(odoc3);
 
 		COMMAND TestCmdRawArg(sys.Raw);
 		PROJECTOR ProjDummy AFTER INSERT ON (CRecord) INTENTS(View(View)); -- does nothing, only to define view.app1pkg.View


### PR DESCRIPTION
Resolves #2784 CP: do not allow `null` values in requests
