### PR TITLE
#3528 fix istructs.ClusterAsRegisterID iota usage

### DIFF
--- a/pkg/istructs/consts.go
+++ b/pkg/istructs/consts.go
@@ -70,9 +70,17 @@ const (
 	// RecordID = RegisterID * RegisterFactor + BaseRecordID
 	RegisterFactor = 5000000000
 
+	// see https://github.com/voedger/voedger/issues/3528
+	doNotUse_ClusterAsRegisterID = 0xFFFF - 1000 + iota
+	doNotUse_ClusterAsCRecordRegisterID
+
+	// do not place here no more consts
+)
+
+const (
 	// ClusterDBSer is used to generate cluster-side IDs
 	// ID = PrimaryDCBaseID + some sequenced number
-	ClusterAsRegisterID = 0xFFFF - 1000 + iota
+	ClusterAsRegisterID = 0xFFFF - 1000 + 1 + iota
 	ClusterAsCRecordRegisterID
 )
 

--- a/pkg/istructs/consts.go
+++ b/pkg/istructs/consts.go
@@ -70,18 +70,9 @@ const (
 	// RecordID = RegisterID * RegisterFactor + BaseRecordID
 	RegisterFactor = 5000000000
 
-	// see https://github.com/voedger/voedger/issues/3528
-	doNotUse_ClusterAsRegisterID = 0xFFFF - 1000 + iota
-	doNotUse_ClusterAsCRecordRegisterID
-
-	// do not place here no more consts
-)
-
-const (
-	// ClusterDBSer is used to generate cluster-side IDs
-	// ID = PrimaryDCBaseID + some sequenced number
-	ClusterAsRegisterID = 0xFFFF - 1000 + 1 + iota
-	ClusterAsCRecordRegisterID
+	// +1 caused by wrong iota usage here before. See https://github.com/voedger/voedger/issues/3528
+	ClusterAsRegisterID        = 0xFFFF - 1000 + 1
+	ClusterAsCRecordRegisterID = 0xFFFF - 1000 + 2
 )
 
 var MinClusterRecordID = NewRecordID(NullRecordID)

--- a/pkg/istructs/consts_test.go
+++ b/pkg/istructs/consts_test.go
@@ -85,6 +85,6 @@ func TestWSID(t *testing.T) {
 }
 
 func TestClusterConsts(t *testing.T) {
-	require.Equal(t, doNotUse_ClusterAsRegisterID, ClusterAsRegisterID)
-	require.Equal(t, doNotUse_ClusterAsCRecordRegisterID, ClusterAsCRecordRegisterID)
+	require.Equal(t, 64536, ClusterAsRegisterID)
+	require.Equal(t, 64537, ClusterAsCRecordRegisterID)
 }

--- a/pkg/istructs/consts_test.go
+++ b/pkg/istructs/consts_test.go
@@ -24,7 +24,7 @@ const (
 	_ = uint16(3 - QNameIDForCorruptedData)
 	_ = uint16(QNameIDPLogOffsetSequence - 4)
 	_ = uint16(4 - QNameIDPLogOffsetSequence)
-	_ = uint16(QNameIDWLogOffsetSequence-5)
+	_ = uint16(QNameIDWLogOffsetSequence - 5)
 	_ = uint16(5 - QNameIDWLogOffsetSequence)
 	_ = uint16(QNameIDCRecordIDSequence - 6)
 	_ = uint16(6 - QNameIDCRecordIDSequence)
@@ -82,4 +82,9 @@ func TestWSID(t *testing.T) {
 	require.Equal(FirstPseudoBaseWSID+MaxPseudoBaseWSID+1, FirstBaseAppWSID)
 	require.Equal(FirstBaseAppWSID+MaxNumAppWorkspaces, FirtReservedWSID)
 	require.Equal(FirtReservedWSID+NumReservedWSID, FirstBaseUserWSID)
+}
+
+func TestClusterConsts(t *testing.T) {
+	require.Equal(t, doNotUse_ClusterAsRegisterID, ClusterAsRegisterID)
+	require.Equal(t, doNotUse_ClusterAsCRecordRegisterID, ClusterAsCRecordRegisterID)
 }


### PR DESCRIPTION
Resolves #3528 fix istructs.ClusterAsRegisterID iota usage
