### PR TITLE
#3808 Invites: eliminate coreutils.IsTest usage on loading the mailer pwd secret

### DIFF
--- a/pkg/state/stateprovide/impl_async_actualizer_state.go
+++ b/pkg/state/stateprovide/impl_async_actualizer_state.go
@@ -52,7 +52,7 @@ func implProvideAsyncActualizerState(ctx context.Context, appStructsFunc state.A
 	state.addStorage(sys.Storage_Record, storages.NewRecordsStorage(appStructsFunc, wsidFunc, nil), S_GET|S_GET_BATCH)
 	state.addStorage(sys.Storage_Event, storages.NewEventStorage(eventFunc), S_GET)
 	state.addStorage(sys.Storage_WLog, storages.NewWLogStorage(ctx, ieventsFunc, wsidFunc), S_GET|S_READ)
-	state.addStorage(sys.Storage_SendMail, storages.NewSendMailStorage(opts.Messages), S_INSERT)
+	state.addStorage(sys.Storage_SendMail, storages.NewSendMailStorage(opts.MessagesSenderOverride), S_INSERT)
 	state.addStorage(sys.Storage_HTTP, storages.NewHTTPStorage(opts.CustomHTTPClient), S_READ)
 	state.addStorage(sys.Storage_FederationCommand, storages.NewFederationCommandStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, opts.FederationCommandHandler), S_GET)
 	state.addStorage(sys.Storage_FederationBlob, storages.NewFederationBlobStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, opts.FederationBlobHandler), S_READ)

--- a/pkg/state/stateprovide/impl_scheduler_state.go
+++ b/pkg/state/stateprovide/impl_scheduler_state.go
@@ -41,7 +41,7 @@ func implProvideSchedulerState(ctx context.Context, appStructsFunc state.AppStru
 	state.addStorage(sys.Storage_View, storages.NewViewRecordsStorage(ctx, appStructsFunc, wsidFunc, n10nFunc), S_GET|S_GET_BATCH|S_READ|S_INSERT|S_UPDATE)
 	state.addStorage(sys.Storage_Record, storages.NewRecordsStorage(appStructsFunc, wsidFunc, nil), S_GET|S_GET_BATCH)
 	state.addStorage(sys.Storage_WLog, storages.NewWLogStorage(ctx, ieventsFunc, wsidFunc), S_GET|S_READ)
-	state.addStorage(sys.Storage_SendMail, storages.NewSendMailStorage(opts.Messages), S_INSERT)
+	state.addStorage(sys.Storage_SendMail, storages.NewSendMailStorage(opts.MessagesSenderOverride), S_INSERT)
 	state.addStorage(sys.Storage_HTTP, storages.NewHTTPStorage(opts.CustomHTTPClient), S_READ)
 	state.addStorage(sys.Storage_FederationCommand, storages.NewFederationCommandStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, opts.FederationCommandHandler), S_GET)
 	state.addStorage(sys.Storage_FederationBlob, storages.NewFederationBlobStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, opts.FederationBlobHandler), S_READ)

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -59,16 +59,18 @@ type IHTTPClient interface {
 }
 
 type StateOpts struct {
-	Messages                 chan smtptest.Message
+	MessagesSenderOverride   chan smtptest.Message
 	FederationCommandHandler FederationCommandHandler
 	FederationBlobHandler    FederationBlobHandler
 	CustomHTTPClient         IHTTPClient
 	UniquesHandler           UniquesHandler
 }
 
-func WithEmailMessagesChan(messages chan smtptest.Message) StateOptFunc {
+// if specified then the email message will be written to the provided chan instead of actual sending
+// should be used in tests only
+func WithEmailSenderOverride(messages chan smtptest.Message) StateOptFunc {
 	return func(opts *StateOpts) {
-		opts.Messages = messages
+		opts.MessagesSenderOverride = messages
 	}
 }
 

--- a/pkg/sys/invite/impl_applyinvitation.go
+++ b/pkg/sys/invite/impl_applyinvitation.go
@@ -77,19 +77,17 @@ func applyInvitationProjector(time timeu.ITime, federation federation.IFederatio
 		skbSendMail.PutInt32(sys.Storage_SendMail_Field_Port, smtpCfg.Port)
 		skbSendMail.PutString(sys.Storage_SendMail_Field_Username, smtpCfg.Username)
 
-		pwd := ""
-		if !coreutils.IsTest() {
-			skbAppSecretsStorage, err := s.KeyBuilder(sys.Storage_AppSecret, appdef.NullQName)
-			if err != nil {
-				return err
-			}
-			skbAppSecretsStorage.PutString(sys.Storage_AppSecretField_Secret, smtpCfg.PwdSecret)
-			svAppSecretsStorage, err := s.MustExist(skbAppSecretsStorage)
-			if err != nil {
-				return err
-			}
-			pwd = svAppSecretsStorage.AsString("")
+		skbAppSecretsStorage, err := s.KeyBuilder(sys.Storage_AppSecret, appdef.NullQName)
+		if err != nil {
+			return err
 		}
+		skbAppSecretsStorage.PutString(sys.Storage_AppSecretField_Secret, smtpCfg.PwdSecret)
+		svAppSecretsStorage, err := s.MustExist(skbAppSecretsStorage)
+		if err != nil {
+			return err
+		}
+		
+		pwd := svAppSecretsStorage.AsString("")
 		skbSendMail.PutString(sys.Storage_SendMail_Field_Password, pwd)
 
 		// Send invitation Email

--- a/pkg/sys/invite/impl_applyupdateinviteroles.go
+++ b/pkg/sys/invite/impl_applyupdateinviteroles.go
@@ -91,19 +91,17 @@ func applyUpdateInviteRolesProjector(time timeu.ITime, federation federation.IFe
 		skbSendMail.PutInt32(sys.Storage_SendMail_Field_Port, smtpCfg.Port)
 		skbSendMail.PutString(sys.Storage_SendMail_Field_Username, smtpCfg.Username)
 
-		pwd := ""
-		if !coreutils.IsTest() {
-			skbAppSecretsStorage, err := s.KeyBuilder(sys.Storage_AppSecret, appdef.NullQName)
-			if err != nil {
-				return err
-			}
-			skbAppSecretsStorage.PutString(sys.Storage_AppSecretField_Secret, smtpCfg.PwdSecret)
-			svAppSecretsStorage, err := s.MustExist(skbAppSecretsStorage)
-			if err != nil {
-				return err
-			}
-			pwd = svAppSecretsStorage.AsString("")
+		skbAppSecretsStorage, err := s.KeyBuilder(sys.Storage_AppSecret, appdef.NullQName)
+		if err != nil {
+			return err
 		}
+		skbAppSecretsStorage.PutString(sys.Storage_AppSecretField_Secret, smtpCfg.PwdSecret)
+		svAppSecretsStorage, err := s.MustExist(skbAppSecretsStorage)
+		if err != nil {
+			return err
+		}
+		
+		pwd := svAppSecretsStorage.AsString("")
 		skbSendMail.PutString(sys.Storage_SendMail_Field_Password, pwd)
 
 		_, err = intents.NewValue(skbSendMail)

--- a/pkg/sys/storages/impl_send_mail_storage.go
+++ b/pkg/sys/storages/impl_send_mail_storage.go
@@ -18,12 +18,12 @@ import (
 )
 
 type sendMailStorage struct {
-	messages chan smtptest.Message // not nil in tests only
+	messagesSenderOverride chan smtptest.Message // not nil in tests only
 }
 
 func NewSendMailStorage(messages chan smtptest.Message) state.IStateStorage {
 	return &sendMailStorage{
-		messages: messages,
+		messagesSenderOverride: messages,
 	}
 }
 
@@ -206,7 +206,7 @@ func (s *sendMailStorage) ApplyBatch(items []state.ApplyBatchItem) (err error) {
 
 		logger.Info(fmt.Sprintf("send mail '%s' from '%s' to %s, cc %s, bcc %s", stringOrEmpty(k.subject), k.from, k.to, k.cc, k.bcc))
 
-		if s.messages != nil {
+		if s.messagesSenderOverride != nil {
 			// happens in tests only
 			m := smtptest.Message{
 				Subject: stringOrEmpty(k.subject),
@@ -216,7 +216,7 @@ func (s *sendMailStorage) ApplyBatch(items []state.ApplyBatchItem) (err error) {
 				BCC:     k.bcc,
 				Body:    stringOrEmpty(k.body),
 			}
-			s.messages <- m
+			s.messagesSenderOverride <- m
 		} else {
 			c, e := mail.NewClient(k.host, opts...)
 			if e != nil {

--- a/pkg/sys/verifier/impl.go
+++ b/pkg/sys/verifier/impl.go
@@ -104,19 +104,16 @@ func applySendEmailVerificationCode(federation federation.IFederation, smtpCfg s
 		kb.PutString(sys.Storage_SendMail_Field_Host, smtpCfg.Host)
 		kb.PutInt32(sys.Storage_SendMail_Field_Port, smtpCfg.Port)
 		kb.PutString(sys.Storage_SendMail_Field_Username, smtpCfg.Username)
-		pwd := ""
-		if !coreutils.IsTest() {
-			kbSecret, err := st.KeyBuilder(sys.Storage_AppSecret, appdef.NullQName)
-			if err != nil {
-				return err
-			}
-			kbSecret.PutString(sys.Storage_AppSecretField_Secret, smtpCfg.PwdSecret)
-			sv, err := st.MustExist(kbSecret)
-			if err != nil {
-				return err
-			}
-			pwd = sv.AsString("")
+		kbSecret, err := st.KeyBuilder(sys.Storage_AppSecret, appdef.NullQName)
+		if err != nil {
+			return err
 		}
+		kbSecret.PutString(sys.Storage_AppSecretField_Secret, smtpCfg.PwdSecret)
+		sv, err := st.MustExist(kbSecret)
+		if err != nil {
+			return err
+		}
+		pwd := sv.AsString("")
 		kb.PutString(sys.Storage_SendMail_Field_Password, pwd)
 
 		_, err = intents.NewValue(kb)

--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -33,7 +33,6 @@ import (
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/istructsmem"
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
-	"github.com/voedger/voedger/pkg/itokensjwt"
 	"github.com/voedger/voedger/pkg/state"
 	"github.com/voedger/voedger/pkg/state/smtptest"
 	"github.com/voedger/voedger/pkg/sys/authnz"
@@ -85,12 +84,9 @@ func newVit(t testing.TB, vitCfg *VITConfig, useCas bool, vvmLaunchOnly bool) *V
 	cfg.SequencesTrustLevel = isequencer.SequencesTrustLevel_0
 
 	cfg.Time = testingu.MockTime
-	if !coreutils.IsTest() {
-		cfg.SecretsReader = itokensjwt.ProvideTestSecretsReader(cfg.SecretsReader)
-	}
 
 	emailMessagesChan := make(chan smtptest.Message, 1) // must be buffered
-	cfg.ActualizerStateOpts = append(cfg.ActualizerStateOpts, state.WithEmailMessagesChan(emailMessagesChan))
+	cfg.ActualizerStateOpts = append(cfg.ActualizerStateOpts, state.WithEmailSenderOverride(emailMessagesChan))
 
 	vitPreConfig := &vitPreConfig{
 		vvmCfg:  &cfg,

--- a/pkg/vit/impl_test.go
+++ b/pkg/vit/impl_test.go
@@ -240,7 +240,7 @@ func TestEmailExpectation(t *testing.T) {
 
 	// provide VIT email sending chan to the IBundledHostState, then use it to send an email
 	s := stateprovide.ProvideAsyncActualizerStateFactory()(context.Background(), func() istructs.IAppStructs { return &nilAppStructs{} }, nil, nil, nil, nil, nil, nil, nil, 1, 0,
-		state.WithEmailMessagesChan(vit.emailCaptor))
+		state.WithEmailSenderOverride(vit.emailCaptor))
 	k, err := s.KeyBuilder(sys.Storage_SendMail, appdef.NullQName)
 	require.NoError(err)
 

--- a/pkg/vit/shared_cfgs.go
+++ b/pkg/vit/shared_cfgs.go
@@ -61,6 +61,7 @@ const (
 	Field_GroupB         = "GroupB"
 	Field_Blob           = "Blob"
 	Field_BlobReadDenied = "BlobReadDenied"
+	testSMTPPwdSecretName = "smtp-pwd-secret-name"
 )
 
 var (
@@ -90,9 +91,10 @@ var (
 	QNameODoc1                               = appdef.NewQName(app1PkgName, "odoc1")
 	QNameODoc2                               = appdef.NewQName(app1PkgName, "odoc2")
 	TestSMTPCfg                              = smtp.Cfg{
-		Host:     "smtp.testserver.com",
-		Port:     1,
-		Username: "username@gmail.com",
+		Host:      "smtp.testserver.com",
+		Port:      1,
+		Username:  "username@gmail.com",
+		PwdSecret: testSMTPPwdSecretName,
 	}
 	QNameDocWithBLOB  = appdef.NewQName(app1PkgName, "DocWithBLOB")
 	QNameODocWithBLOB = appdef.NewQName(app1PkgName, "ODocWithBLOB")
@@ -124,6 +126,7 @@ var (
 
 			cfg.SMTPConfig = TestSMTPCfg
 		}),
+		WithSecret(testSMTPPwdSecretName, []byte("smtpPassword")),
 		WithCleanup(func(_ *VIT) {
 			MockCmdExec = func(input string, args istructs.ExecCommandArgs) error { panic("") }
 			MockQryExec = func(input string, args istructs.ExecQueryArgs, callback istructs.ExecQueryCallback) error { panic("") }


### PR DESCRIPTION
Resolves #3808 Invites: eliminate coreutils.IsTest usage on loading the mailer pwd secret
