### PR TITLE
#3607 APIv2: set missing reqmd tags for already imolemented APIv2 funcs

### DIFF
--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -262,6 +262,7 @@ func requestHandlerV2_auth_login(federation federation.IFederation, numsAppsWork
 	}
 }
 
+// [~cmp.router.UsersCreatePathHandler~]
 func requestHandlerV2_create_user(numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces,
 	iTokens itokens.ITokens, federation federation.IFederation) http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {

--- a/pkg/sys/it/impl_cpv2_test.go
+++ b/pkg/sys/it/impl_cpv2_test.go
@@ -365,11 +365,11 @@ func TestErrorsCPv2(t *testing.T) {
 	})
 }
 
-func TestCreateUser(t *testing.T) {
+// [~it.TestUsersCreate~]
+func TestUsersCreate(t *testing.T) {
 	require := require.New(t)
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
-	// ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
 	login := vit.NextName() + "@123.com"
 	pseudoWSID := coreutils.GetPseudoWSID(istructs.NullWSID, login, istructs.CurrentClusterID())
 	appWSID := coreutils.GetAppWSID(pseudoWSID, istructs.DefaultNumAppWorkspaces)
@@ -383,7 +383,7 @@ func TestCreateUser(t *testing.T) {
 	verifiedEmailToken, err := vit.ITokens.IssueToken(istructs.AppQName_sys_registry, 10*time.Minute, &p)
 	require.NoError(err)
 	body := fmt.Sprintf(`{"VerifiedEmailToken": "%s","Password": "123","DisplayName": "%s"}`, verifiedEmailToken, login)
-	vit.POST("api/v2/apps/test1/app1/users", body)
+	vit.POST("api/v2/apps/test1/app1/users", body).Println()
 
 	// try to sign in
 	prn := vit.SignIn(it.Login{Name: login, Pwd: "123", AppQName: istructs.AppQName_test1_app1})


### PR DESCRIPTION
Resolves #3607 APIv2: set missing reqmd tags for already imolemented APIv2 funcs
