### PR TITLE
#3111 vsql update query field: max default len 255

### DIFF
--- a/pkg/cluster/appws.vsql
+++ b/pkg/cluster/appws.vsql
@@ -18,7 +18,7 @@ ALTER WORKSPACE sys.AppWorkspaceWS (
 	);
 
 	TYPE VSqlUpdateParams (
-		Query varchar NOT NULL
+		Query varchar(65535) NOT NULL
 	);
 
 	TYPE VSqlUpdateResult (


### PR DESCRIPTION
Resolves #3111 vsql update query field: max default len 255
