### PR TITLE
#3623 /auth: relocate handling from router to QPv2 + eliminate retries on query from QP

### DIFF
--- a/pkg/coreutils/federation/impl.go
+++ b/pkg/coreutils/federation/impl.go
@@ -333,3 +333,8 @@ func (f *implIFederation) N10NSubscribe(projectionKey in10n.ProjectionKey) (offs
 	}
 	return
 }
+
+func (f *implIFederationForQP) QueryNoRetry(relativeURL string, optFuncs ...coreutils.ReqOptFunc) (*coreutils.FuncResponse, error) {
+	optFuncs = append(optFuncs, coreutils.WithSkipRetryOn503())
+	return f.fed.Query(relativeURL, optFuncs...)
+}

--- a/pkg/coreutils/federation/interface.go
+++ b/pkg/coreutils/federation/interface.go
@@ -28,3 +28,8 @@ type IFederation interface {
 	N10NSubscribe(projectionKey in10n.ProjectionKey) (offsetsChan OffsetsChan, unsubscribe func(), err error)
 	AdminFunc(relativeURL string, body string, optFuncs ...coreutils.ReqOptFunc) (*coreutils.FuncResponse, error)
 }
+
+type IFederationForQP interface {
+	// unlike IFederation.Query does not retry on 503 to avoid QPs depleetion
+	QueryNoRetry(relativeURL string, optFuncs ...coreutils.ReqOptFunc) (*coreutils.FuncResponse, error)
+}

--- a/pkg/coreutils/federation/interface.go
+++ b/pkg/coreutils/federation/interface.go
@@ -29,6 +29,9 @@ type IFederation interface {
 	AdminFunc(relativeURL string, body string, optFuncs ...coreutils.ReqOptFunc) (*coreutils.FuncResponse, error)
 }
 
+// IFederationForQP is a specialized interface for query processing (QP) scenarios.
+// Unlike IFederation, it provides a QueryNoRetry method that does not retry on HTTP 503 errors.
+// This behavior is designed to prevent the depletion of query processing resources.
 type IFederationForQP interface {
 	// unlike IFederation.Query does not retry on 503 to avoid QPs depleetion
 	QueryNoRetry(relativeURL string, optFuncs ...coreutils.ReqOptFunc) (*coreutils.FuncResponse, error)

--- a/pkg/coreutils/federation/provide.go
+++ b/pkg/coreutils/federation/provide.go
@@ -20,3 +20,9 @@ func New(federationURL func() *url.URL, adminPortGetter func() int) (federation 
 	}
 	return fed, cln
 }
+
+func NewForQP(federation IFederation) IFederationForQP {
+	return &implIFederationForQP{
+		fed: federation,
+	}
+}

--- a/pkg/coreutils/federation/types.go
+++ b/pkg/coreutils/federation/types.go
@@ -18,4 +18,8 @@ type implIFederation struct {
 	adminPortGetter func() int
 }
 
+type implIFederationForQP struct {
+	fed IFederation
+}
+
 type OffsetsChan chan istructs.Offset

--- a/pkg/processors/query2/impl_auth_login_handler.go
+++ b/pkg/processors/query2/impl_auth_login_handler.go
@@ -37,7 +37,7 @@ func authLoginHandler() apiPathHandler {
 			url := fmt.Sprintf(`api/v2/apps/%s/%s/workspaces/%d/queries/registry.IssuePrincipalToken?arg=%s`,
 				istructs.SysOwner, istructs.AppQName_sys_registry.Name(), pseudoWSID,
 				url.QueryEscape(fmt.Sprintf(`{"Login":"%s", "Password":"%s", "AppName": "%s"}`, login, password, qw.msg.AppQName())))
-			resp, err := qw.federation.Query(url)
+			resp, err := qw.federation.QueryNoRetry(url)
 			if err != nil {
 				return err
 			}

--- a/pkg/processors/query2/impl_auth_login_handler.go
+++ b/pkg/processors/query2/impl_auth_login_handler.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025-present unTill Software Development Group B.V.
+ * @author Michael Saigachenko
+ */
+package query2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/voedger/voedger/pkg/bus"
+	"github.com/voedger/voedger/pkg/coreutils"
+	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/sys/authnz"
+)
+
+// [~server.apiv2.auth/cmp.authLoginHandler~impl]
+func authLoginHandler() apiPathHandler {
+	return apiPathHandler{
+		exec: func(ctx context.Context, qw *queryWork) (err error) {
+
+			args := coreutils.MapObject(qw.msg.QueryParams().Argument)
+			login, _, err := args.AsString("Login")
+			if err != nil {
+				return coreutils.NewHTTPError(http.StatusBadRequest, err)
+			}
+			password, _, err := args.AsString("Password")
+			if err != nil {
+				return coreutils.NewHTTPError(http.StatusBadRequest, err)
+			}
+
+			pseudoWSID := coreutils.GetPseudoWSID(istructs.NullWSID, login, istructs.CurrentClusterID())
+
+			url := fmt.Sprintf(`api/v2/apps/%s/%s/workspaces/%d/queries/registry.IssuePrincipalToken?arg=%s`,
+				istructs.SysOwner, istructs.AppQName_sys_registry.Name(), pseudoWSID,
+				url.QueryEscape(fmt.Sprintf(`{"Login":"%s", "Password":"%s", "AppName": "%s"}`, login, password, qw.msg.AppQName())))
+			resp, err := qw.federation.Query(url)
+			if err != nil {
+				return err
+			}
+			if resp.IsEmpty() {
+				return errors.New("sys.IssuePrincipalToken response is empty")
+			}
+			token := resp.QPv2Response.Result()["PrincipalToken"].(string)
+			wsError := resp.QPv2Response.Result()["WSError"].(string)
+			wsid := resp.QPv2Response.Result()["WSID"].(float64)
+
+			if len(wsError) > 0 {
+				return errors.New("the login profile is created with an error: " + wsError)
+			}
+
+			expiresIn := authnz.DefaultPrincipalTokenExpiration.Seconds()
+			json := fmt.Sprintf(`{
+				"PrincipalToken": "%s",
+				"ExpiresIn": %d,
+				"WSID": %d
+			}`, token, int(expiresIn), int(wsid))
+			return qw.msg.Responder().Respond(bus.ResponseMeta{ContentType: coreutils.ContentType_ApplicationJSON, StatusCode: http.StatusOK}, json)
+		},
+	}
+}

--- a/pkg/processors/query2/impl_auth_refresh_handler.go
+++ b/pkg/processors/query2/impl_auth_refresh_handler.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025-present unTill Software Development Group B.V.
+ * @author Michael Saigachenko
+ */
+package query2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/voedger/voedger/pkg/bus"
+	"github.com/voedger/voedger/pkg/coreutils"
+	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
+)
+
+// [~server.apiv2.auth/cmp.authRefreshHandler~impl]
+func authRefreshHandler() apiPathHandler {
+	return apiPathHandler{
+		exec: func(ctx context.Context, qw *queryWork) (err error) {
+			if qw.msg.Token() == "" {
+				return coreutils.NewHTTPErrorf(http.StatusUnauthorized, fmt.Errorf("authorization header is empty"))
+			}
+
+			url := fmt.Sprintf("api/v2/apps/%s/%s/workspaces/%d/queries/sys.RefreshPrincipalToken", qw.msg.AppQName().Owner(), qw.msg.AppQName().Name(),
+				qw.principalPayload.ProfileWSID)
+			resp, err := qw.federation.Query(url, coreutils.WithAuthorizeBy(qw.msg.Token()))
+			if err != nil {
+				return err
+			}
+
+			if resp.IsEmpty() {
+				return coreutils.NewHTTPErrorf(http.StatusInternalServerError, "sys.RefreshPrincipalToken response is empty")
+			}
+
+			newToken := resp.QPv2Response.Result()["NewPrincipalToken"].(string)
+			if len(newToken) == 0 {
+				return coreutils.NewHTTPErrorf(http.StatusInternalServerError, "sys.RefreshPrincipalToken response contains empty token")
+			}
+
+			payload := payloads.PrincipalPayload{}
+			gp, err := qw.appStructs.AppTokens().ValidateToken(newToken, &payload)
+			if err != nil {
+				return err
+			}
+			expiresIn := gp.Duration.Seconds()
+			json := fmt.Sprintf(`{"PrincipalToken": "%s", "ExpiresIn": %d, "WSID": %d}`, newToken, int(expiresIn), qw.principalPayload.ProfileWSID)
+			return qw.msg.Responder().Respond(bus.ResponseMeta{ContentType: coreutils.ContentType_ApplicationJSON, StatusCode: http.StatusOK}, json)
+
+		},
+	}
+}

--- a/pkg/processors/query2/impl_auth_refresh_handler.go
+++ b/pkg/processors/query2/impl_auth_refresh_handler.go
@@ -24,7 +24,7 @@ func authRefreshHandler() apiPathHandler {
 
 			url := fmt.Sprintf("api/v2/apps/%s/%s/workspaces/%d/queries/sys.RefreshPrincipalToken", qw.msg.AppQName().Owner(), qw.msg.AppQName().Name(),
 				qw.principalPayload.ProfileWSID)
-			resp, err := qw.federation.Query(url, coreutils.WithAuthorizeBy(qw.msg.Token()))
+			resp, err := qw.federation.QueryNoRetry(url, coreutils.WithAuthorizeBy(qw.msg.Token()))
 			if err != nil {
 				return err
 			}

--- a/pkg/processors/query2/interface.go
+++ b/pkg/processors/query2/interface.go
@@ -18,6 +18,7 @@ import (
 
 type ServiceFactory func(serviceChannel iprocbus.ServiceChannel,
 	appParts appparts.IAppPartitions, maxPrepareQueries int, metrics imetrics.IMetrics, vvm string,
-	authn iauthnz.IAuthenticator, itokens itokens.ITokens, federationForQP federation.IFederationForQP,
-	federationForState federation.IFederation, statelessResources istructsmem.IStatelessResources,
-	secretReader isecrets.ISecretReader) pipeline.IService
+	authn iauthnz.IAuthenticator, itokens itokens.ITokens, 
+	federationForQP federation.IFederationForQP, // Federation interface for query processing
+	federationForState federation.IFederation,   // Federation interface for state management
+	statelessResources istructsmem.IStatelessResources, secretReader isecrets.ISecretReader) pipeline.IService

--- a/pkg/processors/query2/interface.go
+++ b/pkg/processors/query2/interface.go
@@ -18,5 +18,6 @@ import (
 
 type ServiceFactory func(serviceChannel iprocbus.ServiceChannel,
 	appParts appparts.IAppPartitions, maxPrepareQueries int, metrics imetrics.IMetrics, vvm string,
-	authn iauthnz.IAuthenticator, itokens itokens.ITokens, federation federation.IFederation,
-	statelessResources istructsmem.IStatelessResources, secretReader isecrets.ISecretReader) pipeline.IService
+	authn iauthnz.IAuthenticator, itokens itokens.ITokens, federationForQP federation.IFederationForQP,
+	federationForState federation.IFederation, statelessResources istructsmem.IStatelessResources,
+	secretReader isecrets.ISecretReader) pipeline.IService

--- a/pkg/processors/query2/util.go
+++ b/pkg/processors/query2/util.go
@@ -80,7 +80,7 @@ type queryWork struct {
 	callbackFunc         istructs.ExecQueryCallback
 	responseWriterGetter func() bus.IResponseWriter
 	apiPathHandler       apiPathHandler
-	federation           federation.IFederation
+	federation           federation.IFederationForQP
 }
 
 var _ pipeline.IWorkpiece = (*queryWork)(nil) // ensure that queryWork implements pipeline.IWorkpiece
@@ -103,7 +103,7 @@ func (qw *queryWork) borrow() (err error) {
 }
 
 func newQueryWork(msg IQueryMessage, appParts appparts.IAppPartitions,
-	maxPrepareQueries int, metrics *queryProcessorMetrics, secretReader isecrets.ISecretReader, federation federation.IFederation) *queryWork {
+	maxPrepareQueries int, metrics *queryProcessorMetrics, secretReader isecrets.ISecretReader, federation federation.IFederationForQP) *queryWork {
 	return &queryWork{
 		msg:                msg,
 		appParts:           appParts,

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 
 	"github.com/gorilla/mux"
@@ -25,7 +24,6 @@ import (
 	"github.com/voedger/voedger/pkg/itokens"
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
 	"github.com/voedger/voedger/pkg/processors"
-	"github.com/voedger/voedger/pkg/sys/authnz"
 )
 
 func (s *httpService) registerHandlersV2() {
@@ -100,14 +98,14 @@ func (s *httpService) registerHandlersV2() {
 	// [~server.apiv2.auth/cmp.routerLoginPathHandler~impl]
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/auth/login",
 		URLPlaceholder_appOwner, URLPlaceholder_appName),
-		corsHandler(requestHandlerV2_auth_login(s.federation, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_auth_login(s.requestSender, s.numsAppsWorkspaces))).
 		Methods(http.MethodPost).Name("auth login")
 
 	// auth/login: /api/v2/apps/{owner}/{app}/auth/login
 	// [~server.apiv2.auth/cmp.routerRefreshHandler~impl]
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/auth/refresh",
 		URLPlaceholder_appOwner, URLPlaceholder_appName),
-		corsHandler(requestHandlerV2_auth_refresh(s.iTokens, s.federation, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_auth_refresh(s.requestSender, s.numsAppsWorkspaces))).
 		Methods(http.MethodPost).Name("auth refresh")
 
 	// create user /api/v2/apps/{owner}/{app}/users
@@ -115,12 +113,6 @@ func (s *httpService) registerHandlersV2() {
 		URLPlaceholder_appOwner, URLPlaceholder_appName),
 		corsHandler(requestHandlerV2_create_user(s.numsAppsWorkspaces, s.iTokens, s.federation))).
 		Methods(http.MethodPost).Name("create user")
-
-	// create device /api/v2/apps/{owner}/{app}/devices
-	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/devices",
-		URLPlaceholder_appOwner, URLPlaceholder_appName),
-		corsHandler(requestHandlerV2_create_device(s.numsAppsWorkspaces, s.federation))).
-		Methods(http.MethodPost).Name("create device")
 }
 
 func requestHandlerV2_schemas(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
@@ -149,152 +141,6 @@ func requestHandlerV2_schemas_wsRoles(reqSender bus.IRequestSender, numsAppsWork
 	}
 }
 
-// [~server.apiv2.auth/cmp.provideAuthRefreshHandler~impl]
-func requestHandlerV2_auth_refresh(iTokens itokens.ITokens, federation federation.IFederation,
-	numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
-	return func(rw http.ResponseWriter, req *http.Request) {
-		busRequest, ok := createBusRequest(req.Method, req, rw, numsAppsWorkspaces)
-		if !ok {
-			return
-		}
-		body := map[string]interface{}{}
-		if len(busRequest.Body) > 0 {
-			if err := json.Unmarshal(busRequest.Body, &body); err != nil {
-				ReplyCommonError(rw, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-		token, err := bus.GetPrincipalToken(busRequest)
-		if err != nil {
-			ReplyCommonError(rw, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if len(token) == 0 {
-			ReplyCommonError(rw, "authorization header is empty", http.StatusUnauthorized)
-			return
-		}
-
-		var principalPayload payloads.PrincipalPayload
-		if _, err = iTokens.ValidateToken(token, &principalPayload); err != nil {
-			ReplyCommonError(rw, err.Error(), http.StatusUnauthorized)
-			return
-		}
-
-		url := fmt.Sprintf("api/v2/apps/%s/%s/workspaces/%d/queries/sys.RefreshPrincipalToken", busRequest.AppQName.Owner(), busRequest.AppQName.Name(),
-			principalPayload.ProfileWSID)
-		resp, err := federation.Query(url, coreutils.WithAuthorizeBy(token))
-		if err != nil {
-			replyErr(rw, err)
-			return
-		}
-
-		if resp.IsEmpty() {
-			ReplyCommonError(rw, "sys.RefreshPrincipalToken response is empty", http.StatusInternalServerError)
-			return
-		}
-
-		newToken := resp.QPv2Response.Result()["NewPrincipalToken"].(string)
-		if len(newToken) == 0 {
-			ReplyCommonError(rw, "sys.RefreshPrincipalToken response contains empty token", http.StatusInternalServerError)
-			return
-		}
-
-		payload := payloads.PrincipalPayload{}
-		gp, err := iTokens.ValidateToken(newToken, &payload)
-		if err != nil {
-			ReplyCommonError(rw, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		expiresIn := gp.Duration.Seconds()
-		json := fmt.Sprintf(`{"PrincipalToken": "%s", "ExpiresIn": %d, "WSID": %d}`, newToken, int(expiresIn), principalPayload.ProfileWSID)
-		ReplyJSON(rw, json, http.StatusOK)
-	}
-}
-
-// [~server.apiv2.auth/cmp.provideAuthLoginHandler~impl]
-// wrong to handle it by QPv2 because 10 simultaneous calls of aut/login -> each would be fail to call registry.IssuePrincipalToken
-func requestHandlerV2_auth_login(federation federation.IFederation, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
-	return func(rw http.ResponseWriter, req *http.Request) {
-		busRequest, ok := createBusRequest(req.Method, req, rw, numsAppsWorkspaces)
-		if !ok {
-			return
-		}
-
-		body := map[string]interface{}{}
-		if len(busRequest.Body) > 0 {
-			if err := json.Unmarshal(busRequest.Body, &body); err != nil {
-				ReplyCommonError(rw, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-
-		args := coreutils.MapObject(body)
-		login, _, err := args.AsString("Login")
-		if err != nil {
-			ReplyCommonError(rw, err.Error(), http.StatusBadRequest)
-			return
-		}
-		password, _, err := args.AsString("Password")
-		if err != nil {
-			ReplyCommonError(rw, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		pseudoWSID := coreutils.GetPseudoWSID(istructs.NullWSID, login, istructs.CurrentClusterID())
-
-		url := fmt.Sprintf(`api/v2/apps/%s/%s/workspaces/%d/queries/registry.IssuePrincipalToken?arg=%s`,
-			istructs.SysOwner, istructs.AppQName_sys_registry.Name(), pseudoWSID,
-			url.QueryEscape(fmt.Sprintf(`{"Login":"%s", "Password":"%s", "AppName": "%s"}`, login, password, busRequest.AppQName)))
-		resp, err := federation.Query(url)
-		if err != nil {
-			replyErr(rw, err)
-			return
-		}
-		if resp.IsEmpty() {
-			ReplyCommonError(rw, "registry.IssuePrincipalToken response is empty", http.StatusInternalServerError)
-			return
-		}
-		token := resp.QPv2Response.Result()["PrincipalToken"].(string)
-		wsError := resp.QPv2Response.Result()["WSError"].(string)
-		wsid := resp.QPv2Response.Result()["WSID"].(float64)
-
-		if len(wsError) > 0 {
-			ReplyCommonError(rw, "the login profile is created with an error: "+wsError, http.StatusInternalServerError)
-		}
-
-		expiresIn := authnz.DefaultPrincipalTokenExpiration.Seconds()
-		json := fmt.Sprintf(`{"PrincipalToken": "%s","ExpiresIn": %d,"WSID": %d}`, token, int(expiresIn), int(wsid))
-		ReplyJSON(rw, json, http.StatusOK)
-	}
-}
-
-// [~cmp.routerDevicesCreatePathHandler~]
-func requestHandlerV2_create_device(numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces, federation federation.IFederation) http.HandlerFunc {
-	return func(rw http.ResponseWriter, req *http.Request) {
-		busRequest, ok := createBusRequest(req.Method, req, rw, numsAppsWorkspaces)
-		if !ok {
-			return
-		}
-		if len(busRequest.Body) > 0 {
-			ReplyCommonError(rw, "unexpected body", http.StatusBadRequest)
-			return
-		}
-		login, pwd := coreutils.DeviceRandomLoginPwd()
-		pseudoWSID := coreutils.GetPseudoWSID(istructs.NullWSID, login, istructs.CurrentClusterID())
-		url := fmt.Sprintf("api/v2/apps/sys/registry/workspaces/%d/commands/registry.CreateLogin", pseudoWSID)
-		body := fmt.Sprintf(`{"args":{"Login":"%s","AppName":"%s","SubjectKind":%d,"WSKindInitializationData":"{}","ProfileCluster":%d},"unloggedArgs":{"Password":"%s"}}`,
-			login, busRequest.AppQName, istructs.SubjectKind_Device, istructs.CurrentClusterID(), pwd)
-		_, err := federation.Func(url, body, coreutils.WithMethod(http.MethodPost))
-		if err != nil {
-			replyErr(rw, err)
-			return
-		}
-		result := fmt.Sprintf(`{"Login":"%s","Password":"%s"}`, login, pwd)
-		ReplyJSON(rw, result, http.StatusCreated)
-	}
-}
-
-// [~cmp.router.UsersCreatePathHandler~]
 func requestHandlerV2_create_user(numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces,
 	iTokens itokens.ITokens, federation federation.IFederation) http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
@@ -336,43 +182,34 @@ func requestHandlerV2_create_user(numsAppsWorkspaces map[appdef.AppQName]istruct
 	}
 }
 
-func replyErr(rw http.ResponseWriter, err error) {
-	var funcErr coreutils.FuncError
-	if errors.As(err, &funcErr) {
-		ReplyJSON(rw, funcErr.ToJSON_APIV2(), funcErr.HTTPStatus)
-	} else {
-		ReplyCommonError(rw, err.Error(), funcErr.HTTPStatus)
+func requestHandlerV2_auth_refresh(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		busRequest, ok := createBusRequest(req.Method, req, rw, numsAppsWorkspaces)
+		if !ok {
+			return
+		}
+		busRequest.IsAPIV2 = true
+		busRequest.APIPath = int(processors.APIPath_Auth_Refresh)
+		busRequest.Method = http.MethodGet
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw)
 	}
 }
 
-func parseCreateLoginArgs(body string) (verifiedEmailToken, displayName, pwd string, err error) {
-	args := coreutils.MapObject{}
-	if err = json.Unmarshal([]byte(body), &args); err != nil {
-		return "", "", "", fmt.Errorf("failed to unmarshal body: %w:\n%s", err, body)
+func requestHandlerV2_auth_login(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		busRequest, ok := createBusRequest(req.Method, req, rw, numsAppsWorkspaces)
+		if !ok {
+			return
+		}
+
+		busRequest.IsAPIV2 = true
+		busRequest.APIPath = int(processors.APIPath_Auth_Login)
+		busRequest.Method = http.MethodGet
+		queryParams := map[string]string{}
+		queryParams["arg"] = string(busRequest.Body)
+		busRequest.Query = queryParams
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw)
 	}
-	ok := false
-	verifiedEmailToken, ok, err = args.AsString("VerifiedEmailToken")
-	if err != nil {
-		return "", "", "", err
-	}
-	if !ok {
-		return "", "", "", errors.New("VerifiedEmailToken field missing") // nolint ST1005
-	}
-	displayName, ok, err = args.AsString("DisplayName")
-	if err != nil {
-		return "", "", "", err
-	}
-	if !ok {
-		return "", "", "", errors.New("DisplayName field missing") // nolint ST1005
-	}
-	pwd, ok, err = args.AsString("Password")
-	if err != nil {
-		return "", "", "", err
-	}
-	if !ok {
-		return "", "", "", errors.New("Password field missing") // nolint ST1005
-	}
-	return
 }
 
 func requestHandlerV2_schemas_wsRole(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
@@ -501,4 +338,43 @@ func sendRequestAndReadResponse(req *http.Request, busRequest bus.Request, reqSe
 
 	initResponse(rw, respMeta.ContentType, respMeta.StatusCode)
 	reply_v2(requestCtx, rw, respCh, respErr, cancel, respMeta.Mode())
+}
+
+func parseCreateLoginArgs(body string) (verifiedEmailToken, displayName, pwd string, err error) {
+	args := coreutils.MapObject{}
+	if err = json.Unmarshal([]byte(body), &args); err != nil {
+		return "", "", "", fmt.Errorf("failed to unmarshal body: %w:\n%s", err, body)
+	}
+	ok := false
+	verifiedEmailToken, ok, err = args.AsString("VerifiedEmailToken")
+	if err != nil {
+		return "", "", "", err
+	}
+	if !ok {
+		return "", "", "", errors.New("VerifiedEmailToken field missing")
+	}
+	displayName, ok, err = args.AsString("DisplayName")
+	if err != nil {
+		return "", "", "", err
+	}
+	if !ok {
+		return "", "", "", errors.New("displayName field missing")
+	}
+	pwd, ok, err = args.AsString("Password")
+	if err != nil {
+		return "", "", "", err
+	}
+	if !ok {
+		return "", "", "", errors.New("password field missing")
+	}
+	return
+}
+
+func replyErr(rw http.ResponseWriter, err error) {
+	var funcErr coreutils.FuncError
+	if errors.As(err, &funcErr) {
+		ReplyJSON(rw, funcErr.ToJSON_APIV2(), funcErr.HTTPStatus)
+	} else {
+		ReplyCommonError(rw, err.Error(), funcErr.HTTPStatus)
+	}
 }

--- a/pkg/vvm/provide.go
+++ b/pkg/vvm/provide.go
@@ -224,6 +224,7 @@ func wireVVM(vvmCtx context.Context, vvmConfig *VVMConfig) (*VVM, func(), error)
 		blobprocessor.NewIRequestHandler,
 		provideIVVMAppTTLStorage,
 		storage.NewElectionsTTLStorage,
+		federation.NewForQP,
 		// wire.Value(vvmConfig.NumCommandProcessors) -> (wire bug?) value github.com/untillpro/airs-bp3/vvm.CommandProcessorsCount can't be used: vvmConfig is not declared in package scope
 		wire.FieldsOf(&vvmConfig,
 			"NumCommandProcessors",
@@ -809,11 +810,11 @@ func provideQueryProcessors_V1(qpCount istructs.NumQueryProcessors, qc QueryChan
 
 func provideQueryProcessors_V2(qpCount istructs.NumQueryProcessors, qc QueryChannel_V2, appParts appparts.IAppPartitions, qpFactory query2.ServiceFactory,
 	imetrics imetrics.IMetrics, vvm processors.VVMName, mpq MaxPrepareQueriesType, authn iauthnz.IAuthenticator,
-	tokens itokens.ITokens, federation federation.IFederation, statelessResources istructsmem.IStatelessResources, secretReader isecrets.ISecretReader) OperatorQueryProcessors_V2 {
+	tokens itokens.ITokens, federation federation.IFederationForQP, federationForState federation.IFederation, statelessResources istructsmem.IStatelessResources, secretReader isecrets.ISecretReader) OperatorQueryProcessors_V2 {
 	forks := make([]pipeline.ForkOperatorOptionFunc, qpCount)
 	for i := 0; i < int(qpCount); i++ {
 		forks[i] = pipeline.ForkBranch(pipeline.ServiceOperator(qpFactory(iprocbus.ServiceChannel(qc), appParts, int(mpq), imetrics,
-			string(vvm), authn, tokens, federation, statelessResources, secretReader)))
+			string(vvm), authn, tokens, federation, federationForState, statelessResources, secretReader)))
 	}
 	return pipeline.ForkOperator(pipeline.ForkSame, forks[0], forks[1:]...)
 }

--- a/pkg/vvm/wire_gen.go
+++ b/pkg/vvm/wire_gen.go
@@ -166,7 +166,8 @@ func wireVVM(vvmCtx context.Context, vvmConfig *VVMConfig) (*VVM, func(), error)
 	operatorQueryProcessors_V1 := provideQueryProcessors_V1(numQueryProcessors, queryChannel_V1, iAppPartitions, queryprocessorServiceFactory, iMetrics, vvmName, maxPrepareQueriesType, iAuthenticator, iTokens, iFederation, iStatelessResources, iSecretReader)
 	queryChannel_V2 := provideQueryChannel_V2(serviceChannelFactory)
 	query2ServiceFactory := query2.ProvideServiceFactory()
-	operatorQueryProcessors_V2 := provideQueryProcessors_V2(numQueryProcessors, queryChannel_V2, iAppPartitions, query2ServiceFactory, iMetrics, vvmName, maxPrepareQueriesType, iAuthenticator, iTokens, iFederation, iStatelessResources, iSecretReader)
+	iFederationForQP := federation.NewForQP(iFederation)
+	operatorQueryProcessors_V2 := provideQueryProcessors_V2(numQueryProcessors, queryChannel_V2, iAppPartitions, query2ServiceFactory, iMetrics, vvmName, maxPrepareQueriesType, iAuthenticator, iTokens, iFederationForQP, iFederation, iStatelessResources, iSecretReader)
 	numBLOBProcessors := vvmConfig.NumBLOBProcessors
 	blobServiceChannel := provideBLOBChannel(serviceChannelFactory)
 	blobAppStoragePtr := provideBlobAppStoragePtr(iAppStorageProvider)
@@ -866,10 +867,10 @@ func provideQueryProcessors_V1(qpCount istructs.NumQueryProcessors, qc QueryChan
 
 func provideQueryProcessors_V2(qpCount istructs.NumQueryProcessors, qc QueryChannel_V2, appParts appparts.IAppPartitions, qpFactory query2.ServiceFactory, imetrics2 imetrics.IMetrics,
 	vvm processors.VVMName, mpq MaxPrepareQueriesType, authn iauthnz.IAuthenticator,
-	tokens itokens.ITokens, federation2 federation.IFederation, statelessResources istructsmem.IStatelessResources, secretReader isecrets.ISecretReader) OperatorQueryProcessors_V2 {
+	tokens itokens.ITokens, federation2 federation.IFederationForQP, federationForState federation.IFederation, statelessResources istructsmem.IStatelessResources, secretReader isecrets.ISecretReader) OperatorQueryProcessors_V2 {
 	forks := make([]pipeline.ForkOperatorOptionFunc, qpCount)
 	for i := 0; i < int(qpCount); i++ {
-		forks[i] = pipeline.ForkBranch(pipeline.ServiceOperator(qpFactory(iprocbus.ServiceChannel(qc), appParts, int(mpq), imetrics2, string(vvm), authn, tokens, federation2, statelessResources, secretReader)))
+		forks[i] = pipeline.ForkBranch(pipeline.ServiceOperator(qpFactory(iprocbus.ServiceChannel(qc), appParts, int(mpq), imetrics2, string(vvm), authn, tokens, federation2, federationForState, statelessResources, secretReader)))
 	}
 	return pipeline.ForkOperator(pipeline.ForkSame, forks[0], forks[1:]...)
 }


### PR DESCRIPTION
Resolves #3623 /auth: relocate handling from router to QPv2 + eliminate retries on query from QP
