### PR TITLE
#3420 qpv2: declare `/schemas` paths

### DIFF
--- a/pkg/processors/query2/const.go
+++ b/pkg/processors/query2/const.go
@@ -10,4 +10,7 @@ const (
 	ApiPath_Queries
 	ApiPath_Views
 	ApiPath_Commands
+	ApiPaths_Schemas
+	ApiPaths_Schemas_WorkspaceRoles
+	ApiPaths_Schemas_WorkspaceRole
 )


### PR DESCRIPTION
Resolves #3420 qpv2: declare `/schemas` paths
