### PR TITLE
q.sys.SqlQuery:-support-`-signs-in-field-names

### DIFF
--- a/pkg/dml/consts.go
+++ b/pkg/dml/consts.go
@@ -10,9 +10,9 @@ import "regexp"
 const (
 	opRegexpStr = `^` +
 		`\s*((\w*\s*update\s*\w*)|(\w*\s*insert)|(select\s+.+\s+from))\s+` +
-		`(?P<appQName>[^\d][a-zA-Z0-9_-]+\.[^\d][a-zA-Z0-9_-]+\.)?` +
+		`(?P<appQName>[^\d][a-zA-Z0-9_-`+"`"+`]+\.[^\d][a-zA-Z0-9_-`+"`"+`]+\.)?` +
 		`((?P<wsidOrPartno>\d+\.)|(?P<appWSNum>a\d+.)|(?P<login>".+"\.))?` +
-		`(?P<qName>[^\d][a-zA-Z0-9_-]+\.[^\d][a-zA-Z0-9_-]+)` +
+		`(?P<qName>[^\d][a-zA-Z0-9_-`+"`"+`]+\.[^\d][a-zA-Z0-9_-`+"`"+`]+)` +
 		`(?P<idOrOffset>\.\d+)?` +
 		`(?P<pars>\s+.*)?$`
 )

--- a/pkg/dml/consts.go
+++ b/pkg/dml/consts.go
@@ -8,6 +8,7 @@ package dml
 import "regexp"
 
 const (
+	// +"`"+ means just ` sign
 	opRegexpStr = `^` +
 		`\s*((\w*\s*update\s*\w*)|(\w*\s*insert)|(select\s+.+\s+from))\s+` +
 		`(?P<appQName>[^\d][a-zA-Z0-9_-`+"`"+`]+\.[^\d][a-zA-Z0-9_-`+"`"+`]+\.)?` +

--- a/pkg/dml/consts.go
+++ b/pkg/dml/consts.go
@@ -8,12 +8,11 @@ package dml
 import "regexp"
 
 const (
-	// +"`"+ means just ` sign
 	opRegexpStr = `^` +
 		`\s*((\w*\s*update\s*\w*)|(\w*\s*insert)|(select\s+.+\s+from))\s+` +
-		`(?P<appQName>[^\d][a-zA-Z0-9_-`+"`"+`]+\.[^\d][a-zA-Z0-9_-`+"`"+`]+\.)?` +
+		`(?P<appQName>[^\d][a-zA-Z0-9_-]+\.[^\d][a-zA-Z0-9_-]+\.)?` +
 		`((?P<wsidOrPartno>\d+\.)|(?P<appWSNum>a\d+.)|(?P<login>".+"\.))?` +
-		`(?P<qName>[^\d][a-zA-Z0-9_-`+"`"+`]+\.[^\d][a-zA-Z0-9_-`+"`"+`]+)` +
+		`(?P<qName>[^\d][a-zA-Z0-9_-]+\.[^\d][a-zA-Z0-9_-]+)` +
 		`(?P<idOrOffset>\.\d+)?` +
 		`(?P<pars>\s+.*)?$`
 )

--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -668,7 +668,7 @@ func TestValuesFieldConditions(t *testing.T) {
 
 	valuesHash := coreutils.HashBytes([]byte(istructs.AppQName_test1_app1.String()))
 
-	// Values istead of `Values` -> syntax error at position 116. Vitess sql parser bug?
+	// Values instead of `Values` -> syntax error at position 116. Vitess sql parser bug?
 	body := fmt.Sprintf("{\"args\":{\"Query\":\"select * from sys.Uniques where QName = 'cluster.App$uniques$01' and ValuesHash = %d and `Values` = '%s'\"},\"elements\":[{\"fields\":[\"Result\"]}]}",
 		valuesHash, base64.URLEncoding.EncodeToString([]byte(istructs.AppQName_test1_app1.String())))
 	sysPrn := vit.GetSystemPrincipal(istructs.AppQName_sys_cluster)


### PR DESCRIPTION
Resolves #3916 q.sys.SqlQuery: support ` signs in field names
