### PR TITLE
#3724 fix camelCase in CPv2: must be for APIv2 only

### DIFF
--- a/pkg/coreutils/types.go
+++ b/pkg/coreutils/types.go
@@ -32,11 +32,12 @@ type HTTPResponse struct {
 
 type ReqOptFunc func(opts *reqOpts)
 
+// implements json.Unmarshaler
 type CommandResponse struct {
-	NewIDs            map[string]istructs.RecordID `json:"newIDs"`
-	CurrentWLogOffset istructs.Offset              `json:"currentWLogOffset"`
-	SysError          SysError                     `json:"sys.Error"`
-	CmdResult         map[string]interface{}       `json:"result"`
+	NewIDs            map[string]istructs.RecordID
+	CurrentWLogOffset istructs.Offset
+	SysError          SysError
+	CmdResult         map[string]interface{}
 }
 
 type QPv2Response map[string]interface{}
@@ -49,6 +50,7 @@ func (r QPv2Response) ResultRow(rowNum int) map[string]interface{} {
 	return r["results"].([]interface{})[rowNum].(map[string]interface{})
 }
 
+// implements json.Unmarshaler
 type FuncResponse struct {
 	*HTTPResponse
 	CommandResponse
@@ -128,4 +130,83 @@ type CUD struct {
 type IReadFS interface {
 	fs.ReadDirFS
 	fs.ReadFileFS
+}
+
+// TODO: temporary solution. Eliminate after switching to APIv2
+func (cr *CommandResponse) UnmarshalJSON(data []byte) error {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+
+	if raw, ok := m["NewIDs"]; ok || len(raw) > 0 {
+		if err := json.Unmarshal(raw, &cr.NewIDs); err != nil {
+			return err
+		}
+	} else if raw, ok = m["newIDs"]; ok || len(raw) > 0 {
+		if err := json.Unmarshal(raw, &cr.NewIDs); err != nil {
+			return err
+		}
+	}
+
+	if raw, ok := m["CurrentWLogOffset"]; ok || len(raw) > 0 {
+		if err := json.Unmarshal(raw, &cr.CurrentWLogOffset); err != nil {
+			return err
+		}
+	} else if raw, ok = m["currentWLogOffset"]; ok || len(raw) > 0 {
+		if err := json.Unmarshal(raw, &cr.CurrentWLogOffset); err != nil {
+			return err
+		}
+	}
+
+	if raw, ok := m["sys.Error"]; ok || len(raw) > 0 {
+		if err := json.Unmarshal(raw, &cr.SysError); err != nil {
+			return err
+		}
+	}
+
+	if raw, ok := m["Result"]; ok || len(raw) > 0 {
+		if err := json.Unmarshal(raw, &cr.CmdResult); err != nil {
+			return err
+		}
+	} else if raw, ok = m["result"]; ok || len(raw) > 0 {
+		if err := json.Unmarshal(raw, &cr.CmdResult); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// TODO: temporary solution. Eliminate after switching to APIv2
+func (fr *FuncResponse) UnmarshalJSON(data []byte) error {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+
+	if raw, ok := m["HTTPResponse"]; ok && len(raw) > 0 {
+		if err := json.Unmarshal(raw, &fr.HTTPResponse); err != nil {
+			return err
+		}
+	}
+
+	var commandResp CommandResponse
+	if err := commandResp.UnmarshalJSON(data); err != nil {
+		return err
+	}
+	fr.CommandResponse = commandResp
+
+	if raw, ok := m["sections"]; ok && len(raw) > 0 {
+		if err := json.Unmarshal(raw, &fr.Sections); err != nil {
+			return err
+		}
+	}
+
+	if raw, ok := m["QPv2Response"]; ok && len(raw) > 0 {
+		if err := json.Unmarshal(raw, &fr.QPv2Response); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/processors/command/impl.go
+++ b/pkg/processors/command/impl.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/voedger/voedger/pkg/bus"
@@ -812,9 +813,9 @@ func sendResponse(cmd *cmdWorkpiece, handlingError error) {
 		bus.ReplyErr(cmd.cmdMes.Responder(), handlingError)
 		return
 	}
-	body := bytes.NewBufferString(fmt.Sprintf(`{"currentWLogOffset":%d`, cmd.pLogEvent.WLogOffset()))
+	body := bytes.NewBufferString(fmt.Sprintf(`{"CurrentWLogOffset":%d`, cmd.pLogEvent.WLogOffset()))
 	if len(cmd.idGeneratorReporter.generatedIDs) > 0 {
-		body.WriteString(`,"newIDs":{`)
+		body.WriteString(`,"NewIDs":{`)
 		for rawID, generatedID := range cmd.idGeneratorReporter.generatedIDs {
 			fmt.Fprintf(body, `"%d":%d,`, rawID, generatedID)
 		}
@@ -832,11 +833,31 @@ func sendResponse(cmd *cmdWorkpiece, handlingError error) {
 			logger.Error("failed to marshal response: " + err.Error())
 			return
 		}
-		body.WriteString(`,"result":`)
+		body.WriteString(`,"Result":`)
 		body.Write(cmdResultBytes)
 	}
 	body.WriteString("}")
-	bus.ReplyJSON(cmd.cmdMes.Responder(), cmd.statusCodeOfSuccess, body.String())
+	res := body.String()
+	if cmd.cmdMes.APIPath() !=0 {
+		// TODO: temporary solution. Eliminate after switching to APIv2
+		pascalCasedResMap := map[string]interface{}{}
+		if err := json.Unmarshal([]byte(res), &pascalCasedResMap); err != nil {
+			// notest
+			panic(err)
+		}
+		camelCasedResMap := map[string]interface{}{}
+		for pascalCasedKey, val := range pascalCasedResMap {
+			camelCasedKey := strings.ToLower(pascalCasedKey[:1]) + pascalCasedKey[1:]
+			camelCasedResMap[camelCasedKey] = val
+		}
+		camelCasedResBytes, err := json.Marshal(&camelCasedResMap)
+		if err != nil {
+			// notest
+			panic(err)
+		}
+		res = string(camelCasedResBytes)
+	}
+	bus.ReplyJSON(cmd.cmdMes.Responder(), cmd.statusCodeOfSuccess, res)
 }
 
 func (idGen *implIDGeneratorReporter) NextID(rawID istructs.RecordID) (storageID istructs.RecordID, err error) {

--- a/pkg/processors/command/impl_test.go
+++ b/pkg/processors/command/impl_test.go
@@ -244,10 +244,10 @@ func TestRecoveryOnSyncProjectorError(t *testing.T) {
 
 	// ok to c.sys.CUD
 	respData := sendCUD(t, 1, app)
-	require.Equal(2, int(respData["currentWLogOffset"].(float64))) // 1st is WorkspaceDescriptor stub insert
-	require.Equal(istructs.FirstUserRecordID, istructs.RecordID(respData["newIDs"].(map[string]interface{})["1"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+1, istructs.RecordID(respData["newIDs"].(map[string]interface{})["2"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+2, istructs.RecordID(respData["newIDs"].(map[string]interface{})["3"].(float64)))
+	require.Equal(2, int(respData["CurrentWLogOffset"].(float64))) // 1st is WorkspaceDescriptor stub insert
+	require.Equal(istructs.FirstUserRecordID, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["1"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+1, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["2"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+2, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["3"].(float64)))
 
 	// 2nd c.sys.CUD -> sync projector failure, expect 500 internal server error
 	respData = sendCUD(t, 1, app, http.StatusInternalServerError)
@@ -258,10 +258,10 @@ func TestRecoveryOnSyncProjectorError(t *testing.T) {
 
 	// 3rd c.sys.CUD - > recovery procedure must re-apply 2nd event (PLog, records and WLog), then 3rd event is processed ok (sync projectors are ok)
 	respData = sendCUD(t, 1, app)
-	require.Equal(4, int(respData["currentWLogOffset"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+6, istructs.RecordID(respData["newIDs"].(map[string]interface{})["1"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+7, istructs.RecordID(respData["newIDs"].(map[string]interface{})["2"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+8, istructs.RecordID(respData["newIDs"].(map[string]interface{})["3"].(float64)))
+	require.Equal(4, int(respData["CurrentWLogOffset"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+6, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["1"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+7, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["2"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+8, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["3"].(float64)))
 }
 
 func TestRecovery(t *testing.T) {
@@ -284,31 +284,31 @@ func TestRecovery(t *testing.T) {
 	app.cfg.Resources.Add(cmdCUD)
 
 	respData := sendCUD(t, 1, app)
-	require.Equal(2, int(respData["currentWLogOffset"].(float64)))
-	require.Equal(istructs.FirstUserRecordID, istructs.RecordID(respData["newIDs"].(map[string]interface{})["1"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+1, istructs.RecordID(respData["newIDs"].(map[string]interface{})["2"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+2, istructs.RecordID(respData["newIDs"].(map[string]interface{})["3"].(float64)))
+	require.Equal(2, int(respData["CurrentWLogOffset"].(float64)))
+	require.Equal(istructs.FirstUserRecordID, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["1"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+1, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["2"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+2, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["3"].(float64)))
 
 	restartCmdProc(&app)
 	respData = sendCUD(t, 1, app)
-	require.Equal(3, int(respData["currentWLogOffset"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+3, istructs.RecordID(respData["newIDs"].(map[string]interface{})["1"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+4, istructs.RecordID(respData["newIDs"].(map[string]interface{})["2"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+5, istructs.RecordID(respData["newIDs"].(map[string]interface{})["3"].(float64)))
+	require.Equal(3, int(respData["CurrentWLogOffset"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+3, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["1"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+4, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["2"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+5, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["3"].(float64)))
 
 	restartCmdProc(&app)
 	respData = sendCUD(t, 2, app)
-	require.Equal(2, int(respData["currentWLogOffset"].(float64)))
-	require.Equal(istructs.FirstUserRecordID, istructs.RecordID(respData["newIDs"].(map[string]interface{})["1"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+1, istructs.RecordID(respData["newIDs"].(map[string]interface{})["2"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+2, istructs.RecordID(respData["newIDs"].(map[string]interface{})["3"].(float64)))
+	require.Equal(2, int(respData["CurrentWLogOffset"].(float64)))
+	require.Equal(istructs.FirstUserRecordID, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["1"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+1, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["2"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+2, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["3"].(float64)))
 
 	restartCmdProc(&app)
 	respData = sendCUD(t, 1, app)
-	require.Equal(4, int(respData["currentWLogOffset"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+6, istructs.RecordID(respData["newIDs"].(map[string]interface{})["1"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+7, istructs.RecordID(respData["newIDs"].(map[string]interface{})["2"].(float64)))
-	require.Equal(istructs.FirstUserRecordID+8, istructs.RecordID(respData["newIDs"].(map[string]interface{})["3"].(float64)))
+	require.Equal(4, int(respData["CurrentWLogOffset"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+6, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["1"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+7, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["2"].(float64)))
+	require.Equal(istructs.FirstUserRecordID+8, istructs.RecordID(respData["NewIDs"].(map[string]interface{})["3"].(float64)))
 
 	app.cancel()
 	<-app.done

--- a/pkg/sys/it/impl_cpv2_test.go
+++ b/pkg/sys/it/impl_cpv2_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
+	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/istructs"
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
 	"github.com/voedger/voedger/pkg/registry"
@@ -52,7 +53,8 @@ func TestBasicUsage_CommandProcessorV2_Doc(t *testing.T) {
 		coreutils.WithMethod(http.MethodPost),
 		coreutils.WithAuthorizeBy(ws.Owner.Token),
 	)
-	resp.Println()
+	logger.Error("insert done")
+	// resp.Println()
 	newIDsAfterInsert := newIDs(t, resp)
 	require.Equal(t, http.StatusCreated, resp.HTTPResp.StatusCode)
 

--- a/pkg/sys/it/impl_httpconventions_test.go
+++ b/pkg/sys/it/impl_httpconventions_test.go
@@ -36,9 +36,6 @@ func TestBasicUsage_HTTPConventions(t *testing.T) {
 		require.Equal("world", resp.SectionRow()[0])
 		require.Equal(coreutils.ContentType_ApplicationJSON, resp.HTTPResp.Header["Content-Type"][0])
 		require.Equal(http.StatusOK, resp.HTTPResp.StatusCode)
-		require.Equal(http.StatusInternalServerError, resp.SysError.HTTPStatus)
-		require.Empty(resp.SysError.Data)
-		require.Empty(resp.SysError.QName)
 		resp.Println()
 	})
 


### PR DESCRIPTION
Resolves #3724 fix camelCase in CPv2: must be for APIv2 only
