### PR TITLE
#3281 q.sys.SqlQuery in different app: forward with sys token -> forward with the provided token re-issued for the target app

### DIFF
--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -515,8 +515,10 @@ func TestReadFromAnDifferentLocations(t *testing.T) {
 
 		// for example read cdoc.registry.Login.LoginHash from the app workspace
 		loginID := vit.GetCDocLoginID(prn.Login)
+		// request to the different app -> use sys token to avoid 403
+		sysPrincipal := vit.GetSystemPrincipal(istructs.AppQName_test1_app1)
 		body := fmt.Sprintf(`{"args":{"Query":"select * from sys.registry.a%d.registry.Login where id = %d"},"elements":[{"fields":["Result"]}]}`, appWSNumber, loginID)
-		resp := vit.PostWS(oneAppWS, "q.sys.SqlQuery", body)
+		resp := vit.PostWS(oneAppWS, "q.sys.SqlQuery", body, coreutils.WithAuthorizeBy(sysPrincipal.Token))
 		loginHash := registry.GetLoginHash(prn.Login.Name)
 		require.Contains(resp.SectionRow()[0].(string), fmt.Sprintf(`"LoginHash":"%s"`, loginHash))
 	})
@@ -525,8 +527,10 @@ func TestReadFromAnDifferentLocations(t *testing.T) {
 		// for example read cdoc.registry.Login.LoginHash from the app workspace determined by the login name
 		prn := vit.GetPrincipal(istructs.AppQName_test1_app1, "login") // from VIT shared config
 		loginID := vit.GetCDocLoginID(prn.Login)
+		// request to the different app -> use sys token to avoid 403
+		sysPrincipal := vit.GetSystemPrincipal(istructs.AppQName_test1_app1)
 		body := fmt.Sprintf(`{"args":{"Query":"select * from sys.registry.\"login\".registry.Login where id = %d"},"elements":[{"fields":["Result"]}]}`, loginID)
-		resp := vit.PostWS(oneAppWS, "q.sys.SqlQuery", body)
+		resp := vit.PostWS(oneAppWS, "q.sys.SqlQuery", body, coreutils.WithAuthorizeBy(sysPrincipal.Token))
 		loginHash := registry.GetLoginHash(prn.Login.Name)
 		require.Contains(resp.SectionRow()[0].(string), fmt.Sprintf(`"LoginHash":"%s"`, loginHash))
 	})
@@ -553,6 +557,16 @@ func TestAuthnz(t *testing.T) {
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
 	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
+
+	t.Run("foreign app", func(t *testing.T) {
+		loginID := vit.GetCDocLoginID(ws.Owner.Login)
+		registryAppStructs, err := vit.IAppStructsProvider.BuiltIn(istructs.AppQName_sys_registry)
+		require.NoError(t, err)
+		pseudoWSID := coreutils.GetPseudoWSID(istructs.NullWSID, ws.Owner.Name, istructs.CurrentClusterID())
+		appWSNumber := pseudoWSID.BaseWSID() % istructs.WSID(registryAppStructs.NumAppWorkspaces())
+		body := fmt.Sprintf(`{"args":{"Query":"select * from sys.registry.a%d.registry.Login where id = %d"},"elements":[{"fields":["Result"]}]}`, appWSNumber, loginID)
+		vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect403())
+	})
 
 	t.Run("doc", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from app1pkg.TestDeniedCDoc.123"},"elements":[{"fields":["Result"]}]}`

--- a/pkg/sys/sqlquery/impl.go
+++ b/pkg/sys/sqlquery/impl.go
@@ -24,6 +24,8 @@ import (
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/itokens"
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
+	"github.com/voedger/voedger/pkg/sys"
+	"github.com/voedger/voedger/pkg/sys/authnz"
 )
 
 func provideExecQrySqlQuery(federation federation.IFederation, itokens itokens.ITokens) func(ctx context.Context, args istructs.ExecQueryArgs, callback istructs.ExecQueryCallback) (err error) {
@@ -60,15 +62,33 @@ func provideExecQrySqlQuery(federation federation.IFederation, itokens itokens.I
 			if targetAppQName == appdef.NullAppQName {
 				targetAppQName = args.State.App()
 			}
-			sysTokenForTargetApp, err := payloads.GetSystemPrincipalToken(itokens, targetAppQName)
+			subjKB, err := args.State.KeyBuilder(sys.Storage_RequestSubject, appdef.NullQName)
+			if err != nil {
+				//notest
+				return err
+			}
+			subj, err := args.State.MustExist(subjKB)
 			if err != nil {
 				// notest
 				return err
 			}
+
+			tokenForTargetApp := subj.AsString(sys.Storage_RequestSubject_Field_Token)
+			if targetAppQName != args.State.App() {
+				// query is for a foreign app -> re-issue token for the target app
+				var pp payloads.PrincipalPayload
+				if _, err = itokens.ValidateToken(tokenForTargetApp, &pp); err != nil {
+					// notest: validated already by the processor
+					return err
+				}
+				if tokenForTargetApp, err = itokens.IssueToken(targetAppQName, authnz.DefaultPrincipalTokenExpiration, &pp); err != nil {
+					return err
+				}
+			}
 			logger.Info(fmt.Sprintf("forwarding query to %s/%d", targetAppQName, targetWSID))
 			body := fmt.Sprintf(`{"args":{"Query":%q},"elements":[{"fields":["Result"]}]}`, op.VSQLWithoutAppAndWSID)
 			resp, err := federation.Func(fmt.Sprintf("api/%s/%d/q.sys.SqlQuery", targetAppQName, targetWSID),
-				body, coreutils.WithAuthorizeBy(sysTokenForTargetApp))
+				body, coreutils.WithAuthorizeBy(tokenForTargetApp))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Resolves #3281 q.sys.SqlQuery in different app: forward with sys token -> forward with the provided token re-issued for the target app
