### PR TITLE
#3182 CP: clarify the error message if `sys.QName` on insert is missing

### DIFF
--- a/pkg/processors/command/impl.go
+++ b/pkg/processors/command/impl.go
@@ -626,7 +626,7 @@ func parseCUDs(_ context.Context, work pipeline.IWorkpiece) (err error) {
 				return cudXPath.Error(err)
 			}
 			if parsedCUD.qName, err = appdef.ParseQName(qNameStr); err != nil {
-				return cudXPath.Error(err)
+				return cudXPath.Error(fmt.Errorf("failed to parse sys.QName: %w", err))
 			}
 		} else {
 			if parsedCUD.id, ok, err = cudData.AsInt64(appdef.SystemField_ID); err != nil {

--- a/pkg/sys/it/impl_cud_test.go
+++ b/pkg/sys/it/impl_cud_test.go
@@ -610,3 +610,15 @@ func TestFieldsAuthorization_OpForbidden(t *testing.T) {
 
 	// note: select authorization is tested in [TestDeniedResourcesAuthorization]
 }
+
+func TestErrors(t *testing.T) {
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
+
+	t.Run("no QName on insert -> 400 bad request", func(t *testing.T) {
+		body := `{"cuds": [{"fields": {"sys.ID": 1,"FldAllowed":42}}]}`
+		vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect400("failed to parse sys.QName"))
+	})
+}

--- a/pkg/sys/it/impl_test.go
+++ b/pkg/sys/it/impl_test.go
@@ -125,6 +125,8 @@ func Test400BadRequests(t *testing.T) {
 		{desc: "unknown app", funcName: "c.sys.CUD", appName: "un/known"},
 	}
 
+	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
+
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			appQName := istructs.AppQName_test1_app1
@@ -132,7 +134,7 @@ func Test400BadRequests(t *testing.T) {
 				appQName, err = appdef.ParseAppQName(c.appName)
 				require.NoError(t, err)
 			}
-			vit.PostApp(appQName, 1, c.funcName, "", coreutils.Expect400()).Println()
+			vit.PostApp(appQName, ws.WSID, c.funcName, "", coreutils.Expect400()).Println()
 		})
 	}
 }


### PR DESCRIPTION
Resolves #3182 CP: clarify the error message if `sys.QName` on insert is missing
