### PR TITLE
#3310 ITTLStorage must work on `sysvvm` keyspace

### DIFF
--- a/pkg/vvm/provide.go
+++ b/pkg/vvm/provide.go
@@ -220,7 +220,7 @@ func ProvideCluster(vvmCtx context.Context, vvmConfig *VVMConfig) (*VVM, func(),
 }
 
 func provideIVVMAppTTLStorage(prov istorage.IAppStorageProvider) (IVVMAppTTLStorage, error) {
-	return prov.AppStorage(istructs.AppQName_sys_cluster)
+	return prov.AppStorage(appdef.NewAppQName(istructs.SysOwner, "vvm"))
 }
 
 func provideWLimiterFactory(maxSize iblobstorage.BLOBMaxSizeType) blobprocessor.WLimiterFactory {

--- a/pkg/vvm/ttlstorage/impl.go
+++ b/pkg/vvm/ttlstorage/impl.go
@@ -13,7 +13,7 @@ import (
 )
 
 type storageImpl struct {
-	prefix        PKeyPrefix // вот этот прфеикс 1 - leader elections, 2 - appQName->safeAppName и т.д.
+	prefix        PKeyPrefix
 	vvmttlstorage vvm.IVVMAppTTLStorage
 }
 

--- a/pkg/vvm/ttlstorage/impl.go
+++ b/pkg/vvm/ttlstorage/impl.go
@@ -13,7 +13,7 @@ import (
 )
 
 type storageImpl struct {
-	prefix        PKeyPrefix
+	prefix        PKeyPrefix // вот этот прфеикс 1 - leader elections, 2 - appQName->safeAppName и т.д.
 	vvmttlstorage vvm.IVVMAppTTLStorage
 }
 

--- a/pkg/vvm/wire_gen.go
+++ b/pkg/vvm/wire_gen.go
@@ -285,7 +285,7 @@ func (vvm *VoedgerVM) Launch() error {
 }
 
 func provideIVVMAppTTLStorage(prov istorage.IAppStorageProvider) (IVVMAppTTLStorage, error) {
-	return prov.AppStorage(istructs.AppQName_sys_cluster)
+	return prov.AppStorage(appdef.NewAppQName(istructs.SysOwner, "vvm"))
 }
 
 func provideWLimiterFactory(maxSize iblobstorage.BLOBMaxSizeType) blobprocessor.WLimiterFactory {


### PR DESCRIPTION
Resolves #3310 ITTLStorage must work on sysvvm keyspace
