### PR TITLE
#2993 Router: read from CDocs collection: url path: `docs` -> `cdocs`

### DIFF
--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -14,11 +14,11 @@ import (
 )
 
 func (s *httpService) registerHandlersV2() {
-	// create, read collection: /api/v2/users/{owner}/apps/{app}/workspaces/{wsid}/docs/{pkg}.{table}
+	// create: /api/v2/users/{owner}/apps/{app}/workspaces/{wsid}/docs/{pkg}.{table}
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/users/{%s}/apps/{%s}/workspaces/{%s:[0-9]+}/docs/{%s}.{%s}",
 		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_wsid, URLPlaceholder_pkg, URLPlaceholder_table),
 		corsHandler(requestHandlerV2_table())).
-		Methods(http.MethodPost, http.MethodGet)
+		Methods(http.MethodPost)
 
 	// update, deactivate, read single doc: /api/v2/users/{owner}/apps/{app}/workspaces/{wsid}/docs/{pkg}.{table}/{id}
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/users/{%s}/apps/{%s}/workspaces/{%s:[0-9]+}/docs/{%s}.{%s}/{%s:[0-9]+}",
@@ -26,6 +26,12 @@ func (s *httpService) registerHandlersV2() {
 		URLPlaceholder_id),
 		corsHandler(requestHandlerV2_table())).
 		Methods(http.MethodPatch, http.MethodDelete, http.MethodGet)
+
+	// read collection: /api/v2/users/{owner}/apps/{app}/workspaces/{wsid}/cdocs/{pkg}.{table}
+	s.router.HandleFunc(fmt.Sprintf("/api/v2/users/{%s}/apps/{%s}/workspaces/{%s:[0-9]+}/cdocs/{%s}.{%s}",
+		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_wsid, URLPlaceholder_pkg, URLPlaceholder_table),
+		corsHandler(requestHandlerV2_table())).
+		Methods(http.MethodGet)
 
 	// execute cmd: /api/v2/users/{owner}/apps/{app}/workspaces/{wsid}/commands/{pkg}.{command}
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/users/{%s}/apps/{%s}/workspaces/{%s:[0-9]+}/commands/{%s}.{%s}",


### PR DESCRIPTION
Resolves #2993 Router: read from CDocs collection: url path: `docs` -> `cdocs`
