### PR TITLE
#3445 Provide response meta to `IResponder.Respond()`

### DIFF
--- a/pkg/bus/impl.go
+++ b/pkg/bus/impl.go
@@ -102,10 +102,11 @@ func (r *implIResponder) InitResponse(statusCode int) IResponseWriter {
 	return r.respWriter
 }
 
-func (r *implIResponder) Respond(statusCode int, obj any) error {
+func (r *implIResponder) Respond(responseMeta ResponseMeta, obj any) error {
 	r.checkStarted()
+	responseMeta.mode = RespondMode_Single
 	select {
-	case r.responseMetaCh <- ResponseMeta{ContentType: coreutils.ApplicationJSON, StatusCode: statusCode, mode: RespondMode_Single}:
+	case r.responseMetaCh <- responseMeta:
 		// TODO: rework here: possible: http client disconnected, write to r.respWriter.ch successful, we're thinking that we're replied, but it is not, no socket to write to
 		r.respWriter.ch <- obj // buf size 1
 		close(r.respWriter.ch)

--- a/pkg/bus/impl.go
+++ b/pkg/bus/impl.go
@@ -104,6 +104,9 @@ func (r *implIResponder) InitResponse(statusCode int) IResponseWriter {
 
 func (r *implIResponder) Respond(responseMeta ResponseMeta, obj any) error {
 	r.checkStarted()
+	if responseMeta.mode != 0 {
+		panic("responseMeta.mode is set by someone else!")
+	}
 	responseMeta.mode = RespondMode_Single
 	select {
 	case r.responseMetaCh <- responseMeta:

--- a/pkg/bus/impl_test.go
+++ b/pkg/bus/impl_test.go
@@ -226,7 +226,7 @@ func TestPanicOnBeginResponseAgain(t *testing.T) {
 			require.Panics(func() {
 				responder.InitResponse(http.StatusOK)
 			})
-			require.Panics(func() { responder.Respond(http.StatusOK, nil) })
+			require.Panics(func() { responder.Respond(ResponseMeta{}, nil) })
 			respWriter.Close(nil)
 		})
 
@@ -236,11 +236,11 @@ func TestPanicOnBeginResponseAgain(t *testing.T) {
 
 	t.Run("respond", func(t *testing.T) {
 		requestSender := NewIRequestSender(coreutils.MockTime, DefaultSendTimeout, func(requestCtx context.Context, request Request, responder IResponder) {
-			responder.Respond(http.StatusOK, nil)
+			responder.Respond(ResponseMeta{ContentType: coreutils.ApplicationJSON, StatusCode: http.StatusOK}, nil)
 			require.Panics(func() {
 				responder.InitResponse(http.StatusOK)
 			})
-			require.Panics(func() { responder.Respond(http.StatusOK, nil) })
+			require.Panics(func() { responder.Respond(ResponseMeta{}, nil) })
 		})
 
 		_, _, _, err := requestSender.SendRequest(context.Background(), Request{})

--- a/pkg/bus/interface.go
+++ b/pkg/bus/interface.go
@@ -26,8 +26,7 @@ type IResponder interface {
 	InitResponse(statusCode int) IResponseWriter
 
 	// panics if called >1 times or after InitResponse
-	// ContentType is ApplicationJSON
-	Respond(statusCode int, obj any) error
+	Respond(responseMeta ResponseMeta, obj any) error
 }
 
 type IResponseWriter interface {

--- a/pkg/bus/utils.go
+++ b/pkg/bus/utils.go
@@ -59,7 +59,7 @@ func ReplyErrf(responder IResponder, status int, args ...interface{}) {
 //nolint:errorlint
 func ReplyErrDef(responder IResponder, err error, defaultStatusCode int) {
 	res := coreutils.WrapSysErrorToExact(err, defaultStatusCode)
-	if err := responder.Respond(res.HTTPStatus, res); err != nil {
+	if err := responder.Respond(ResponseMeta{ContentType: coreutils.ApplicationJSON, StatusCode: res.HTTPStatus}, res); err != nil {
 		logger.Error(err)
 	}
 }
@@ -69,7 +69,7 @@ func ReplyErr(responder IResponder, err error) {
 }
 
 func ReplyJSON(responder IResponder, httpCode int, obj any) {
-	if err := responder.Respond(httpCode, obj); err != nil {
+	if err := responder.Respond(ResponseMeta{ContentType: coreutils.ApplicationJSON, StatusCode: httpCode}, obj); err != nil {
 		logger.Error(err)
 	}
 }

--- a/pkg/router/impl_test.go
+++ b/pkg/router/impl_test.go
@@ -139,7 +139,7 @@ func TestBasicUsage_Respond(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			router := setUp(t, func(requestCtx context.Context, request bus.Request, responder bus.IResponder) {
 				go func() {
-					err := responder.Respond(http.StatusOK, c.obj)
+					err := responder.Respond(bus.ResponseMeta{ContentType: coreutils.ApplicationJSON, StatusCode: http.StatusOK}, c.obj)
 					require.NoError(err)
 				}()
 			}, bus.DefaultSendTimeout)


### PR DESCRIPTION
Resolves #3445 Provide response meta to `IResponder.Respond()`
