### PR TITLE
#2952 c.sys.InitiateJoinWorkspace: new error: token login does not match invite login

### DIFF
--- a/pkg/sys/invite/impl_initiatejoinworkspace.go
+++ b/pkg/sys/invite/impl_initiatejoinworkspace.go
@@ -5,6 +5,7 @@
 package invite
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/voedger/voedger/pkg/appdef"
@@ -54,6 +55,12 @@ func execCmdInitiateJoinWorkspace(tm coreutils.ITime) func(args istructs.ExecCom
 		svPrincipal, err := args.State.MustExist(skbPrincipal)
 		if err != nil {
 			return
+		}
+
+		loginFromToken := svPrincipal.AsString(sys.Storage_RequestSubject_Field_Name)
+		emailWeSentTo := svCDocInvite.AsString(field_Email)
+		if loginFromToken != emailWeSentTo {
+			return coreutils.NewHTTPErrorf(http.StatusBadRequest, fmt.Sprintf("invitation was sent to %s but current login is %s", emailWeSentTo, loginFromToken))
 		}
 
 		svbCDocInvite, err := args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)

--- a/pkg/sys/it/impl_invite_test.go
+++ b/pkg/sys/it/impl_invite_test.go
@@ -359,5 +359,5 @@ func TestRejectInvitationOnDifferentLogin(t *testing.T) {
 	// simulate accepting invitation by different login
 	differentLogin := vit.GetPrincipal(istructs.AppQName_test1_app1, "login")
 	InitiateJoinWorkspace(vit, ws, inviteID, differentLogin, verificationCode,
-		coreutils.Expect400("invitation was sent to testcancelsentinvite_1@123.com but current login is login"))
+		coreutils.Expect400(fmt.Sprintf("invitation was sent to %s but current login is login", email)))
 }

--- a/pkg/sys/it/impl_invite_test.go
+++ b/pkg/sys/it/impl_invite_test.go
@@ -341,3 +341,23 @@ func testOverwriteRoles(t *testing.T, vit *it.VIT, ws *it.AppWorkspace, email st
 
 	return verificationCode
 }
+
+func TestRejectInvitationOnDifferentLogin(t *testing.T) {
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	email := fmt.Sprintf("testcancelsentinvite_%d@123.com", vit.NextNumber())
+	login := vit.SignUp(email, "1", istructs.AppQName_test1_app1)
+	loginPrn := vit.SignIn(login)
+	wsParams := it.SimpleWSParams("TestCancelSentInvite_ws")
+	ws := vit.CreateWorkspace(wsParams, loginPrn)
+	inviteID := InitiateInvitationByEMail(vit, ws, vit.Now().UnixMilli(), email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+	actualEmail := vit.CaptureEmail()
+	verificationCode := actualEmail.Body[:6]
+	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+
+	// simulate accepting invitation by different login
+	differentLogin := vit.GetPrincipal(istructs.AppQName_test1_app1, "login")
+	InitiateJoinWorkspace(vit, ws, inviteID, differentLogin, verificationCode,
+		coreutils.Expect400("invitation was sent to testcancelsentinvite_1@123.com but current login is login"))
+}

--- a/pkg/sys/it/test_utils.go
+++ b/pkg/sys/it/test_utils.go
@@ -76,9 +76,10 @@ func InitiateInvitationByEMail(vit *it.VIT, ws *it.AppWorkspace, expireDatetime 
 	return vit.PostWS(ws, "c.sys.InitiateInvitationByEMail", body).NewID()
 }
 
-func InitiateJoinWorkspace(vit *it.VIT, ws *it.AppWorkspace, inviteID int64, login *it.Principal, verificationCode string) {
+func InitiateJoinWorkspace(vit *it.VIT, ws *it.AppWorkspace, inviteID int64, login *it.Principal, verificationCode string, opts ...coreutils.ReqOptFunc) {
 	vit.T.Helper()
-	vit.PostWS(ws, "c.sys.InitiateJoinWorkspace", fmt.Sprintf(`{"args":{"InviteID":%d,"VerificationCode":"%s"}}`, inviteID, verificationCode), coreutils.WithAuthorizeBy(login.Token))
+	opts = append(opts, coreutils.WithAuthorizeBy(login.Token))
+	vit.PostWS(ws, "c.sys.InitiateJoinWorkspace", fmt.Sprintf(`{"args":{"InviteID":%d,"VerificationCode":"%s"}}`, inviteID, verificationCode), opts...)
 }
 
 func WaitForInviteState(vit *it.VIT, ws *it.AppWorkspace, inviteID int64, inviteStatesSeq ...int32) {


### PR DESCRIPTION
Resolves #2952 c.sys.InitiateJoinWorkspace: new error: token login does not match invite login
