### PR TITLE
#3610 Fix /devices result and argsissue 'CPv2: handle `/devices`'#3565 CPv2: handle `/devices`

### DIFF
--- a/pkg/coreutils/random.go
+++ b/pkg/coreutils/random.go
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025-present unTill Software Development Group B.V.
+ * @author Denis Gribanov
+ */
+
+package coreutils
+
+import "crypto/rand"
+
+const base32alphabet = "abcdefghijklmnopqrstuvwxyz234567"
+
+func RandomLowercaseDigits(l int) string {
+	src := make([]byte, l)
+	rand.Read(src)
+	for i := range src {
+		src[i] = base32alphabet[src[i]%32]
+	}
+	return string(src)
+}

--- a/pkg/coreutils/random.go
+++ b/pkg/coreutils/random.go
@@ -11,9 +11,13 @@ const base32alphabet = "abcdefghijklmnopqrstuvwxyz234567"
 
 func RandomLowercaseDigits(l int) string {
 	src := make([]byte, l)
-	rand.Read(src)
+	_, err := rand.Read(src)
+	if err != nil {
+		// notest
+		panic(err)
+	}
 	for i := range src {
-		src[i] = base32alphabet[src[i]%32]
+		src[i] = base32alphabet[int(src[i])%len(base32alphabet)]
 	}
 	return string(src)
 }

--- a/pkg/coreutils/random_test.go
+++ b/pkg/coreutils/random_test.go
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025-present unTill Software Development Group B.V.
+ * @author Denis Gribanov
+ */
+
+package coreutils
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandomLowercaseDigits_BasicUsage(t *testing.T) {
+	log.Println(RandomLowercaseDigits(26))
+	require.Len(t, RandomLowercaseDigits(26), 26)
+	require.Empty(t, RandomLowercaseDigits(0))
+	require.NotEqual(t, RandomLowercaseDigits(26), RandomLowercaseDigits((26)))
+}

--- a/pkg/router/consts.go
+++ b/pkg/router/consts.go
@@ -35,6 +35,7 @@ const (
 	URLPlaceholder_role             = "role"
 	hours24                         = 24 * time.Hour
 	DefaultRetryAfterSecondsOn503   = 1
+	deviceLoginAndPasswordLen       = 26
 )
 
 var (

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -279,8 +279,8 @@ func requestHandlerV2_create_device(numsAppsWorkspaces map[appdef.AppQName]istru
 			ReplyCommonError(rw, "unexpected body", http.StatusBadRequest)
 			return
 		}
-		login := "device" + coreutils.RandomLowercaseDigits(26)
-		pwd := coreutils.RandomLowercaseDigits(26)
+		login := "device" + coreutils.RandomLowercaseDigits(deviceLoginAndPasswordLen)
+		pwd := coreutils.RandomLowercaseDigits(deviceLoginAndPasswordLen)
 		pseudoWSID := coreutils.GetPseudoWSID(istructs.NullWSID, login, istructs.CurrentClusterID())
 		url := fmt.Sprintf("api/v2/apps/sys/registry/workspaces/%d/commands/registry.CreateLogin", pseudoWSID)
 		body := fmt.Sprintf(`{"args":{"Login":"%s","AppName":"%s","SubjectKind":%d,"WSKindInitializationData":"{}","ProfileCluster":%d},"unloggedArgs":{"Password":"%s"}}`,

--- a/pkg/sys/it/impl_signupin_test.go
+++ b/pkg/sys/it/impl_signupin_test.go
@@ -228,7 +228,7 @@ func TestCreateDevice(t *testing.T) {
 		require.NotEqual(devicePrn.Token, resp.SectionRow()[0].(string))
 	})
 
-	t.Run("400 bad request on an enexpected body", func(t *testing.T) {
+	t.Run("400 bad request on an unexpected body", func(t *testing.T) {
 		vit.Func(fmt.Sprintf("api/v2/apps/%s/%s/devices", deviceLogin.AppQName.Owner(), deviceLogin.AppQName.Name()), "body",
 			coreutils.Expect400()).Println()
 	})

--- a/pkg/sys/it/impl_signupin_test.go
+++ b/pkg/sys/it/impl_signupin_test.go
@@ -6,6 +6,7 @@ package sys_it
 
 import (
 	"fmt"
+	"log"
 	"testing"
 	"time"
 
@@ -200,8 +201,12 @@ func TestCreateDevice(t *testing.T) {
 	require := require.New(t)
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
-	loginName := vit.NextName()
-	deviceLogin := vit.SignUpDevice(loginName, "123", istructs.AppQName_test1_app2)
+	deviceLogin := vit.SignUpDevice(istructs.AppQName_test1_app2)
+
+	// APIv2 create device returns generated device login and password
+	log.Println(deviceLogin.Name)
+	log.Println(deviceLogin.Pwd)
+
 	devicePrn := vit.SignIn(deviceLogin)
 	as, err := vit.BuiltIn(istructs.AppQName_test1_app2)
 	require.NoError(err)
@@ -223,30 +228,9 @@ func TestCreateDevice(t *testing.T) {
 		require.NotEqual(devicePrn.Token, resp.SectionRow()[0].(string))
 	})
 
-	t.Run("errors", func(t *testing.T) {
-		t.Run("409 on device login already exists", func(t *testing.T) {
-			body := fmt.Sprintf(`{"Login": "%s","Password": "%s"}`, loginName, deviceLogin.Pwd)
-			vit.Func(fmt.Sprintf("api/v2/apps/%s/%s/devices", deviceLogin.AppQName.Owner(), deviceLogin.AppQName.Name()), body,
-				coreutils.Expect409("login already exists"))
-		})
-
-		t.Run("wrong args", func(t *testing.T) {
-			cases := []string{
-				"",
-				"wrong json",
-				`{"Login":"123"}`,
-				`{"Password":"123}`,
-				`{"Login":"123", "Password": 42}`,
-				`{"Login":42, "Password": "123"}`,
-			}
-
-			for _, c := range cases {
-				t.Run(c, func(t *testing.T) {
-					vit.Func(fmt.Sprintf("api/v2/apps/%s/%s/devices", deviceLogin.AppQName.Owner(), deviceLogin.AppQName.Name()), c,
-						coreutils.Expect400()).Println()
-				})
-			}
-		})
+	t.Run("400 bad request on an enexpected body", func(t *testing.T) {
+		vit.Func(fmt.Sprintf("api/v2/apps/%s/%s/devices", deviceLogin.AppQName.Owner(), deviceLogin.AppQName.Name()), "body",
+			coreutils.Expect400()).Println()
 	})
 }
 

--- a/pkg/vit/utils.go
+++ b/pkg/vit/utils.go
@@ -93,12 +93,13 @@ func getSignUpOpts(opts []signUpOptFunc) *signUpOpts {
 	return res
 }
 
-func (vit *VIT) SignUpDevice(loginName, pwd string, appQName appdef.AppQName, opts ...signUpOptFunc) Login {
+func (vit *VIT) SignUpDevice(appQName appdef.AppQName, opts ...signUpOptFunc) Login {
 	vit.T.Helper()
 	signUpOpts := getSignUpOpts(opts)
-	deviceLogin := NewLogin(loginName, pwd, appQName, istructs.SubjectKind_Device, signUpOpts.profileClusterID)
-	body := fmt.Sprintf(`{"Login": "%s","Password": "%s"}`, loginName, pwd)
-	vit.Func(fmt.Sprintf("api/v2/apps/%s/%s/devices", deviceLogin.AppQName.Owner(), deviceLogin.AppQName.Name()), body, signUpOpts.reqOpts...)
+	resp := vit.Func(fmt.Sprintf("api/v2/apps/%s/%s/devices", appQName.Owner(), appQName.Name()), "", signUpOpts.reqOpts...)
+	m := map[string]interface{}{}
+	require.NoError(vit.T, json.Unmarshal([]byte(resp.Body), &m))
+	deviceLogin := NewLogin(m["Login"].(string), m["Password"].(string), appQName, istructs.SubjectKind_Device, signUpOpts.profileClusterID)
 	return deviceLogin
 }
 


### PR DESCRIPTION
Resolves #3610 Fix /devices result and argsResolves issue 'CPv2: handle `/devices`'Resolves #3565 CPv2: handle `/devices`
