### PR TITLE
#3465 schemas: use role comment as an OpenApi description

### DIFF
--- a/pkg/processors/query2/impl_openapi.go
+++ b/pkg/processors/query2/impl_openapi.go
@@ -784,7 +784,6 @@ func (g *schemaGenerator) write(writer io.Writer) error {
 		"openapi": "3.0.0",
 		"info": map[string]interface{}{
 			"title":              g.meta.SchemaTitle,
-			"summary":            "Summary",
 			"version":            g.meta.SchemaVersion,
 			schemaKeyDescription: g.meta.Description,
 		},
@@ -792,7 +791,7 @@ func (g *schemaGenerator) write(writer io.Writer) error {
 			"name": g.meta.AppName.Owner(),
 		},
 		"externalDocs": map[string]interface{}{
-			schemaKeyDescription: "Built with Voedger: distributed cloud application platform",
+			schemaKeyDescription: "Powered by Voedger: distributed cloud application platform",
 			"url":                "https://voedger.io",
 		},
 		"servers": []map[string]interface{}{

--- a/pkg/processors/query2/impl_schemas_role_handler.go
+++ b/pkg/processors/query2/impl_schemas_role_handler.go
@@ -74,7 +74,7 @@ func (h *schemasRoleHandler) Exec(ctx context.Context, qw *queryWork) (err error
 	schemaMeta := SchemaMeta{
 		SchemaTitle:   fmt.Sprintf("%s: %s OpenAPI 3.0", qw.msg.AppQName().Name(), role.QName().Entity()),
 		SchemaVersion: "1.0.0", // TODO: get app name and version from appdef
-		Description:   workspace.Comment(),
+		Description:   role.Comment(),
 		AppName:       qw.msg.AppQName(),
 	}
 

--- a/pkg/sys/it/impl_qpv2_test.go
+++ b/pkg/sys/it/impl_qpv2_test.go
@@ -512,7 +512,7 @@ func TestQueryProcessor2_SchemasRoles(t *testing.T) {
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
 
-	// fmt.Printf("Port: %d\n", vit.Port())
+	//fmt.Printf("Port: %d\n", vit.Port())
 
 	t.Run("read app workspace roles", func(t *testing.T) {
 		resp, err := vit.IFederation.Query(`api/v2/users/test1/apps/app1/schemas/app1pkg.test_wsWS/roles`)

--- a/pkg/vit/schemaTestApp1.vsql
+++ b/pkg/vit/schemaTestApp1.vsql
@@ -25,8 +25,6 @@ ALTERABLE WORKSPACE test_wsWS_another (
 	);
 );
 
-/* Workspace for testing
-   Contains tables with different fields and constraints */
 ALTERABLE WORKSPACE test_wsWS (
 
 	DESCRIPTOR test_ws (
@@ -706,6 +704,7 @@ ALTERABLE WORKSPACE test_wsWS (
 	TAG WorkspaceOwnerFuncTag;
 	TAG ApiFeatureTag FEATURE 'Backoffice API';
 
+	/* ApiRole is used for testing API access */
 	PUBLISHED ROLE ApiRole;
 	GRANT SELECT, INSERT, UPDATE, ACTIVATE, DEACTIVATE ON TABLE Currency TO ApiRole;
 	GRANT SELECT ON TABLE category TO ApiRole;


### PR DESCRIPTION
Resolves #3465 schemas: use role comment as an OpenApi description
