### PR TITLE
#2844 checking if a goroutine has started each nanosecond causes very long awaiting on Linux

### DIFF
--- a/pkg/appparts/internal/actualizers/actualizers.go
+++ b/pkg/appparts/internal/actualizers/actualizers.go
@@ -47,7 +47,7 @@ func (pa *PartitionActualizers) Deploy(vvmCtx context.Context, appDef appdef.IAp
 			go func(rt *runtime) {
 				rt.cancel()
 				for rt.state.Load() >= 0 {
-					time.Sleep(time.Nanosecond) // wait until actualizer is finished
+					time.Sleep(time.Millisecond) // wait until actualizer is finished
 				}
 				stopWG.Done()
 			}(rt)
@@ -82,7 +82,7 @@ func (pa *PartitionActualizers) Deploy(vvmCtx context.Context, appDef appdef.IAp
 			}()
 
 			for rt.state.Load() == 0 {
-				time.Sleep(time.Nanosecond) // wait until actualizer go-routine is started
+				time.Sleep(time.Millisecond) // wait until actualizer go-routine is started
 			}
 			startWG.Done()
 		}()
@@ -120,7 +120,7 @@ func (pa *PartitionActualizers) Wait() {
 		if cnt == 0 {
 			break
 		}
-		time.Sleep(time.Nanosecond)
+		time.Sleep(time.Millisecond)
 	}
 }
 

--- a/pkg/appparts/internal/schedulers/schedulers.go
+++ b/pkg/appparts/internal/schedulers/schedulers.go
@@ -55,7 +55,7 @@ func (ps *PartitionSchedulers) Deploy(vvmCtx context.Context, appDef appdef.IApp
 				go func(rt *runtime) {
 					rt.cancel()
 					for rt.state.Load() >= 0 {
-						time.Sleep(time.Nanosecond) // wait until scheduler is finished
+						time.Sleep(time.Millisecond) // wait until scheduler is finished
 					}
 					stopWG.Done()
 				}(rt)
@@ -99,7 +99,7 @@ func (ps *PartitionSchedulers) Deploy(vvmCtx context.Context, appDef appdef.IApp
 				}(appWSNumber, appWSID)
 
 				for rt.state.Load() == 0 {
-					time.Sleep(time.Nanosecond) // wait until actualizer go-routine is started
+					time.Sleep(time.Millisecond) // wait until actualizer go-routine is started
 				}
 			}
 			startWG.Done()
@@ -147,7 +147,7 @@ func (ps *PartitionSchedulers) Wait() {
 		if cnt == 0 {
 			break
 		}
-		time.Sleep(time.Nanosecond)
+		time.Sleep(time.Millisecond)
 	}
 }
 

--- a/pkg/processors/actualizers/async_test.go
+++ b/pkg/processors/actualizers/async_test.go
@@ -111,10 +111,10 @@ func TestBasicUsage_AsynchronousActualizer(t *testing.T) {
 
 	// Wait for the projectors
 	for getActualizerOffset(require, appStructs, partitionNr, incrementorName) < topOffset {
-		time.Sleep(time.Nanosecond)
+		time.Sleep(time.Millisecond)
 	}
 	for getActualizerOffset(require, appStructs, partitionNr, decrementorName) < topOffset {
-		time.Sleep(time.Nanosecond)
+		time.Sleep(time.Millisecond)
 	}
 
 	// stop services
@@ -191,7 +191,7 @@ func Test_AsynchronousActualizer_FlushByRange(t *testing.T) {
 
 	// Wait for the projectors
 	for getActualizerOffset(require, appStructs, partitionNr, incrementorName) < topOffset {
-		time.Sleep(time.Nanosecond)
+		time.Sleep(time.Millisecond)
 	}
 	require.True(time.Now().Before(t0.Add(conf.FlushInterval)))
 
@@ -258,7 +258,7 @@ func Test_AsynchronousActualizer_FlushByInterval(t *testing.T) {
 
 	// Wait for the projectors
 	for getActualizerOffset(require, appStructs, partitionNr, incrementorName) < topOffset {
-		time.Sleep(time.Nanosecond)
+		time.Sleep(time.Millisecond)
 	}
 	require.True(time.Now().After(t0.Add(actCfg.FlushInterval)))
 
@@ -459,7 +459,7 @@ func Test_AsynchronousActualizer_ResumeReadAfterNotifications(t *testing.T) {
 
 	// Wait for the projectors
 	for getActualizerOffset(require, appStructs, partitionNr, incrementorName) < topOffset {
-		time.Sleep(time.Nanosecond)
+		time.Sleep(time.Millisecond)
 	}
 
 	//New events in pLog
@@ -475,7 +475,7 @@ func Test_AsynchronousActualizer_ResumeReadAfterNotifications(t *testing.T) {
 
 	// Wait for the projectors
 	for getActualizerOffset(require, appStructs, partitionNr, incrementorName) < topOffset {
-		time.Sleep(time.Nanosecond)
+		time.Sleep(time.Millisecond)
 	}
 
 	// stop services
@@ -602,7 +602,7 @@ func Test_AsynchronousActualizer_Stress(t *testing.T) {
 
 	// Wait for the projectors
 	for actMetrics.value(aaStoredOffset, partitionNr, incrementorName) < int64(topOffset) {
-		time.Sleep(time.Nanosecond)
+		time.Sleep(time.Millisecond)
 	}
 	d := time.Since(t0)
 	d0 := d.Nanoseconds() / totalEvents
@@ -679,7 +679,7 @@ func Test_AsynchronousActualizer_NonBuffered(t *testing.T) {
 
 	// Wait for the projectors
 	for actMetrics.value(aaStoredOffset, partitionNr, incrementorName) < int64(topOffset) {
-		time.Sleep(time.Nanosecond)
+		time.Sleep(time.Millisecond)
 	}
 	require.True(time.Now().Before(t0.Add(actCfg.FlushInterval))) // no flushes by timer happen
 


### PR DESCRIPTION
Resolves #2844 checking if a goroutine has started each nanosecond causes very long awaiting on Linux
