### PR TITLE
voedger: fix referential integrity checking in ORecords

### DIFF
--- a/pkg/sys/it/impl_cpv2_test.go
+++ b/pkg/sys/it/impl_cpv2_test.go
@@ -324,7 +324,7 @@ func TestErrorsCPv2(t *testing.T) {
 		})
 
 		t.Run("ODoc", func(t *testing.T) {
-			body := `{"args":{"sys.ID": 1}}`
+			body := `{"args":{"sys.ID": 1},"unloggedArgs":{"sys.ID":2}}`
 			resp := vit.PostWS(ws, "c.app1pkg.CmdODocOne", body)
 			odocID := resp.NewID()
 			t.Run("update", func(t *testing.T) {
@@ -344,7 +344,7 @@ func TestErrorsCPv2(t *testing.T) {
 		})
 
 		t.Run("ORecord", func(t *testing.T) {
-			body := `{"args":{"sys.ID": 1,"orecord1":[{"sys.ID":2,"sys.ParentID":1}]}}`
+			body := `{"args":{"sys.ID": 1,"orecord1":[{"sys.ID":2,"sys.ParentID":1}]},"unloggedArgs":{"sys.ID":3}}`
 			resp := vit.PostWS(ws, "c.app1pkg.CmdODocOne", body)
 			orecordID := resp.NewIDs["2"]
 			t.Run("update", func(t *testing.T) {

--- a/pkg/sys/it/impl_cud_test.go
+++ b/pkg/sys/it/impl_cud_test.go
@@ -328,27 +328,41 @@ func TestRefIntegrity(t *testing.T) {
 		})
 
 		t.Run("unloggedArgs", func(t *testing.T) {
-			testArgsRefIntegrity(t, vit, ws, appDef, `{"args":{"sys.ID": 1},"unloggedArgs":{"sys.ID":2, %s}}`)
+			testArgsRefIntegrity(t, vit, ws, appDef, `{"args":{"sys.ID": 2},"unloggedArgs":{"sys.ID":1, %s}}`)
 		})
 	})
 }
 
 func testArgsRefIntegrity(t *testing.T, vit *it.VIT, ws *it.AppWorkspace, app appdef.IAppDef, urlTemplate string) {
-	body := `{"args":{"sys.ID": 1,"orecord1":[{"sys.ID":2,"sys.ParentID":1,"orecord2":[{"sys.ID":3,"sys.ParentID":2}]}]}}`
+	body := `{"args":{"sys.ID": 1,"orecord1":[{"sys.ID":2,"sys.ParentID":1,"orecord2":[{"sys.ID":3,"sys.ParentID":2}]}]},"unloggedArgs":{"sys.ID":4}}`
 	resp := vit.PostWS(ws, "c.app1pkg.CmdODocOne", body)
 	idOdoc1 := resp.NewIDs["1"]
 	idOrecord1 := resp.NewIDs["2"]
 	idOrecord2 := resp.NewIDs["3"]
 	body = `{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.cdoc1"}}]}`
 	idCDoc := vit.PostWS(ws, "c.sys.CUD", body).NewID()
+
 	t.Run("ref to unexisting -> 400 bad request", func(t *testing.T) {
-		oDoc := appdef.ODoc(app.Type, it.QNameODoc2)
-		for _, oDoc1RefField := range oDoc.RefFields() {
-			t.Run(oDoc1RefField.Name(), func(t *testing.T) {
-				body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"%s":%d`, oDoc1RefField.Name(), istructs.NonExistingRecordID))
-				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, coreutils.Expect400RefIntegrity_Existence()).Println()
-			})
-		}
+		t.Run("ODoc", func(t *testing.T) {
+			oDoc := appdef.ODoc(app.Type, it.QNameODoc2)
+			for _, oDoc1RefField := range oDoc.RefFields() {
+				t.Run(oDoc1RefField.Name(), func(t *testing.T) {
+					body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"%s":%d`, oDoc1RefField.Name(), istructs.NonExistingRecordID))
+					vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, coreutils.Expect400(fmt.Sprintf("record ID %d referenced by app1pkg.odoc2.%s does not exist",
+						istructs.NonExistingRecordID, oDoc1RefField.Name()))).Println()
+				})
+			}
+		})
+		t.Run("ref in ORecord", func(t *testing.T) {
+			oRecord := appdef.ORecord(app.Type, appdef.NewQName("app1pkg", "orecord1"))
+			for _, oRecord1RefField := range oRecord.RefFields() {
+				t.Run(oRecord1RefField.Name(), func(t *testing.T) {
+					body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"orecord1":[{"%s":%d,"sys.ID":3,"sys.ParentID":1}]`, oRecord1RefField.Name(), istructs.NonExistingRecordID))
+					vit.PostWS(ws, "c.app1pkg.CmdODocOne", body, coreutils.Expect400(fmt.Sprintf("record ID %d referenced by app1pkg.orecord1.%s does not exist",
+						istructs.NonExistingRecordID, oRecord1RefField.Name()))).Println()
+				})
+			}
+		})
 	})
 
 	t.Run("ref to existing", func(t *testing.T) {

--- a/pkg/sys/it/impl_qpv2_test.go
+++ b/pkg/sys/it/impl_qpv2_test.go
@@ -2424,7 +2424,7 @@ func TestQueryProcessor2_Docs(t *testing.T) {
 	})
 
 	t.Run("odocs", func(t *testing.T) {
-		body := `{"args":{"sys.ID": 1,"odocIntFld":42, "orecord1":[{"sys.ID":2,"sys.ParentID":1,"orecord1IntFld":43}]}}`
+		body := `{"args":{"sys.ID": 1,"odocIntFld":42, "orecord1":[{"sys.ID":2,"sys.ParentID":1,"orecord1IntFld":43}]},"unloggedArgs":{"sys.ID":3}}`
 		resp := vit.PostWS(ws, "c.app1pkg.CmdODocOne", body)
 		odocID := resp.NewIDs["1"]
 		orecordID := resp.NewIDs["2"]

--- a/pkg/sys/it/impl_recovery_test.go
+++ b/pkg/sys/it/impl_recovery_test.go
@@ -51,7 +51,7 @@ func TestCorrectIDsIssueAfterRecovery(t *testing.T) {
 	vit := it.NewVIT(t, &cfg)
 	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
 
-	body := `{"args":{"sys.ID": 1,"orecord1":[{"sys.ID":2,"sys.ParentID":1,"orecord2":[{"sys.ID":3,"sys.ParentID":2}]}]}}`
+	body := `{"args":{"sys.ID": 1,"orecord1":[{"sys.ID":2,"sys.ParentID":1,"orecord2":[{"sys.ID":3,"sys.ParentID":2}]}]},"unloggedArgs":{"sys.ID":4}}`
 	resp := vit.PostWS(ws, "c.app1pkg.CmdODocOne", body)
 	resp.Println()
 

--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -600,7 +600,8 @@ func TestReadODocs(t *testing.T) {
 			{"sys.ID":4,"sys.ParentID":1, "orecord1IntFld": 45, "orecord2": [
 				{"sys.ID":5, "sys.ParentID":4, "orecord2IntFld": 46}
 			]}
-		]}
+		]},
+		"unloggedArgs":{"sys.ID":6}
 	}`
 	resp := vit.Func(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/commands/app1pkg.CmdODocOne", ws.WSID), body,
 		coreutils.WithMethod(http.MethodPost),
@@ -610,7 +611,7 @@ func TestReadODocs(t *testing.T) {
 	odoc1ORec11ID := resp.NewIDs["2"]
 	odoc1ORec12ID := resp.NewIDs["4"]
 
-	body = `{"args":{"sys.ID": 1,"odocIntFld": 47}}`
+	body = `{"args":{"sys.ID": 1,"odocIntFld": 47},"unloggedArgs":{"sys.ID":2}}`
 	resp = vit.Func(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/commands/app1pkg.CmdODocOne", ws.WSID), body,
 		coreutils.WithMethod(http.MethodPost),
 		coreutils.WithAuthorizeBy(ws.Owner.Token),

--- a/pkg/vit/schemaTestApp1.vsql
+++ b/pkg/vit/schemaTestApp1.vsql
@@ -482,6 +482,10 @@ ALTERABLE WORKSPACE test_wsWS (
 		odocIntFld int32,
 		orecord1 TABLE orecord1(
 			orecord1IntFld int32,
+			refToCDoc1 ref(cdoc1),
+			refToORecord1 ref(orecord1),
+			refToAny ref,
+			refToCDoc1OrODoc1 ref(cdoc1, odoc1),
 			orecord2 TABLE orecord2(
 				orecord2IntFld int32
 			)
@@ -736,7 +740,7 @@ ALTERABLE WORKSPACE test_wsWS (
 		COMMAND TestDeniedCmd;
 		QUERY TestDeniedQuery() RETURNS TestCmdResult;
 
-		COMMAND CmdODocOne(odoc1) WITH Tags=(WorkspaceOwnerFuncTag, ApiFeatureTag);
+		COMMAND CmdODocOne(odoc1, UNLOGGED odoc1) WITH Tags=(WorkspaceOwnerFuncTag, ApiFeatureTag);
 		COMMAND CmdODocTwo(odoc2, UNLOGGED odoc2) WITH Tags=(WorkspaceOwnerFuncTag);
 
 		COMMAND TestCmdRawArg(sys.Raw) WITH Tags=(WorkspaceOwnerFuncTag);


### PR DESCRIPTION
[AIR-1257] voedger: fix referential integrity checking in ORecords
https://untill.atlassian.net/browse/AIR-1257