### PR TITLE
#3644 VIT: force `SequencesTrustLevel_0`

### DIFF
--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/iblobstorage"
+	"github.com/voedger/voedger/pkg/isequencer"
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
@@ -79,6 +80,9 @@ func newVit(t testing.TB, vitCfg *VITConfig, useCas bool, vvmLaunchOnly bool) *V
 	// only dynamic ports are used in tests
 	cfg.VVMPort = 0
 	cfg.MetricsServicePort = 0
+
+	// [~server.design.sequences/tuc.VVMConfig.ConfigureSequencesTrustLevel~impl]
+	cfg.SequencesTrustLevel = isequencer.SequencesTrustLevel_0
 
 	cfg.Time = coreutils.MockTime
 	if !coreutils.IsTest() {

--- a/pkg/vvm/impl_cfg.go
+++ b/pkg/vvm/impl_cfg.go
@@ -56,7 +56,7 @@ func NewVVMDefaultConfig() VVMConfig {
 		IP:            coreutils.LocalhostIP,
 		NumVVM:        1,
 
-		// [~tuc.VVMConfig.ConfigureSequencesTrustLevel~]
+		// [~server.design.sequences/tuc.VVMConfig.ConfigureSequencesTrustLevel~impl]
 		SequencesTrustLevel: isequencer.SequencesTrustLevel_2,
 	}
 	if coreutils.IsTest() {


### PR DESCRIPTION
Resolves #3644 VIT: force `SequencesTrustLevel_0`
