### PR TITLE
#3340 GET `/schemas/{workspace}/roles`: return the list of published roles

### DIFF
--- a/pkg/processors/query2/impl.go
+++ b/pkg/processors/query2/impl.go
@@ -122,6 +122,8 @@ func newQueryProcessorPipeline(requestCtx context.Context, authn iauthnz.IAuthen
 				qw.apiPathHandler = &docsHandler{}
 			case ApiPaths_Schema:
 				qw.apiPathHandler = &schemasHandler{}
+			case ApiPath_Schemas_WorkspaceRoles:
+				qw.apiPathHandler = &schemasRolesHandler{}
 			default:
 				return coreutils.NewHTTPErrorf(http.StatusBadRequest, fmt.Sprintf("unsupported api path %v", qw.msg.ApiPath()))
 			}

--- a/pkg/processors/query2/impl_schemas_handler.go
+++ b/pkg/processors/query2/impl_schemas_handler.go
@@ -44,19 +44,10 @@ func (h *schemasHandler) AuthorizeResult(ctx context.Context, qw *queryWork) (er
 }
 
 func (h *schemasHandler) RowsProcessor(ctx context.Context, qw *queryWork) (err error) {
-	// sender := &sender{responder: qw.msg.Responder(), isArrayResponse: false, contentType: contentTypeHtml}
-	// qw.rowsProcessor = pipeline.NewAsyncPipeline(ctx, "View rows processor", pipeline.WireAsyncOperator("Sender", sender))
-	// qw.responseWriterGetter = func() bus.IResponseWriter {
-	// 	return sender.respWriter
-	// }
 	return nil
 }
 
 func (h *schemasHandler) Exec(ctx context.Context, qw *queryWork) (err error) {
-	// wsQname := qw.msg.WorkspaceQName()
-	// if wsQname == appdef.NullQName {
-	// 	return coreutils.NewHTTPErrorf(http.StatusBadRequest, fmt.Errorf("workspace is not specified"))
-	// }
 	generatedHtml := fmt.Sprintf("<html><head><title>App %s schema</title></head><body>", qw.msg.AppQName().String())
 	generatedHtml += fmt.Sprintf("<h1>App %s schema</h1>", qw.msg.AppQName().String())
 

--- a/pkg/processors/query2/impl_schemas_roles_handler.go
+++ b/pkg/processors/query2/impl_schemas_roles_handler.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025-present unTill Software Development Group B.V.
+ * @author Michael Saigachenko
+ */
+package query2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/voedger/voedger/pkg/appdef"
+	"github.com/voedger/voedger/pkg/bus"
+	"github.com/voedger/voedger/pkg/coreutils"
+	"github.com/voedger/voedger/pkg/istructsmem"
+)
+
+type schemasRolesHandler struct {
+}
+
+var _ IApiPathHandler = (*schemasRolesHandler)(nil) // ensure that queryHandler implements IApiPathHandler
+
+func (h *schemasRolesHandler) IsArrayResult() bool {
+	return false
+}
+
+func (h *schemasRolesHandler) CheckRateLimit(ctx context.Context, qw *queryWork) error {
+	return nil
+}
+
+func (h *schemasRolesHandler) SetRequestType(ctx context.Context, qw *queryWork) error {
+	return nil
+}
+
+func (h *schemasRolesHandler) SetResultType(ctx context.Context, qw *queryWork, statelessResources istructsmem.IStatelessResources) error {
+	return nil
+}
+
+func (h *schemasRolesHandler) RequestOpKind() appdef.OperationKind {
+	return appdef.OperationKind_Select
+}
+
+func (h *schemasRolesHandler) AuthorizeResult(ctx context.Context, qw *queryWork) (err error) {
+	return nil
+}
+
+func (h *schemasRolesHandler) RowsProcessor(ctx context.Context, qw *queryWork) (err error) {
+	return nil
+}
+
+func (h *schemasRolesHandler) Exec(ctx context.Context, qw *queryWork) (err error) {
+	wsQname := qw.msg.WorkspaceQName()
+	if wsQname == appdef.NullQName {
+		return coreutils.NewHTTPErrorf(http.StatusBadRequest, fmt.Errorf("workspace is not specified"))
+	}
+	workspace := qw.appStructs.AppDef().Workspace(wsQname)
+	if workspace == nil {
+		return coreutils.NewHTTPErrorf(http.StatusNotFound, fmt.Errorf("workspace %s not found", wsQname.String()))
+	}
+
+	generatedHtml := fmt.Sprintf("<html><head><title>App %s: workspace %s published roles</title></head><body>", qw.msg.AppQName().String(), wsQname.String())
+	generatedHtml += fmt.Sprintf("<h1>App %s</h1><h2>Workspace %s published roles</h2>", qw.msg.AppQName().String(), wsQname.String())
+	roles := make([]appdef.IRole, 0)
+	for _, typ := range workspace.Types() {
+		if typ.Kind() == appdef.TypeKind_Role {
+			role := typ.(appdef.IRole)
+			if role.Published() {
+				roles = append(roles, role)
+				break
+			}
+		}
+	}
+
+	if len(roles) == 0 {
+		generatedHtml += "<p>No published roles</p>"
+	} else {
+		generatedHtml += "<ul>"
+		for _, role := range roles {
+			ref := fmt.Sprintf("/api/v2/users/%s/apps/%s/schemas/%s/roles/%s", qw.msg.AppQName().Owner(), qw.msg.AppQName().Name(), workspace.QName().String(), role.QName().String())
+			generatedHtml += fmt.Sprintf(`<li><a href="%s">%s</a></li>`, ref, role.QName().String())
+		}
+		generatedHtml += "</ul>"
+	}
+	generatedHtml += "</body></html>"
+
+	return qw.msg.Responder().Respond(bus.ResponseMeta{ContentType: contentTypeHtml, StatusCode: http.StatusOK}, generatedHtml)
+}

--- a/pkg/sys/it/impl_qpv2_test.go
+++ b/pkg/sys/it/impl_qpv2_test.go
@@ -513,7 +513,13 @@ func TestQueryProcessor2_SchemasRoles(t *testing.T) {
 		resp, err := vit.IFederation.Query(`api/v2/users/test1/apps/app1/schemas/app1pkg.test_wsWS/roles`)
 		require.NoError(err)
 		resp.Println()
-		require.Equal(`<html><head><title>App test1/app1 schema</title></head><body><h1>App test1/app1 schema</h1><ul><li><a href="/api/v2/users/test1/apps/app1/schemas/app1pkg.test_wsWS/roles">app1pkg.test_wsWS</a></li></ul></body></html>`, resp.Body)
+		require.Equal(`<html><head><title>App test1/app1: workspace app1pkg.test_wsWS published roles</title></head><body><h1>App test1/app1</h1><h2>Workspace app1pkg.test_wsWS published roles</h2><ul><li><a href="/api/v2/users/test1/apps/app1/schemas/app1pkg.test_wsWS/roles/app1pkg.ApiRole">app1pkg.ApiRole</a></li></ul></body></html>`, resp.Body)
+	})
+
+	t.Run("unknown ws", func(t *testing.T) {
+		resp, err := vit.IFederation.Query(`api/v2/users/test1/apps/app1/schemas/pkg.unknown/roles`, coreutils.Expect404())
+		require.NoError(err)
+		require.JSONEq(`{"status":404,"message":"workspace pkg.unknown not found"}`, resp.Body)
 	})
 }
 

--- a/pkg/sys/it/impl_qpv2_test.go
+++ b/pkg/sys/it/impl_qpv2_test.go
@@ -502,7 +502,19 @@ func TestQueryProcessor2_Schemas(t *testing.T) {
 		resp.Println()
 		require.Equal(`<html><head><title>App test1/app1 schema</title></head><body><h1>App test1/app1 schema</h1><ul><li><a href="/api/v2/users/test1/apps/app1/schemas/app1pkg.test_wsWS/roles">app1pkg.test_wsWS</a></li></ul></body></html>`, resp.Body)
 	})
+}
 
+func TestQueryProcessor2_SchemasRoles(t *testing.T) {
+	require := require.New(t)
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+	//	fmt.Printf("Port: %d\n", vit.Port())
+	t.Run("read app workspace roles", func(t *testing.T) {
+		resp, err := vit.IFederation.Query(`api/v2/users/test1/apps/app1/schemas/app1pkg.test_wsWS/roles`)
+		require.NoError(err)
+		resp.Println()
+		require.Equal(`<html><head><title>App test1/app1 schema</title></head><body><h1>App test1/app1 schema</h1><ul><li><a href="/api/v2/users/test1/apps/app1/schemas/app1pkg.test_wsWS/roles">app1pkg.test_wsWS</a></li></ul></body></html>`, resp.Body)
+	})
 }
 
 func TestQueryProcessor2_Docs(t *testing.T) {


### PR DESCRIPTION
Resolves #3340 GET `/schemas/{workspace}/roles`: return the list of published roles
