### PR TITLE
#3750 APIv2 notifications: extract router serve SSE and client-side read SSE routine

### DIFF
--- a/pkg/coreutils/federation/impl.go
+++ b/pkg/coreutils/federation/impl.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/iblobstorage"
 	"github.com/voedger/voedger/pkg/in10n"

--- a/pkg/coreutils/federation/utils.go
+++ b/pkg/coreutils/federation/utils.go
@@ -59,6 +59,7 @@ func ListenSSEEvents(ctx context.Context, body io.Reader) (offsetsChan OffsetsCh
 			} else {
 				offset, err := strconv.ParseUint(data, utils.DecimalBase, utils.BitSize64)
 				if err != nil {
+					// notest
 					panic(fmt.Sprint("failed to parse offset", data, err))
 				}
 				offsetsChan <- istructs.Offset(offset)

--- a/pkg/coreutils/federation/utils.go
+++ b/pkg/coreutils/federation/utils.go
@@ -22,7 +22,7 @@ import (
 )
 
 // launches listening for sse events from body reader in a separate goroutine
-// returns when the first sse packet with channelID is came from the server, i.e. when the subscribing is actualy done
+// returns when the first sse packet with channelID is came from the server, i.e. when the subscribing is actually done
 // if caller side unsubscribes from events, then it must:
 // - read out offsetsChan
 // - call waitForDone() to ensure the goroutine finished

--- a/pkg/router/impl_n10n.go
+++ b/pkg/router/impl_n10n.go
@@ -75,11 +75,11 @@ func (s *httpService) subscribeAndWatchHandler() http.HandlerFunc {
 			}
 		}
 		flusher.Flush()
-		serverSubscriptions(req.Context(), rw, flusher, channel, s.n10n, urlParams.SubjectLogin)
+		serveSubscriptions(req.Context(), rw, flusher, channel, s.n10n, urlParams.SubjectLogin)
 	}
 }
 
-func serverSubscriptions(ctx context.Context, rw http.ResponseWriter, flusher http.Flusher, channel in10n.ChannelID, n10n in10n.IN10nBroker,
+func serveSubscriptions(ctx context.Context, rw http.ResponseWriter, flusher http.Flusher, channel in10n.ChannelID, n10n in10n.IN10nBroker,
 	subjectLogin istructs.SubjectLogin) {
 	ch := make(chan in10nmem.UpdateUnit)
 	watchChannelContext, cancel := context.WithCancel(ctx)

--- a/pkg/router/impl_n10n.go
+++ b/pkg/router/impl_n10n.go
@@ -26,7 +26,7 @@ import (
 /*
 curl -G --data-urlencode "payload={\"SubjectLogin\": \"paa\", \"ProjectionKey\":[{\"App\":\"Application\",\"Projection\":\"paa.price\",\"WS\":1}, {\"App\":\"Application\",\"Projection\":\"paa.wine_price\",\"WS\":1}]}" https://alpha2.dev.untill.ru/n10n/channel -H "Content-Type: application/json"
 */
-func (s *httpService) subscribeAndWatchHandler_V1() http.HandlerFunc {
+func (s *httpService) subscribeAndWatchHandler() http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		var (
 			urlParams in10nmem.CreateChannelParamsType


### PR DESCRIPTION
Resolves #3750 APIv2 notifications: extract router serve SSE and client-side read SSe routine