### PR TITLE
3083 insertifnotexistscompareandswap method must insert persistent key if ttl is zero 1

### DIFF
--- a/pkg/istorage/interface.go
+++ b/pkg/istorage/interface.go
@@ -75,7 +75,7 @@ type IAppStorage interface {
 	//   - pKey: Primary key bytes
 	//   - cCols: Clustering columns bytes (if any)
 	//   - value: Value bytes to be inserted
-	//   - ttlSeconds: Time-to-live in seconds after which the record will be automatically deleted
+	//   - ttlSeconds: Time-to-live in seconds after which the record will be automatically deleted. Ignored if zero.
 	//
 	// Returns:
 	//   - ok: true if insert was successful (record didn't exist), false if record already exists
@@ -90,7 +90,7 @@ type IAppStorage interface {
 	//   - cCols: Clustering columns bytes (if any)
 	//   - oldValue: Expected current value bytes to compare against
 	//   - newValue: New value bytes to swap in if comparison succeeds
-	//   - ttlSeconds: Time-to-live in seconds to set/update on the record
+	//   - ttlSeconds: Time-to-live in seconds to set/update on the record. Ignored if zero.
 	//
 	// Returns:
 	//   - ok: true if swap was successful (record existed and matched oldValue), false otherwise

--- a/pkg/istorage/mem/impl.go
+++ b/pkg/istorage/mem/impl.go
@@ -78,10 +78,14 @@ func (s *appStorage) InsertIfNotExists(pKey []byte, cCols []byte, newValue []byt
 		return false, nil
 	}
 
-	newExpireAt := now.Add(time.Duration(ttlSeconds) * time.Second)
+	var expireAt *time.Time
+	if ttlSeconds > 0 {
+		newExpireAt := now.Add(time.Duration(ttlSeconds) * time.Second)
+		expireAt = &newExpireAt
+	}
 	p[string(cCols)] = dataWithTTL{
 		data:     copySlice(newValue),
-		expireAt: &newExpireAt,
+		expireAt: expireAt,
 	}
 
 	return true, nil
@@ -111,10 +115,14 @@ func (s *appStorage) CompareAndSwap(pKey []byte, cCols []byte, oldValue, newValu
 	if !ttlExpired && bytes.Compare(currentValue, oldValue) == 0 {
 		ok = true
 
-		newExpireAt := now.Add(time.Duration(ttlSeconds) * time.Second)
+		var expireAt *time.Time
+		if ttlSeconds > 0 {
+			newExpireAt := now.Add(time.Duration(ttlSeconds) * time.Second)
+			expireAt = &newExpireAt
+		}
 		p[string(cCols)] = dataWithTTL{
 			data:     copySlice(newValue),
-			expireAt: &newExpireAt,
+			expireAt: expireAt,
 		}
 
 		return

--- a/pkg/istorage/tck.go
+++ b/pkg/istorage/tck.go
@@ -669,6 +669,23 @@ func testAppStorage_InsertIfNotExists(t *testing.T, storage IAppStorage, iTime c
 		require.True(ok)
 		require.Equal(value, data)
 	})
+
+	t.Run("ttl is zero", func(t *testing.T) {
+		require := require.New(t)
+		pKey := []byte("Vehicles2")
+		ccols := []byte("Cars2")
+		value := []byte("Toyota2")
+
+		ok, err := storage.InsertIfNotExists(pKey, ccols, value, 0)
+		require.NoError(err)
+		require.True(ok)
+
+		iTime.Sleep(2 * time.Second)
+
+		ok, err = storage.InsertIfNotExists(pKey, ccols, value, 0)
+		require.NoError(err)
+		require.False(ok)
+	})
 }
 
 //nolint:revive,goconst
@@ -747,6 +764,30 @@ func testAppStorage_CompareAndSwap(t *testing.T, storage IAppStorage, iTime core
 		require.NoError(err)
 		require.True(ok)
 		require.Equal(oldValue, data)
+	})
+
+	t.Run("ttl is zero", func(t *testing.T) {
+		require := require.New(t)
+		pKey := []byte("Movies2")
+		ccols := []byte("The Hobbit2")
+		oldValue := []byte("An unexpected journey2")
+
+		ok, err := storage.InsertIfNotExists(pKey, ccols, oldValue, 0)
+		require.NoError(err)
+		require.True(ok)
+
+		iTime.Sleep(3 * time.Second)
+
+		newValue := []byte("The desolation of Smaug")
+		ok, err = storage.CompareAndSwap(pKey, ccols, oldValue, newValue, 2)
+		require.NoError(err)
+		require.True(ok)
+
+		data := make([]byte, 0)
+		ok, err = storage.Get(pKey, ccols, &data)
+		require.NoError(err)
+		require.True(ok)
+		require.Equal(newValue, data)
 	})
 }
 


### PR DESCRIPTION
fix #3083 