### PR TITLE
#3773 APIv2 notifications: return 204 on successful unsubscribe

### DIFF
--- a/pkg/coreutils/http.go
+++ b/pkg/coreutils/http.go
@@ -162,6 +162,10 @@ func WithMethod(m string) ReqOptFunc {
 	}
 }
 
+func Expect204(expectErrorContains ...string) ReqOptFunc {
+	return WithExpectedCode(http.StatusNoContent, expectErrorContains...)
+}
+
 func Expect409(expected ...string) ReqOptFunc {
 	return WithExpectedCode(http.StatusConflict, expected...)
 }

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -358,6 +358,7 @@ func requestHandlerV2_notifications_unsubscribe(numsAppsWorkspaces map[appdef.Ap
 			}
 			ReplyCommonError(rw, "failed to unsubscribe: "+err.Error(), code)
 		}
+		rw.WriteHeader(http.StatusNoContent)
 	})
 }
 

--- a/pkg/sys/it/impl_n10n_test.go
+++ b/pkg/sys/it/impl_n10n_test.go
@@ -73,6 +73,7 @@ func TestBasicUsage_n10n_APIv2(t *testing.T) {
 		coreutils.WithAuthorizeBy(token),
 		coreutils.WithLongPolling(),
 	)
+
 	offsetsChan, channelID, waitForDone := federation.ListenSSEEvents(resp.HTTPResp.Request.Context(), resp.HTTPResp.Body)
 
 	// force projections update
@@ -90,11 +91,13 @@ func TestBasicUsage_n10n_APIv2(t *testing.T) {
 	vit.POST(url, "",
 		coreutils.WithMethod(http.MethodDelete),
 		coreutils.WithAuthorizeBy(token),
+		coreutils.Expect204(),
 	)
 	url = fmt.Sprintf("api/v2/apps/test1/app1/notifications/%s/workspaces/%d/subscriptions/app1pkg.DailyIdx", channelID, ws.WSID)
 	vit.POST(url, "",
 		coreutils.WithMethod(http.MethodDelete),
 		coreutils.WithAuthorizeBy(token),
+		coreutils.Expect204(),
 	)
 
 	// force updates again to check that no new notifications arrived after unsubscribe


### PR DESCRIPTION
Resolves #3773 APIv2 notifications: return 204 on successful unsubscribe
