### PR TITLE
#3041 CP: skip work with `WorkspaceDescriptor` on `c.sys.CreateWorkspaceID`

### DIFF
--- a/pkg/processors/command/impl.go
+++ b/pkg/processors/command/impl.go
@@ -150,7 +150,7 @@ func (cmdProc *cmdProc) getAppPartition(ctx context.Context, work pipeline.IWork
 
 func getIWorkspace(_ context.Context, work pipeline.IWorkpiece) (err error) {
 	cmd := work.(*cmdWorkpiece)
-	if cmd.cmdMes.QName() != workspacemgmt.QNameCommandCreateWorkspace {
+	if cmd.cmdMes.QName() != workspacemgmt.QNameCommandCreateWorkspace && cmd.cmdMes.QName() != workspacemgmt.QNameCommandCreateWorkspaceID {
 		cmd.iWorkspace = cmd.appStructs.AppDef().WorkspaceByDescriptor(cmd.wsDesc.AsQName(authnz.Field_WSKind))
 	}
 	return nil
@@ -160,7 +160,7 @@ func getICommand(_ context.Context, work pipeline.IWorkpiece) (err error) {
 	cmd := work.(*cmdWorkpiece)
 	var cmdType appdef.IType
 	if cmd.iWorkspace == nil {
-		// DummyWS or c.sys.CreateWorkspace
+		// DummyWS or c.sys.CreateWorkspace or c.sys.CreateWorkspaceID
 		cmdType = cmd.appStructs.AppDef().Type(cmd.cmdMes.QName())
 	} else {
 		if cmdType = cmd.iWorkspace.Type(cmd.cmdMes.QName()); cmdType.Kind() == appdef.TypeKind_null {
@@ -564,7 +564,7 @@ func (cmdProc *cmdProc) cudsValidators(ctx context.Context, work pipeline.IWorkp
 func (cmdProc *cmdProc) validateCUDsQNames(ctx context.Context, work pipeline.IWorkpiece) (err error) {
 	cmd := work.(*cmdWorkpiece)
 	if cmd.iWorkspace == nil {
-		// dummy or c.sys.CreateWorkspace
+		// dummy or c.sys.CreateWorkspace or c.sys.CreateWorkspaceID
 		return nil
 	}
 	for cud := range cmd.rawEvent.CUDs {

--- a/pkg/sys/workspace/impl.go
+++ b/pkg/sys/workspace/impl.go
@@ -91,7 +91,7 @@ func ApplyInvokeCreateWorkspaceID(federation federation.IFederation, appQName ap
 		coreutils.WithExpectedCode(http.StatusOK),
 		coreutils.WithExpectedCode(http.StatusConflict),
 	); createWSIDCmdErr != nil {
-		logger.Error(fmt.Sprintf("aproj.sys.InvokeCreateWorkspaceID: c.sys.CreateWorkspaceID failed: %s. Body:\n%s", createWSIDCmdErr, body))
+		logger.Error(fmt.Sprintf("aproj.sys.InvokeCreateWorkspaceID: c.sys.CreateWorkspaceID failed: %s. Body:\n%s", createWSIDCmdErr.Error(), body))
 		ownerAppQName, err := appdef.ParseAppQName(ownerApp)
 		if err != nil {
 			// notest


### PR DESCRIPTION
Resolves #3041 CP: skip work with `WorkspaceDescriptor` on `c.sys.CreateWorkspaceID`
