### PR TITLE
#3471 parser: unable to use `sys.*` fields in GRANTS

### DIFF
--- a/pkg/parser/impl_analyse.go
+++ b/pkg/parser/impl_analyse.go
@@ -411,8 +411,12 @@ func analyseGrantOrRevoke(toOrFrom DefQName, grant *GrantOrRevoke, c *iterateCtx
 		}
 		for _, i := range grant.Table.Items {
 			for _, column := range i.Columns {
-				if err := checkColumn(column.Value); err != nil {
-					c.stmtErr(&column.Pos, err)
+				if column.Name != nil {
+					if err := checkColumn(column.Name.Value); err != nil {
+						c.stmtErr(&column.Pos, err)
+					}
+				} else {
+					grant.columns = append(grant.columns, column.SysName)
 				}
 			}
 		}

--- a/pkg/parser/impl_test.go
+++ b/pkg/parser/impl_test.go
@@ -598,9 +598,7 @@ func Test_Workspaces(t *testing.T) {
 		w := def.Workspace(appdef.NewQName("pkg", "W"))
 		require.NotNil(w)
 		actualAncestors := []appdef.IWorkspace{}
-		for _, a := range w.Ancestors() {
-			actualAncestors = append(actualAncestors, a)
-		}
+		actualAncestors = append(actualAncestors, w.Ancestors()...)
 		require.Len(actualAncestors, 2)
 	})
 }

--- a/pkg/parser/sql_example_app/pmain/package.vsql
+++ b/pkg/parser/sql_example_app/pmain/package.vsql
@@ -298,7 +298,7 @@ WORKSPACE MyWorkspace INHERITS air.AirAWorkspace (
     GRANT EXECUTE ON COMMAND NewOrder TO LocationUser;
     GRANT EXECUTE ON QUERY Query1 TO LocationUser;
     GRANT SELECT ON TABLE untill.Prices TO LocationUser;
-    GRANT SELECT(Price) ON TABLE untill.Prices TO LocationUser;
+    GRANT SELECT(Price, sys.ID) ON TABLE untill.Prices TO LocationUser;
     GRANT INSERT(Discount) ON TABLE untill.Promotions TO LocationManager; 
     GRANT SELECT ON VIEW XZReports TO LocationUser;
     GRANT SELECT(Year,XZReportWDocID) ON VIEW XZReports TO LocationUser;

--- a/pkg/parser/types.go
+++ b/pkg/parser/types.go
@@ -644,14 +644,19 @@ type LimitStmt struct {
 
 func (s LimitStmt) GetName() string { return string(s.Name) }
 
+type GrantColumn struct {
+	Pos     lexer.Position
+	SysName string      `parser:"@(('sys' '.' 'ID') | 'sys' '.' 'ParentID' | 'sys' '.' 'IsActive' | 'sys' '.' 'QName' | 'sys' '.' 'Container')"`
+	Name    *Identifier `parser:"| @@"`
+}
 type GrantTableAction struct {
 	Pos        lexer.Position
-	Select     bool         `parser:"(@'SELECT'"`
-	Insert     bool         `parser:"| @'INSERT'"`
-	Update     bool         `parser:"| @'UPDATE'"`
-	Activate   bool         `parser:"| @'ACTIVATE'"`
-	Deactivate bool         `parser:"| @'DEACTIVATE')"`
-	Columns    []Identifier `parser:"( '(' @@ (',' @@)* ')' )?"`
+	Select     bool          `parser:"(@'SELECT'"`
+	Insert     bool          `parser:"| @'INSERT'"`
+	Update     bool          `parser:"| @'UPDATE'"`
+	Activate   bool          `parser:"| @'ACTIVATE'"`
+	Deactivate bool          `parser:"| @'DEACTIVATE')"`
+	Columns    []GrantColumn `parser:"( '(' @@ (',' @@)* ')' )?"`
 }
 
 type GrantAllTablesAction struct {


### PR DESCRIPTION
Resolves #3471 parser: unable to use `sys.*` fields in GRANTS
