### PR TITLE
#3706 parser: BLOB field can be only added to documents or records

### DIFF
--- a/pkg/cluster/appws.vsql
+++ b/pkg/cluster/appws.vsql
@@ -13,8 +13,8 @@ ALTER WORKSPACE sys.AppWorkspaceWS (
 	TYPE AppDeploymentDescriptor (
 		AppQName varchar NOT NULL,
 		NumPartitions int32 NOT NULL,
-		NumAppWorkspaces int32 NOT NULL,
-		AppImage blob
+		NumAppWorkspaces int32 NOT NULL
+		-- AppImage blob
 	);
 
 	TYPE VSqlUpdateParams (

--- a/pkg/parser/errors.go
+++ b/pkg/parser/errors.go
@@ -44,6 +44,7 @@ var ErrPkgFolderNotFound = errors.New("pkg folder not found")
 var ErrGrantFollowsRevoke = errors.New("GRANT follows REVOKE in the same container")
 var ErrJobMustBeInAppWorkspace = errors.New("JOB is only allowed in AppWorkspaceWS")
 var ErrPositiveValueOnly = errors.New("positive value only allowed")
+var ErrBlobFieldOnlyInTable = errors.New("BLOB field only allowed in table")
 
 func ErrInvalidLocalPackageName(name string) error {
 	return fmt.Errorf("invalid local package name %s", name)

--- a/pkg/parser/impl_test.go
+++ b/pkg/parser/impl_test.go
@@ -3216,3 +3216,34 @@ func TestIsOperationAllowedOnGrantRoleToRole(t *testing.T) {
 	require.NoError(err)
 	require.True(ok)
 }
+
+func Test_NotAllowedTypes(t *testing.T) {
+
+	require := assertions(t)
+
+	t.Run("BLOB in VIEWs not allowed", func(t *testing.T) {
+		require.AppSchemaError(`APPLICATION test();
+			WORKSPACE MyWS (
+				VIEW v1(
+					f1 int32,
+					f2 binary large object,
+					PRIMARY KEY(f1)
+				) AS RESULT OF p;
+
+				EXTENSION ENGINE BUILTIN (
+					PROJECTOR p AFTER EXECUTE ON c INTENTS (sys.View(v1));
+					COMMAND c();
+				);
+			);`, "file.vsql:5:9: BLOB field only allowed in table")
+	})
+
+	t.Run("BLOB in TYPEs not allowed", func(t *testing.T) {
+		require.AppSchemaError(`APPLICATION test();
+			WORKSPACE MyWS (
+				TYPE t1(
+					f1 int32,
+					f2 binary large object
+				);
+			);`, "file.vsql:5:9: BLOB field only allowed in table")
+	})
+}

--- a/pkg/parser/types.go
+++ b/pkg/parser/types.go
@@ -329,6 +329,7 @@ type VoidOrDef struct {
 }
 
 type DataType struct {
+	Pos       lexer.Position
 	Varchar   *TypeVarchar `parser:"( @@"`
 	Bytes     *TypeBytes   `parser:"| @@"`
 	Int8      bool         `parser:"| @('tinyint' | 'int8')"`


### PR DESCRIPTION
Resolves #3706 parser: BLOB field can be only added to documents or records
