### PR TITLE
#3590 fix typo in TestSequencer_Start

### DIFF
--- a/pkg/isequencer/isequencer_test.go
+++ b/pkg/isequencer/isequencer_test.go
@@ -204,7 +204,7 @@ func TestISequencer_Start(t *testing.T) {
 
 		seq.Flush()
 
-		<-writeOnFlushOccuredCh
+		<-writeOnFlushOccurredCh
 
 		// failed to start because toBeFlushed is overflowed
 		offset, ok := seq.Start(1, 1)


### PR DESCRIPTION
Resolves #3590 fix typo in TestSequencer_Start
