### PR TITLE
skip-TestVSqlUpdate_BasicUsage_UpdateTable

### DIFF
--- a/pkg/sys/it/impl_vsqlupdate_test.go
+++ b/pkg/sys/it/impl_vsqlupdate_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestVSqlUpdate_BasicUsage_UpdateTable(t *testing.T) {
+	t.Skip("https://github.com/voedger/voedger/issues/3845")
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
 


### PR DESCRIPTION
Resolves #3910 skip TestVSqlUpdate_BasicUsage_UpdateTable
