### PR TITLE
#3460 router: explicitly use zero Partition on paths without WSID

### DIFF
--- a/pkg/processors/query2/impl.go
+++ b/pkg/processors/query2/impl.go
@@ -182,6 +182,10 @@ func newQueryProcessorPipeline(requestCtx context.Context, authn iauthnz.IAuthen
 			return qw.apiPathHandler.SetRequestType(ctx, qw)
 		}),
 		operator("authorize query request", func(ctx context.Context, qw *queryWork) (err error) {
+			switch qw.msg.ApiPath() {
+			case ApiPaths_Schemas, ApiPaths_Schemas_WorkspaceRole, ApiPaths_Schemas_WorkspaceRoles:
+				return nil
+			}
 			ok, err := qw.appPart.IsOperationAllowed(qw.iWorkspace, qw.apiPathHandler.RequestOpKind(), qw.msg.QName(), nil, qw.roles)
 			if err != nil {
 				return err

--- a/pkg/router/impl_reply_v2.go
+++ b/pkg/router/impl_reply_v2.go
@@ -27,10 +27,13 @@ import (
 func createBusRequest(reqMethod string, req *http.Request, rw http.ResponseWriter, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) (res bus.Request, ok bool) {
 	vars := mux.Vars(req)
 	wsidStr := vars[URLPlaceholder_wsid]
-	wsidUint, err := strconv.ParseUint(wsidStr, utils.DecimalBase, utils.BitSize64)
-	if err != nil {
-		// notest: impossible because of regexp in a handler
-		panic(err)
+	var wsidUint uint64
+	var err error
+	if len(wsidStr) > 0 {
+		if wsidUint, err = strconv.ParseUint(wsidStr, utils.DecimalBase, utils.BitSize64); err != nil {
+			// notest: impossible because of regexp in a handler
+			panic(err)
+		}
 	}
 	appQNameStr := vars[URLPlaceholder_appOwner] + appdef.AppQNameQualifierChar + vars[URLPlaceholder_appName]
 	wsid := istructs.WSID(wsidUint)


### PR DESCRIPTION
Resolves #3460 router: explicitly use zero Partition on paths without WSID
