### PR TITLE
abstractions leak: high-level `sys.Error` is checked by low-level `IHTTPClient`

### DIFF
--- a/pkg/coreutils/federation/impl.go
+++ b/pkg/coreutils/federation/impl.go
@@ -48,13 +48,11 @@ func (f *implIFederation) reqFederation(apiPath string, body string, optFuncs ..
 func (f *implIFederation) reqReader(relativeURL string, bodyReader io.Reader, optFuncs ...coreutils.ReqOptFunc) (*coreutils.HTTPResponse, error) {
 	url := f.federationURL().String() + "/" + relativeURL
 	optFuncs = append(f.defaultReqOptFuncs, optFuncs...)
-	optFuncs = append(optFuncs, coreutils.WithOptsValidator(coreutils.DenyGETAndDiscardResponse))
 	return f.httpClient.ReqReader(f.vvmCtx, url, bodyReader, optFuncs...)
 }
 
 func (f *implIFederation) reqURL(url string, body string, optFuncs ...coreutils.ReqOptFunc) (*coreutils.HTTPResponse, error) {
 	optFuncs = append(f.defaultReqOptFuncs, optFuncs...)
-	optFuncs = append(optFuncs, coreutils.WithOptsValidator(coreutils.DenyGETAndDiscardResponse))
 	return f.httpClient.Req(f.vvmCtx, url, body, optFuncs...)
 }
 
@@ -74,7 +72,7 @@ func (f *implIFederation) UploadTempBLOB(appQName appdef.AppQName, wsid istructs
 	if err != nil {
 		return "", err
 	}
-	if !slices.Contains(resp.ExpectedHTTPCodes(), resp.HTTPResp.StatusCode) {
+	if !slices.Contains(resp.Opts.ExpectedHTTPCodes(), resp.HTTPResp.StatusCode) {
 		sysErr, err := getSysError(resp)
 		if err != nil {
 			return "", err
@@ -104,7 +102,7 @@ func (f *implIFederation) UploadBLOB(appQName appdef.AppQName, wsid istructs.WSI
 	if err != nil {
 		return istructs.NullRecordID, err
 	}
-	if !slices.Contains(resp.ExpectedHTTPCodes(), resp.HTTPResp.StatusCode) {
+	if !slices.Contains(resp.Opts.ExpectedHTTPCodes(), resp.HTTPResp.StatusCode) {
 		sysErr, err := getSysError(resp)
 		if err != nil {
 			return istructs.NullRecordID, err
@@ -188,8 +186,7 @@ func (f *implIFederation) Query(relativeURL string, optFuncs ...coreutils.ReqOpt
 func (f *implIFederation) AdminFunc(relativeURL string, body string, optFuncs ...coreutils.ReqOptFunc) (*coreutils.FuncResponse, error) {
 	optFuncs = append(optFuncs, coreutils.WithMethod(http.MethodPost))
 	url := fmt.Sprintf("http://127.0.0.1:%d/%s", f.adminPortGetter(), relativeURL)
-	optFuncs = append(f.defaultReqOptFuncs, optFuncs...)
-	httpResp, err := f.httpClient.Req(f.vvmCtx, url, body, optFuncs...)
+	httpResp, err := f.reqURL(url, body, optFuncs...)
 	return HTTPRespToFuncResp(httpResp, err)
 }
 

--- a/pkg/coreutils/federation/impl_test.go
+++ b/pkg/coreutils/federation/impl_test.go
@@ -151,30 +151,6 @@ func TestFederationFunc(t *testing.T) {
 			resp, err := federation.Func("/api/123456789/c.sys.CUD", `{"fld":"val"}`, coreutils.WithExpectedCode(http.StatusInternalServerError))
 			require.NoError(err)
 			resp.Println()
-			resp.RequireContainsError(t, "something")
-			resp.RequireError(t, "something gone wrong")
-		})
-		t.Run("ExpectedErrorContains", func(t *testing.T) {
-			t.Skip("waiting for https://github.com/voedger/voedger/issues/4027")
-			errorMessage := "non-expected"
-			handler = func(w http.ResponseWriter, r *http.Request) {
-				_, err := io.ReadAll(r.Body)
-				require.NoError(err)
-				w.WriteHeader(http.StatusInternalServerError)
-				fmt.Fprintf(w, `{"sys.Error":{"HTTPStatus":500,"Message":"%s","QName":"sys.SomeErrorQName","Data":"additional data"}}`,
-					errorMessage)
-			}
-			resp, err := federation.Func("/api/123456789/c.sys.CUD", `{"fld":"val"}`, coreutils.WithExpectedCode(http.StatusInternalServerError,
-				"expected error message"))
-			require.Error(err)
-			require.Nil(resp)
-
-			errorMessage = "expected error message"
-			resp, err = federation.Func("/api/123456789/c.sys.CUD", `{"fld":"val"}`, coreutils.WithExpectedCode(http.StatusInternalServerError,
-				"expected error message"))
-			require.NoError(err)
-			resp.RequireContainsError(t, "expected")
-			resp.RequireError(t, "expected error message")
 		})
 	})
 

--- a/pkg/coreutils/federation/provide.go
+++ b/pkg/coreutils/federation/provide.go
@@ -13,7 +13,10 @@ import (
 )
 
 func New(vvmCtx context.Context, federationURL func() *url.URL, adminPortGetter func() int) (federation IFederation, cleanup func()) {
-	httpClient, cln := coreutils.NewIHTTPClient(coreutils.WithSkipRetryOn503())
+	httpClient, cln := coreutils.NewIHTTPClient(
+		coreutils.WithSkipRetryOn503(),
+		coreutils.WithOptsValidator(coreutils.DenyGETAndDiscardResponse), // to prevent discarding possible sys.Error
+	)
 	fed := &implIFederation{
 		httpClient:      httpClient,
 		federationURL:   federationURL,

--- a/pkg/coreutils/federation/utils.go
+++ b/pkg/coreutils/federation/utils.go
@@ -96,10 +96,6 @@ func HTTPRespToFuncResp(httpResp *coreutils.HTTPResponse, httpRespErr error) (fu
 		}
 	}
 
-	if !slices.Contains(httpResp.Opts.ExpectedHTTPCodes(), httpResp.HTTPResp.StatusCode) {
-		return nil, unexpectedStatusErr(httpResp.Opts.ExpectedHTTPCodes(), httpResp.HTTPResp.StatusCode, funcResp.SysError)
-	}
-
 	var sysErr coreutils.SysError
 	if errors.As(funcResp.SysError, &sysErr) {
 		if !slices.Contains(httpResp.Opts.ExpectedHTTPCodes(), sysErr.HTTPStatus) {
@@ -107,6 +103,11 @@ func HTTPRespToFuncResp(httpResp *coreutils.HTTPResponse, httpRespErr error) (fu
 		}
 		return funcResp, nil
 	}
+	
+	if !slices.Contains(httpResp.Opts.ExpectedHTTPCodes(), httpResp.HTTPResp.StatusCode) {
+		return nil, unexpectedStatusErr(httpResp.Opts.ExpectedHTTPCodes(), httpResp.HTTPResp.StatusCode, funcResp.SysError)
+	}
+
 	return funcResp, funcResp.SysError
 }
 

--- a/pkg/coreutils/federation/utils.go
+++ b/pkg/coreutils/federation/utils.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"slices"
 	"strconv"
 	"strings"
@@ -75,7 +74,7 @@ func ListenSSEEvents(ctx context.Context, body io.Reader) (offsetsChan OffsetsCh
 	return offsetsChan, channelID, func() { wg.Wait() }
 }
 
-func HTTPRespToFuncResp(httpResp *coreutils.HTTPResponse, httpRespErr error) (res *coreutils.FuncResponse, err error) {
+func HTTPRespToFuncResp(httpResp *coreutils.HTTPResponse, httpRespErr error) (funcResp *coreutils.FuncResponse, err error) {
 	if httpRespErr != nil && !errors.Is(httpRespErr, coreutils.ErrUnexpectedStatusCode) {
 		return nil, httpRespErr
 	}
@@ -84,35 +83,33 @@ func HTTPRespToFuncResp(httpResp *coreutils.HTTPResponse, httpRespErr error) (re
 		return nil, nil
 	}
 
-	res = &coreutils.FuncResponse{
+	funcResp = &coreutils.FuncResponse{
 		CommandResponse: coreutils.CommandResponse{
 			NewIDs:    map[string]istructs.RecordID{},
 			CmdResult: map[string]interface{}{},
 		},
-		HTTPResponse: httpResp,
+		HTTPResponse: *httpResp,
 	}
 	if len(httpResp.Body) > 0 {
-		if err = json.Unmarshal([]byte(httpResp.Body), &res); err != nil {
+		if err = json.Unmarshal([]byte(httpResp.Body), &funcResp); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal response body: %w. Body:\n%s", err, httpResp.Body)
 		}
 	}
 
-	if !slices.Contains(httpResp.ExpectedHTTPCodes(), httpResp.HTTPResp.StatusCode) {
-		if len(httpResp.ExpectedHTTPCodes()) == 1 && httpResp.ExpectedHTTPCodes()[0] == http.StatusOK {
-			return nil, fmt.Errorf("status %d: %w", httpResp.HTTPResp.StatusCode, res.SysError)
-		}
-		return nil, fmt.Errorf("status %d, expected %v: %w", httpResp.HTTPResp.StatusCode, httpResp.ExpectedHTTPCodes(), res.SysError)
+	if !slices.Contains(httpResp.Opts.ExpectedHTTPCodes(), httpResp.HTTPResp.StatusCode) {
+		return nil, unexpectedStatusErr(httpResp.Opts.ExpectedHTTPCodes(), httpResp.HTTPResp.StatusCode, funcResp.SysError)
 	}
 
 	var sysErr coreutils.SysError
-	if errors.As(res.SysError, &sysErr) {
-		if !slices.Contains(httpResp.ExpectedHTTPCodes(), sysErr.HTTPStatus) {
-			if len(httpResp.ExpectedHTTPCodes()) == 1 && httpResp.ExpectedHTTPCodes()[0] == http.StatusOK {
-				return nil, fmt.Errorf("status %d: %w", sysErr.HTTPStatus, res.SysError)
-			}
-			return nil, fmt.Errorf("status %d, expected %v: %w", sysErr.HTTPStatus, httpResp.ExpectedHTTPCodes(), res.SysError)
+	if errors.As(funcResp.SysError, &sysErr) {
+		if !slices.Contains(httpResp.Opts.ExpectedHTTPCodes(), sysErr.HTTPStatus) {
+			return nil, unexpectedStatusErr(httpResp.Opts.ExpectedHTTPCodes(), sysErr.HTTPStatus, funcResp.SysError)
 		}
-		return res, nil
+		return funcResp, nil
 	}
-	return res, res.SysError
+	return funcResp, funcResp.SysError
+}
+
+func unexpectedStatusErr(expectedCodes []int, actualCode int, sysErr error) error {
+	return fmt.Errorf("status %d, expected %v: %w", actualCode, expectedCodes, sysErr)
 }

--- a/pkg/coreutils/http.go
+++ b/pkg/coreutils/http.go
@@ -16,10 +16,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	retrier "github.com/voedger/voedger/pkg/goutils/retry"
 	"github.com/voedger/voedger/pkg/istructs"
@@ -39,27 +37,27 @@ func NewHTTPError(httpStatus int, err error) SysError {
 
 // WithResponseHandler, WithLongPolling and WithDiscardResponse are mutual exclusive
 func WithResponseHandler(responseHandler func(httpResp *http.Response)) ReqOptFunc {
-	return func(ro *reqOpts) {
-		ro.responseHandler = responseHandler
+	return func(opts IReqOpts) {
+		opts.httpOpts().responseHandler = responseHandler
 	}
 }
 
 func withBodyReader(bodyReader io.Reader) ReqOptFunc {
-	return func(opts *reqOpts) {
-		opts.bodyReader = bodyReader
+	return func(opts IReqOpts) {
+		opts.httpOpts().bodyReader = bodyReader
 	}
 }
 
 // WithLongPolling, WithResponseHandler and WithDiscardResponse are mutual exclusive
 func WithLongPolling() ReqOptFunc {
-	return func(ro *reqOpts) {
-		ro.responseHandler = func(resp *http.Response) {
-			if !slices.Contains(ro.expectedHTTPCodes, resp.StatusCode) {
+	return func(opts IReqOpts) {
+		opts.httpOpts().responseHandler = func(resp *http.Response) {
+			if !slices.Contains(opts.httpOpts().expectedHTTPCodes, resp.StatusCode) {
 				body, err := readBody(resp)
 				if err != nil {
 					panic("failed to Read response body in custom response handler: " + err.Error())
 				}
-				panic(fmt.Sprintf("actual status code %d, expected %v. Body: %s", resp.StatusCode, ro.expectedHTTPCodes, body))
+				panic(fmt.Sprintf("actual status code %d, expected %v. Body: %s", resp.StatusCode, opts.httpOpts().expectedHTTPCodes, body))
 			}
 		}
 	}
@@ -68,139 +66,142 @@ func WithLongPolling() ReqOptFunc {
 // WithDiscardResponse, WithResponseHandler and WithLongPolling are mutual exclusive
 // causes FederationReq() to return nil for *HTTPResponse
 func WithDiscardResponse() ReqOptFunc {
-	return func(opts *reqOpts) {
-		opts.discardResp = true
+	return func(opts IReqOpts) {
+		opts.httpOpts().discardResp = true
 	}
 }
 
 func WithoutAuth() ReqOptFunc {
-	return func(opts *reqOpts) {
-		opts.withoutAuth = true
+	return func(opts IReqOpts) {
+		opts.httpOpts().withoutAuth = true
 	}
 }
 
 func WithCookies(cookiesPairs ...string) ReqOptFunc {
-	return func(po *reqOpts) {
+	return func(opts IReqOpts) {
 		for i := 0; i < len(cookiesPairs); i += 2 {
-			po.cookies[cookiesPairs[i]] = cookiesPairs[i+1]
+			opts.httpOpts().cookies[cookiesPairs[i]] = cookiesPairs[i+1]
 		}
 	}
 }
 
 func WithHeaders(headersPairs ...string) ReqOptFunc {
-	return func(po *reqOpts) {
+	return func(opts IReqOpts) {
 		for i := 0; i < len(headersPairs); i += 2 {
-			po.headers[headersPairs[i]] = headersPairs[i+1]
+			opts.httpOpts().headers[headersPairs[i]] = headersPairs[i+1]
 		}
 	}
 }
 
-func WithExpectedCode(expectedHTTPCode int, expectErrorContains ...string) ReqOptFunc {
-	return func(po *reqOpts) {
-		po.expectedHTTPCodes = append(po.expectedHTTPCodes, expectedHTTPCode)
-		po.expectedErrorContains = append(po.expectedErrorContains, expectErrorContains...)
+func WithExpectedCode(expectedHTTPCode int) ReqOptFunc {
+	return func(opts IReqOpts) {
+		opts.httpOpts().expectedHTTPCodes = append(opts.httpOpts().expectedHTTPCodes, expectedHTTPCode)
 	}
 }
 
 // has priority over WithAuthorizeByIfNot
 func WithAuthorizeBy(principalToken string) ReqOptFunc {
-	return func(po *reqOpts) {
-		po.headers[Authorization] = BearerPrefix + principalToken
+	return func(opts IReqOpts) {
+		opts.httpOpts().headers[Authorization] = BearerPrefix + principalToken
 	}
 }
 
 func WithDeadlineOn503(deadline time.Duration) ReqOptFunc {
-	return func(opts *reqOpts) {
-		opts.deadlineOn503 = deadline
+	return func(opts IReqOpts) {
+		opts.httpOpts().deadlineOn503 = deadline
 	}
 }
 
 func WithRetryOn503() ReqOptFunc {
-	return func(opts *reqOpts) {
-		opts.skipRetryOn503 = false
+	return func(opts IReqOpts) {
+		opts.httpOpts().skipRetryOn503 = false
 	}
 }
 
 func WithSkipRetryOn503() ReqOptFunc {
-	return func(opts *reqOpts) {
-		opts.skipRetryOn503 = true
+	return func(opts IReqOpts) {
+		opts.httpOpts().skipRetryOn503 = true
 	}
 }
 
 func WithDefaultAuthorize(principalToken string) ReqOptFunc {
-	return func(po *reqOpts) {
-		if _, ok := po.headers[Authorization]; !ok {
-			po.headers[Authorization] = BearerPrefix + principalToken
+	return func(opts IReqOpts) {
+		if _, ok := opts.httpOpts().headers[Authorization]; !ok {
+			opts.httpOpts().headers[Authorization] = BearerPrefix + principalToken
 		}
 	}
 }
 
 func WithRelativeURL(relativeURL string) ReqOptFunc {
-	return func(ro *reqOpts) {
-		ro.relativeURL = relativeURL
+	return func(opts IReqOpts) {
+		opts.httpOpts().relativeURL = relativeURL
 	}
 }
 
 func WithDefaultMethod(m string) ReqOptFunc {
-	return func(opts *reqOpts) {
-		if len(opts.method) == 0 {
-			opts.method = m
+	return func(opts IReqOpts) {
+		if len(opts.httpOpts().method) == 0 {
+			opts.httpOpts().method = m
 		}
 	}
 }
 
 func WithMethod(m string) ReqOptFunc {
-	return func(po *reqOpts) {
-		po.method = m
+	return func(opts IReqOpts) {
+		opts.httpOpts().method = m
 	}
 }
 
-func Expect204(expectErrorContains ...string) ReqOptFunc {
-	return WithExpectedCode(http.StatusNoContent, expectErrorContains...)
+func WithRetryErrorMatcher(matcher func(err error) (retry bool)) ReqOptFunc {
+	return func(opts IReqOpts) {
+		opts.httpOpts().retryErrsMatchers = append(opts.httpOpts().retryErrsMatchers, matcher)
+	}
 }
 
-func Expect409(expected ...string) ReqOptFunc {
-	return WithExpectedCode(http.StatusConflict, expected...)
+func WithCustomOptsProvider(prov func(internalOpts IReqOpts) (customOpts IReqOpts)) ReqOptFunc {
+	return func(opts IReqOpts) {
+		opts.httpOpts().customOptsProvider = prov
+	}
 }
 
-func Expect404(expected ...string) ReqOptFunc {
-	return WithExpectedCode(http.StatusNotFound, expected...)
+func Expect204() ReqOptFunc {
+	return WithExpectedCode(http.StatusNoContent)
+}
+
+func Expect409() ReqOptFunc {
+	return WithExpectedCode(http.StatusConflict)
+}
+
+func Expect404() ReqOptFunc {
+	return WithExpectedCode(http.StatusNotFound)
 }
 
 func Expect401() ReqOptFunc {
 	return WithExpectedCode(http.StatusUnauthorized)
 }
 
-func Expect403(expectedMessages ...string) ReqOptFunc {
-	return WithExpectedCode(http.StatusForbidden, expectedMessages...)
+func Expect403() ReqOptFunc {
+	return WithExpectedCode(http.StatusForbidden)
 }
 
-func Expect400(expectErrorContains ...string) ReqOptFunc {
-	return WithExpectedCode(http.StatusBadRequest, expectErrorContains...)
+func Expect400() ReqOptFunc {
+	return WithExpectedCode(http.StatusBadRequest)
 }
 
-func Expect405(expectErrorContains ...string) ReqOptFunc {
-	return WithExpectedCode(http.StatusMethodNotAllowed, expectErrorContains...)
+func Expect405() ReqOptFunc {
+	return WithExpectedCode(http.StatusMethodNotAllowed)
 }
 
-func Expect423(expectErrorContains ...string) ReqOptFunc {
-	return WithExpectedCode(http.StatusLocked, expectErrorContains...)
-}
-
-func Expect400RefIntegrity_Existence() ReqOptFunc {
-	return WithExpectedCode(http.StatusBadRequest, "referential integrity violation", "does not exist")
-}
-
-func Expect400RefIntegrity_QName() ReqOptFunc {
-	return WithExpectedCode(http.StatusBadRequest, "referential integrity violation", "QNames are only allowed")
+func Expect423() ReqOptFunc {
+	return WithExpectedCode(http.StatusLocked)
 }
 
 func Expect429() ReqOptFunc {
 	return WithExpectedCode(http.StatusTooManyRequests)
 }
 
-func Expect500(expectErrorContains ...string) ReqOptFunc {
-	return WithExpectedCode(http.StatusInternalServerError, expectErrorContains...)
+func Expect500() ReqOptFunc {
+	return WithExpectedCode(http.StatusInternalServerError)
 }
 
 func Expect503() ReqOptFunc {
@@ -211,27 +212,28 @@ func Expect410() ReqOptFunc {
 	return WithExpectedCode(http.StatusGone)
 }
 
-func WithOptsValidator(validator func(*reqOpts) (panicMessage string)) ReqOptFunc {
-	return func(opts *reqOpts) {
-		opts.validators = append(opts.validators, validator)
+func WithOptsValidator(validator func(IReqOpts) (panicMessage string)) ReqOptFunc {
+	return func(opts IReqOpts) {
+		opts.httpOpts().validators = append(opts.httpOpts().validators, validator)
 	}
 }
 
 type reqOpts struct {
-	method                string
-	headers               map[string]string
-	cookies               map[string]string
-	expectedHTTPCodes     []int
-	expectedErrorContains []string
-	responseHandler       func(httpResp *http.Response) // used if no errors and an expected status code is received
-	relativeURL           string
-	discardResp           bool
-	bodyReader            io.Reader
-	withoutAuth           bool
-	skipRetryOn503        bool
-	deadlineOn503         time.Duration
-	validators            []func(*reqOpts) (panicMessage string)
-	retryErrsMatchers     []func(err error) (retry bool)
+	method             string
+	headers            map[string]string
+	cookies            map[string]string
+	expectedHTTPCodes  []int
+	responseHandler    func(httpResp *http.Response) // used if no errors and an expected status code is received
+	relativeURL        string
+	discardResp        bool
+	bodyReader         io.Reader
+	withoutAuth        bool
+	skipRetryOn503     bool
+	deadlineOn503      time.Duration
+	customOptsProvider func(IReqOpts) IReqOpts
+	appendedOpts       []ReqOptFunc
+	validators         []func(IReqOpts) (panicMessage string)
+	retryErrsMatchers  []func(err error) (retry bool)
 }
 
 // body and bodyReader are mutual exclusive
@@ -268,12 +270,13 @@ func (c *implIHTTPClient) Req(ctx context.Context, urlStr string, body string, o
 	return c.req(ctx, urlStr, body, optFuncs...)
 }
 
-func mutualExclusiveOptsValidator(opts *reqOpts) (panicMessage string) {
+func mutualExclusiveOptsValidator(opts IReqOpts) (panicMessage string) {
 	mutualExclusiveOpts := 0
-	if opts.discardResp {
+	o := opts.httpOpts()
+	if o.discardResp {
 		mutualExclusiveOpts++
 	}
-	if opts.responseHandler != nil {
+	if o.responseHandler != nil {
 		mutualExclusiveOpts++
 	}
 	if mutualExclusiveOpts > 1 {
@@ -282,19 +285,40 @@ func mutualExclusiveOptsValidator(opts *reqOpts) (panicMessage string) {
 	return ""
 }
 
+func (opts *reqOpts) Append(opt ReqOptFunc) {
+	opts.appendedOpts = append(opts.appendedOpts, opt)
+}
+
+func (opts *reqOpts) ExpectedHTTPCodes() []int {
+	return opts.expectedHTTPCodes
+}
+
+func (opts *reqOpts) httpOpts() *reqOpts {
+	return opts
+}
+
 func (c *implIHTTPClient) req(ctx context.Context, urlStr string, body string, optFuncs ...ReqOptFunc) (*HTTPResponse, error) {
 	opts := &reqOpts{
 		headers: map[string]string{},
 		cookies: map[string]string{},
-		validators: []func(*reqOpts) (panicMessage string){
+		validators: []func(IReqOpts) (panicMessage string){
 			mutualExclusiveOptsValidator,
 		},
 	}
 	for _, defaultOptFunc := range c.defaultOpts {
 		defaultOptFunc(opts)
 	}
+	var iOpts IReqOpts = opts
+	var prevCustomOptsProvider func(IReqOpts) IReqOpts = nil
 	for _, optFunc := range optFuncs {
-		optFunc(opts)
+		optFunc(iOpts)
+		if prevCustomOptsProvider == nil && opts.customOptsProvider != nil {
+			iOpts = opts.customOptsProvider(iOpts)
+			prevCustomOptsProvider = opts.customOptsProvider
+		}
+	}
+	for _, optFunc := range opts.appendedOpts {
+		optFunc(iOpts)
 	}
 	if len(opts.method) == 0 {
 		opts.method = http.MethodGet
@@ -315,6 +339,7 @@ func (c *implIHTTPClient) req(ctx context.Context, urlStr string, body string, o
 		delete(opts.headers, Authorization)
 		delete(opts.cookies, Authorization)
 	}
+
 	for _, v := range opts.validators {
 		if panicMessage := v(opts); len(panicMessage) > 0 {
 			panic(panicMessage)
@@ -368,31 +393,26 @@ func (c *implIHTTPClient) req(ctx context.Context, urlStr string, body string, o
 		return nil, err
 	}
 	httpResponse := &HTTPResponse{
-		HTTPResp:          resp,
-		expectedHTTPCodes: opts.expectedHTTPCodes,
+		HTTPResp: resp,
+		Opts:     iOpts,
 	}
 	if resp.StatusCode == http.StatusOK && isCodeExpected && opts.responseHandler != nil {
 		opts.responseHandler(resp)
 		return httpResponse, nil
 	}
-	respBody, err := readBody(resp)
+	httpResponse.Body, err = readBody(resp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
-	httpResponse.Body = respBody
 	var statusErr error
 	if !isCodeExpected {
-		statusErr = fmt.Errorf("%w: %d, %s", ErrUnexpectedStatusCode, resp.StatusCode, respBody)
+		statusErr = fmt.Errorf("%w: %d, %s", ErrUnexpectedStatusCode, resp.StatusCode, httpResponse.Body)
 	}
 	return httpResponse, statusErr
 }
 
 func (c *implIHTTPClient) CloseIdleConnections() {
 	c.client.CloseIdleConnections()
-}
-
-func (resp *HTTPResponse) ExpectedHTTPCodes() []int {
-	return resp.expectedHTTPCodes
 }
 
 func (resp *HTTPResponse) Println() {
@@ -410,26 +430,6 @@ func (resp *HTTPResponse) PrintJSON() {
 		log.Fatalln(err)
 	}
 	log.Println("\n", string(bb))
-}
-
-func (resp *HTTPResponse) getError(t *testing.T) map[string]interface{} {
-	t.Helper()
-	m := map[string]interface{}{}
-	err := json.Unmarshal([]byte(resp.Body), &m)
-	require.NoError(t, err)
-	return m["sys.Error"].(map[string]interface{})
-}
-
-func (resp *HTTPResponse) RequireError(t *testing.T, message string) {
-	t.Helper()
-	m := resp.getError(t)
-	require.Equal(t, message, m["Message"])
-}
-
-func (resp *HTTPResponse) RequireContainsError(t *testing.T, messagePart string) {
-	t.Helper()
-	m := resp.getError(t)
-	require.Contains(t, m["Message"], messagePart)
 }
 
 func readBody(resp *http.Response) (string, error) {
@@ -498,12 +498,6 @@ var constDefaultOpts = []ReqOptFunc{
 	}),
 }
 
-func WithRetryErrorMatcher(matcher func(err error) (retry bool)) ReqOptFunc {
-	return func(opts *reqOpts) {
-		opts.retryErrsMatchers = append(opts.retryErrsMatchers, matcher)
-	}
-}
-
 func NewIHTTPClient(defaultOpts ...ReqOptFunc) (client IHTTPClient, clenup func()) {
 	// set linger - see https://github.com/voedger/voedger/issues/415
 	tr := http.DefaultTransport.(*http.Transport).Clone()
@@ -524,8 +518,8 @@ func NewIHTTPClient(defaultOpts ...ReqOptFunc) (client IHTTPClient, clenup func(
 	return client, client.CloseIdleConnections
 }
 
-func DenyGETAndDiscardResponse(opts *reqOpts) (panicMessage string) {
-	if opts.discardResp && opts.method == http.MethodGet {
+func DenyGETAndDiscardResponse(opts IReqOpts) (panicMessage string) {
+	if opts.httpOpts().discardResp && opts.httpOpts().method == http.MethodGet {
 		return "WithDiscardResponse is denied on GET method"
 	}
 	return ""

--- a/pkg/coreutils/http.go
+++ b/pkg/coreutils/http.go
@@ -532,6 +532,6 @@ func DenyGETAndDiscardResponse(opts IReqOpts) (panicMessage string) {
 	return ""
 }
 
-func (o reqOpts) shouldHandle503() bool {
-	return !slices.Contains(o.expectedHTTPCodes, http.StatusServiceUnavailable) && !o.skipRetryOn503
+func (opts *reqOpts) shouldHandle503() bool {
+	return !slices.Contains(opts.expectedHTTPCodes, http.StatusServiceUnavailable) && !opts.skipRetryOn503
 }

--- a/pkg/coreutils/http_test.go
+++ b/pkg/coreutils/http_test.go
@@ -301,15 +301,6 @@ func TestHTTPReqWithOptions(t *testing.T) {
 		require.GreaterOrEqual(callCount, 1)
 	})
 
-	t.Run("WithExpectedCode and error message matching", func(t *testing.T) {
-		handler = func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusBadRequest)
-			_, err := w.Write([]byte(`{"sys.Error":{"HTTPStatus":400,"Message":"foo bar error"}}`))
-			require.NoError(err)
-		}
-		_, err := httpClient.Req(context.Background(), url, "body", WithExpectedCode(http.StatusBadRequest, "foo", "bar"))
-		require.NoError(err)
-	})
 
 	t.Run("concurrent requests", func(t *testing.T) {
 		var count int32

--- a/pkg/sys/it/bug_test.go
+++ b/pkg/sys/it/bug_test.go
@@ -123,7 +123,7 @@ func TestWrongFieldReferencedByRefField(t *testing.T) {
 	vit.PostWS(ws, "c.sys.CUD", body).NewID()
 
 	body = `{"args":{"Schema":"app1pkg.cdoc2"},"elements":[{"fields": ["field2","sys.ID"], "refs":[["field2","unexistingFieldInTargetDoc"]]}]}`
-	vit.PostWS(ws, "q.sys.Collection", body, coreutils.Expect400("ref field field2 references to table app1pkg.cdoc1 that does not contain field unexistingFieldInTargetDoc"))
+	vit.PostWS(ws, "q.sys.Collection", body, it.Expect400("ref field field2 references to table app1pkg.cdoc1 that does not contain field unexistingFieldInTargetDoc"))
 }
 
 // https://github.com/voedger/voedger/issues/3046

--- a/pkg/sys/it/impl_blob_test.go
+++ b/pkg/sys/it/impl_blob_test.go
@@ -167,7 +167,7 @@ func TestBlobberErrors(t *testing.T) {
 					coreutils.BlobName, "newBlob",
 					coreutils.ContentType, coreutils.ContentType_ApplicationXBinary,
 				),
-				coreutils.Expect400("blob owner QName unknown.doc is unknown"),
+				it.Expect400("blob owner QName unknown.doc is unknown"),
 			).Println()
 		})
 		t.Run("field", func(t *testing.T) {
@@ -178,7 +178,7 @@ func TestBlobberErrors(t *testing.T) {
 					coreutils.BlobName, "newBlob",
 					coreutils.ContentType, coreutils.ContentType_ApplicationXBinary,
 				),
-				coreutils.Expect400("blob owner field someField does not exist in blob owner app1pkg.DocWithBLOB"),
+				it.Expect400("blob owner field someField does not exist in blob owner app1pkg.DocWithBLOB"),
 			).Println()
 		})
 
@@ -190,7 +190,7 @@ func TestBlobberErrors(t *testing.T) {
 					coreutils.BlobName, "newBlob",
 					coreutils.ContentType, coreutils.ContentType_ApplicationXBinary,
 				),
-				coreutils.Expect400("blob owner app1pkg.DocWithBLOB.IntFld must be of blob type"),
+				it.Expect400("blob owner app1pkg.DocWithBLOB.IntFld must be of blob type"),
 			).Println()
 		})
 	})
@@ -199,14 +199,14 @@ func TestBlobberErrors(t *testing.T) {
 		t.Run("doc", func(t *testing.T) {
 			vit.ReadBLOB(istructs.AppQName_test1_app1, ws.WSID, appdef.NewQName("unknown", "doc"), "Name", 1,
 				coreutils.WithAuthorizeBy(ws.Owner.Token),
-				coreutils.Expect400("document or record unknown.doc is not defined in Workspace «app1pkg.test_wsWS»"),
+				it.Expect400("document or record unknown.doc is not defined in Workspace «app1pkg.test_wsWS»"),
 			)
 		})
 
 		t.Run("id", func(t *testing.T) {
 			vit.ReadBLOB(istructs.AppQName_test1_app1, ws.WSID, it.QNameApp1_CDocCountry, "Name", 1,
 				coreutils.WithAuthorizeBy(ws.Owner.Token),
-				coreutils.Expect404("document app1pkg.Country with ID 1 not found"),
+				it.Expect404("document app1pkg.Country with ID 1 not found"),
 			)
 		})
 
@@ -217,14 +217,14 @@ func TestBlobberErrors(t *testing.T) {
 		t.Run("target field is not set", func(t *testing.T) {
 			vit.ReadBLOB(istructs.AppQName_test1_app1, ws.WSID, it.QNameDocWithBLOB, "Blob", docWithBLOBID_noBLOB,
 				coreutils.WithAuthorizeBy(ws.Owner.Token),
-				coreutils.Expect400("no value for owner field Blob in blob owner doc app1pkg.DocWithBLOB"),
+				it.Expect400("no value for owner field Blob in blob owner doc app1pkg.DocWithBLOB"),
 			)
 		})
 
 		t.Run("non-blob field", func(t *testing.T) {
 			vit.ReadBLOB(istructs.AppQName_test1_app1, ws.WSID, it.QNameDocWithBLOB, "IntFld", docWithBLOBID_noBLOB,
 				coreutils.WithAuthorizeBy(ws.Owner.Token),
-				coreutils.Expect400("owner field app1pkg.DocWithBLOB.IntFld is not of blob type"),
+				it.Expect400("owner field app1pkg.DocWithBLOB.IntFld is not of blob type"),
 			)
 		})
 	})
@@ -234,11 +234,11 @@ func TestBlobberErrors(t *testing.T) {
 			it.QNameDocWithBLOB, it.Field_Blob, coreutils.WithAuthorizeBy(ws.Owner.Token))
 		t.Run("403 forbidden on set blob to another owner record", func(t *testing.T) {
 			body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID": 1,"sys.QName":"app1pkg.air_table_plan","image":%d}}]}`, blobID)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect403("intended for app1pkg.DocWithBLOB.Blob whereas it is being used in app1pkg.air_table_plan.image"))
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect403("intended for app1pkg.DocWithBLOB.Blob whereas it is being used in app1pkg.air_table_plan.image"))
 		})
 		t.Run("403 forbidden on set blob to another owner record field", func(t *testing.T) {
 			body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID": 1,"sys.QName":"app1pkg.DocWithBLOB","AnotherBlob":%d}}]}`, blobID)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect403("intended for app1pkg.DocWithBLOB.Blob whereas it is being used in app1pkg.DocWithBLOB.AnotherBlob"))
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect403("intended for app1pkg.DocWithBLOB.Blob whereas it is being used in app1pkg.DocWithBLOB.AnotherBlob"))
 		})
 
 		t.Run("403 forbidden on use the same BLOB twice in CUDs", func(t *testing.T) {
@@ -246,7 +246,7 @@ func TestBlobberErrors(t *testing.T) {
 				{"fields":{"sys.ID": 1,"sys.QName":"app1pkg.DocWithBLOB","Blob":%[1]d}},
 				{"fields":{"sys.ID": 2,"sys.QName":"app1pkg.DocWithBLOB","Blob":%[1]d}}
 			]}`, blobID)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect403("mentioned in CUD app1pkg.DocWithBLOB.Blob is used already in CUD app1pkg.DocWithBLOB.1"))
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect403("mentioned in CUD app1pkg.DocWithBLOB.Blob is used already in CUD app1pkg.DocWithBLOB.1"))
 		})
 
 		// assign the blob to the owner
@@ -255,7 +255,7 @@ func TestBlobberErrors(t *testing.T) {
 
 		t.Run("403 forbidden on re-use the blob", func(t *testing.T) {
 			body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID": 1,"sys.QName":"app1pkg.DocWithBLOB","Blob":%d}}]}`, blobID)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect403(fmt.Sprintf(" mentioned in CUD app1pkg.DocWithBLOB.Blob is used already in app1pkg.DocWithBLOB.%d.Blob", assignedBLOBOwnerID)))
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect403(fmt.Sprintf(" mentioned in CUD app1pkg.DocWithBLOB.Blob is used already in app1pkg.DocWithBLOB.%d.Blob", assignedBLOBOwnerID)))
 		})
 	})
 

--- a/pkg/sys/it/impl_cpv2_test.go
+++ b/pkg/sys/it/impl_cpv2_test.go
@@ -172,7 +172,7 @@ func TestAuth(t *testing.T) {
 		vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.TestDeniedCDoc", ws.WSID), body,
 			coreutils.WithMethod(http.MethodPost),
 			coreutils.WithAuthorizeBy(ws.Owner.Token),
-			coreutils.Expect403("OperationKind_Insert app1pkg.TestDeniedCDoc: operation forbidden"),
+			it.Expect403("OperationKind_Insert app1pkg.TestDeniedCDoc: operation forbidden"),
 		).Println()
 	})
 
@@ -189,7 +189,7 @@ func TestAuth(t *testing.T) {
 		vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.TestDeniedCDoc/%d", ws.WSID, newIDs["1"]), body,
 			coreutils.WithMethod(http.MethodPatch),
 			coreutils.WithAuthorizeBy(ws.Owner.Token),
-			coreutils.Expect403("OperationKind_Update app1pkg.TestDeniedCDoc: operation forbidden"),
+			it.Expect403("OperationKind_Update app1pkg.TestDeniedCDoc: operation forbidden"),
 		).Println()
 	})
 
@@ -204,7 +204,7 @@ func TestAuth(t *testing.T) {
 		vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.DocDeactivateDenied/%d", ws.WSID, newIDs["1"]), "{}",
 			coreutils.WithMethod(http.MethodDelete),
 			coreutils.WithAuthorizeBy(ws.Owner.Token),
-			coreutils.Expect403("OperationKind_Deactivate app1pkg.DocDeactivateDenied: operation forbidden"),
+			it.Expect403("OperationKind_Deactivate app1pkg.DocDeactivateDenied: operation forbidden"),
 		).Println()
 	})
 
@@ -247,7 +247,7 @@ func TestErrorsCPv2(t *testing.T) {
 		vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.Root/%d", ws.WSID, newIDs["7"]), body,
 			coreutils.WithMethod(http.MethodPatch),
 			coreutils.WithAuthorizeBy(ws.Owner.Token),
-			coreutils.Expect400("sys.ID field is not allowed among fields to update"),
+			it.Expect400("sys.ID field is not allowed among fields to update"),
 		).Println()
 	})
 
@@ -274,7 +274,7 @@ func TestErrorsCPv2(t *testing.T) {
 		vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.Root", ws.WSID), body,
 			coreutils.WithMethod(http.MethodPost),
 			coreutils.WithAuthorizeBy(ws.Owner.Token),
-			coreutils.Expect400(`field "sys.ID" must be json.Number`),
+			it.Expect400(`field "sys.ID" must be json.Number`),
 		).Println()
 	})
 
@@ -283,7 +283,7 @@ func TestErrorsCPv2(t *testing.T) {
 		vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.Root/%d", ws.WSID, newIDs["1"]), body,
 			coreutils.WithMethod(http.MethodDelete),
 			coreutils.WithAuthorizeBy(ws.Owner.Token),
-			coreutils.Expect400("unexpected body is provided on delete"),
+			it.Expect400("unexpected body is provided on delete"),
 		).Println()
 	})
 
@@ -293,7 +293,7 @@ func TestErrorsCPv2(t *testing.T) {
 			vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.category/%d", ws.WSID, newIDs["1"]), body,
 				coreutils.WithMethod(http.MethodPatch),
 				coreutils.WithAuthorizeBy(ws.Owner.Token),
-				coreutils.Expect400(fmt.Sprintf("record id %d leads to app1pkg.Root QName whereas app1pkg.category QName is mentioned in the request", newIDs["1"])),
+				it.Expect400(fmt.Sprintf("record id %d leads to app1pkg.Root QName whereas app1pkg.category QName is mentioned in the request", newIDs["1"])),
 			).Println()
 
 		})
@@ -302,7 +302,7 @@ func TestErrorsCPv2(t *testing.T) {
 			vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.category/%d", ws.WSID, newIDs["1"]), "{}",
 				coreutils.WithMethod(http.MethodDelete),
 				coreutils.WithAuthorizeBy(ws.Owner.Token),
-				coreutils.Expect400(fmt.Sprintf("record id %d leads to app1pkg.Root QName whereas app1pkg.category QName is mentioned in the request", newIDs["1"])),
+				it.Expect400(fmt.Sprintf("record id %d leads to app1pkg.Root QName whereas app1pkg.category QName is mentioned in the request", newIDs["1"])),
 			).Println()
 		})
 	})
@@ -312,14 +312,14 @@ func TestErrorsCPv2(t *testing.T) {
 			vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.odoc1", ws.WSID), "{}",
 				coreutils.WithMethod(http.MethodPost),
 				coreutils.WithAuthorizeBy(ws.Owner.Token),
-				coreutils.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
+				it.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
 			).Println()
 		})
 		t.Run("insert ORecord", func(t *testing.T) {
 			vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.orecord1", ws.WSID), "{}",
 				coreutils.WithMethod(http.MethodPost),
 				coreutils.WithAuthorizeBy(ws.Owner.Token),
-				coreutils.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
+				it.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
 			).Println()
 		})
 
@@ -331,14 +331,14 @@ func TestErrorsCPv2(t *testing.T) {
 				vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.odoc1/%d", ws.WSID, odocID), "{}",
 					coreutils.WithMethod(http.MethodPatch),
 					coreutils.WithAuthorizeBy(ws.Owner.Token),
-					coreutils.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
+					it.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
 				).Println()
 			})
 			t.Run("delete", func(t *testing.T) {
 				vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.odoc1/%d", ws.WSID, odocID), "{}",
 					coreutils.WithMethod(http.MethodDelete),
 					coreutils.WithAuthorizeBy(ws.Owner.Token),
-					coreutils.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
+					it.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
 				).Println()
 			})
 		})
@@ -351,14 +351,14 @@ func TestErrorsCPv2(t *testing.T) {
 				vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.orecord1/%d", ws.WSID, orecordID), "{}",
 					coreutils.WithMethod(http.MethodPatch),
 					coreutils.WithAuthorizeBy(ws.Owner.Token),
-					coreutils.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
+					it.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
 				).Println()
 			})
 			t.Run("delete", func(t *testing.T) {
 				vit.POST(fmt.Sprintf("api/v2/apps/test1/app1/workspaces/%d/docs/app1pkg.orecord1/%d", ws.WSID, orecordID), "{}",
 					coreutils.WithMethod(http.MethodDelete),
 					coreutils.WithAuthorizeBy(ws.Owner.Token),
-					coreutils.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
+					it.Expect405("cannot operate on the ODoc\\ORecord in any way other than through command arguments"),
 				).Println()
 			})
 		})

--- a/pkg/sys/it/impl_cud_test.go
+++ b/pkg/sys/it/impl_cud_test.go
@@ -299,10 +299,10 @@ func TestRefIntegrity(t *testing.T) {
 
 		t.Run("ref to unexisting -> 400 bad request", func(t *testing.T) {
 			body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID": 2,"sys.QName":"app1pkg.cdoc2","field1": %d}}]}`, istructs.NonExistingRecordID)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect400RefIntegrity_Existence())
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect400RefIntegrity_Existence())
 
 			body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID": 2,"sys.QName":"app1pkg.cdoc2","field2": %d}}]}`, istructs.NonExistingRecordID)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect400RefIntegrity_Existence())
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect400RefIntegrity_Existence())
 		})
 
 		t.Run("ref to existing, allowed QName", func(t *testing.T) {
@@ -318,7 +318,7 @@ func TestRefIntegrity(t *testing.T) {
 
 		t.Run("ref to existing wrong QName -> 400 bad request", func(t *testing.T) {
 			body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID": 2,"sys.QName":"app1pkg.cdoc2","field2": %d}}]}`, idOption)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect400RefIntegrity_QName())
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect400RefIntegrity_QName())
 		})
 	})
 
@@ -348,7 +348,7 @@ func testArgsRefIntegrity(t *testing.T, vit *it.VIT, ws *it.AppWorkspace, app ap
 			for _, oDoc1RefField := range oDoc.RefFields() {
 				t.Run(oDoc1RefField.Name(), func(t *testing.T) {
 					body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"%s":%d`, oDoc1RefField.Name(), istructs.NonExistingRecordID))
-					vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, coreutils.Expect400(fmt.Sprintf("record ID %d referenced by app1pkg.odoc2.%s does not exist",
+					vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, it.Expect400(fmt.Sprintf("record ID %d referenced by app1pkg.odoc2.%s does not exist",
 						istructs.NonExistingRecordID, oDoc1RefField.Name()))).Println()
 				})
 			}
@@ -358,7 +358,7 @@ func testArgsRefIntegrity(t *testing.T, vit *it.VIT, ws *it.AppWorkspace, app ap
 			for _, oRecord1RefField := range oRecord.RefFields() {
 				t.Run(oRecord1RefField.Name(), func(t *testing.T) {
 					body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"orecord1":[{"%s":%d,"sys.ID":3,"sys.ParentID":1}]`, oRecord1RefField.Name(), istructs.NonExistingRecordID))
-					vit.PostWS(ws, "c.app1pkg.CmdODocOne", body, coreutils.Expect400(fmt.Sprintf("record ID %d referenced by app1pkg.orecord1.%s does not exist",
+					vit.PostWS(ws, "c.app1pkg.CmdODocOne", body, it.Expect400(fmt.Sprintf("record ID %d referenced by app1pkg.orecord1.%s does not exist",
 						istructs.NonExistingRecordID, oRecord1RefField.Name()))).Println()
 				})
 			}
@@ -374,12 +374,12 @@ func testArgsRefIntegrity(t *testing.T, vit *it.VIT, ws *it.AppWorkspace, app ap
 
 			t.Run("wrong QName CDoc-> 400 bad request", func(t *testing.T) {
 				body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"refToODoc1":%d`, idCDoc))
-				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, coreutils.Expect400RefIntegrity_QName()).Println()
+				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, it.Expect400RefIntegrity_QName()).Println()
 			})
 
 			t.Run("wrong QName ORecord -> 400 bad request", func(t *testing.T) {
 				body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"refToODoc1":%d`, idOrecord1))
-				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, coreutils.Expect400RefIntegrity_QName()).Println()
+				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, it.Expect400RefIntegrity_QName()).Println()
 			})
 		})
 		t.Run("ORecord", func(t *testing.T) {
@@ -395,17 +395,17 @@ func testArgsRefIntegrity(t *testing.T, vit *it.VIT, ws *it.AppWorkspace, app ap
 
 			t.Run("wrong QName CDoc -> 400 bad request", func(t *testing.T) {
 				body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"refToORecord1":%d`, idCDoc))
-				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, coreutils.Expect400RefIntegrity_QName()).Println()
+				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, it.Expect400RefIntegrity_QName()).Println()
 			})
 
 			t.Run("wrong QName ODoc ORecord1 -> 400 bad request", func(t *testing.T) {
 				body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"refToORecord1":%d`, idOdoc1))
-				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, coreutils.Expect400RefIntegrity_QName()).Println()
+				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, it.Expect400RefIntegrity_QName()).Println()
 			})
 
 			t.Run("wrong QName ODoc ORecord2 -> 400 bad request", func(t *testing.T) {
 				body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"refToORecord2":%d`, idOdoc1))
-				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, coreutils.Expect400RefIntegrity_QName()).Println()
+				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, it.Expect400RefIntegrity_QName()).Println()
 			})
 		})
 		t.Run("Any", func(t *testing.T) {
@@ -423,7 +423,7 @@ func testArgsRefIntegrity(t *testing.T, vit *it.VIT, ws *it.AppWorkspace, app ap
 			})
 			t.Run("wrong QName -> 400 bad request", func(t *testing.T) {
 				body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"refToCDoc1":%d`, idOdoc1))
-				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, coreutils.Expect400RefIntegrity_QName())
+				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, it.Expect400RefIntegrity_QName())
 			})
 		})
 
@@ -437,7 +437,7 @@ func testArgsRefIntegrity(t *testing.T, vit *it.VIT, ws *it.AppWorkspace, app ap
 			})
 			t.Run("wrong QName -> 400 bad request", func(t *testing.T) {
 				body := fmt.Sprintf(urlTemplate, fmt.Sprintf(`"refToCDoc1OrODoc1":%d`, idOrecord1))
-				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, coreutils.Expect400RefIntegrity_QName())
+				vit.PostWS(ws, "c.app1pkg.CmdODocTwo", body, it.Expect400RefIntegrity_QName())
 			})
 		})
 	})
@@ -520,7 +520,7 @@ func TestSelectFromNestedTables(t *testing.T) {
 				{"path": "unknownNested","fields": ["FldNested"]},
 				{"path": "Nested/Third","fields": ["Fld1"]}
 			]}`
-			vit.PostWS(ws, "q.sys.Collection", body, coreutils.Expect400("unknown nested table unknownNested"))
+			vit.PostWS(ws, "q.sys.Collection", body, it.Expect400("unknown nested table unknownNested"))
 		})
 		t.Run("3rd level", func(t *testing.T) {
 			body = `{"args":{"Schema":"app1pkg.Root"},"elements": [
@@ -528,14 +528,14 @@ func TestSelectFromNestedTables(t *testing.T) {
 				{"path": "Nested","fields": ["FldNested"]},
 				{"path": "Nested/unknownThird","fields": ["Fld1"]}
 			]}`
-			vit.PostWS(ws, "q.sys.Collection", body, coreutils.Expect400("unknown nested table unknownThird"))
+			vit.PostWS(ws, "q.sys.Collection", body, it.Expect400("unknown nested table unknownThird"))
 
 			body = `{"args":{"Schema":"app1pkg.Root"},"elements": [
 				{"fields": ["FldRoot"]},
 				{"path": "Nested","fields": ["FldNested"]},
 				{"path": "unknownNested/Third","fields": ["Fld1"]}
 			]}`
-			vit.PostWS(ws, "q.sys.Collection", body, coreutils.Expect400("unknown nested table unknownNested"))
+			vit.PostWS(ws, "q.sys.Collection", body, it.Expect400("unknown nested table unknownNested"))
 		})
 	})
 
@@ -546,7 +546,7 @@ func TestSelectFromNestedTables(t *testing.T) {
 				{"path": "Nested","fields": ["unknown"]},
 				{"path": "Nested/Third","fields": ["Fld1"]}
 			]}`
-			vit.PostWS(ws, "q.sys.Collection", body, coreutils.Expect400("'unknown' that is unexpected among fields of app1pkg.Nested"))
+			vit.PostWS(ws, "q.sys.Collection", body, it.Expect400("'unknown' that is unexpected among fields of app1pkg.Nested"))
 		})
 		t.Run("3rd level", func(t *testing.T) {
 			body = `{"args":{"Schema":"app1pkg.Root"},"elements": [
@@ -554,7 +554,7 @@ func TestSelectFromNestedTables(t *testing.T) {
 				{"path": "Nested","fields": ["FldNested"]},
 				{"path": "Nested/Third","fields": ["unknown"]}
 			]}`
-			vit.PostWS(ws, "q.sys.Collection", body, coreutils.Expect400("'unknown' that is unexpected among fields of app1pkg.Third"))
+			vit.PostWS(ws, "q.sys.Collection", body, it.Expect400("'unknown' that is unexpected among fields of app1pkg.Third"))
 		})
 	})
 
@@ -564,14 +564,14 @@ func TestSelectFromNestedTables(t *testing.T) {
 			body = `{"args":{"Schema":"app1pkg.cdoc2"},"elements": [
 				{"path": "field1","fields": ["SomeField"]}
 				]}`
-			vit.PostWS(ws, "q.sys.Collection", body, coreutils.Expect400("unknown nested table field1"))
+			vit.PostWS(ws, "q.sys.Collection", body, it.Expect400("unknown nested table field1"))
 		})
 		t.Run("in nested", func(t *testing.T) {
 			// Root.Nested.Third.Fld1 field exists but is not a nested table
 			body = `{"args":{"Schema":"app1pkg.Root"},"elements": [
 				{"path": "Nested/Third/Fld1","fields": ["SomeField"]}
 			]}`
-			vit.PostWS(ws, "q.sys.Collection", body, coreutils.Expect400("unknown nested table Fld1"))
+			vit.PostWS(ws, "q.sys.Collection", body, it.Expect400("unknown nested table Fld1"))
 		})
 	})
 }
@@ -590,7 +590,7 @@ func TestFieldsAuthorization_OpForbidden(t *testing.T) {
 		id := vit.PostWS(ws, "c.sys.CUD", body).NewID()
 
 		body = fmt.Sprintf(`{"cuds": [{"sys.ID":%d,"fields": {"sys.IsActive":true}}]}`, id)
-		vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect403("cuds[0] OperationKind_Activate", "operation forbidden"))
+		vit.PostWS(ws, "c.sys.CUD", body, it.Expect400("cuds[0] OperationKind_Activate", "operation forbidden"))
 	})
 
 	t.Run("deactivate", func(t *testing.T) {
@@ -598,7 +598,7 @@ func TestFieldsAuthorization_OpForbidden(t *testing.T) {
 		id := vit.PostWS(ws, "c.sys.CUD", body).NewID()
 
 		body = fmt.Sprintf(`{"cuds": [{"sys.ID":%d,"fields": {"sys.IsActive":false}}]}`, id)
-		vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect403("cuds[0] OperationKind_Deactivate", "operation forbidden"))
+		vit.PostWS(ws, "c.sys.CUD", body, it.Expect400("cuds[0] OperationKind_Deactivate", "operation forbidden"))
 	})
 
 	t.Run("field insert", func(t *testing.T) {
@@ -608,7 +608,7 @@ func TestFieldsAuthorization_OpForbidden(t *testing.T) {
 
 		// denied
 		body = `{"cuds": [{"fields": {"sys.ID": 1,"sys.QName": "app1pkg.DocFieldInsertDenied","FldDenied":42}}]}`
-		vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect403("cuds[0] OperationKind_Insert", "operation forbidden"))
+		vit.PostWS(ws, "c.sys.CUD", body, it.Expect400("cuds[0] OperationKind_Insert", "operation forbidden"))
 	})
 
 	t.Run("field update", func(t *testing.T) {
@@ -621,7 +621,7 @@ func TestFieldsAuthorization_OpForbidden(t *testing.T) {
 
 		// denied
 		body = fmt.Sprintf(`{"cuds": [{"sys.ID":%d,"fields": {"FldDenied":46}}]}`, id)
-		vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect403("cuds[0] OperationKind_Update", "operation forbidden"))
+		vit.PostWS(ws, "c.sys.CUD", body, it.Expect400("cuds[0] OperationKind_Update", "operation forbidden"))
 	})
 
 	// note: select authorization is tested in [TestDeniedResourcesAuthorization]
@@ -635,7 +635,7 @@ func TestErrors(t *testing.T) {
 
 	t.Run("no QName on insert -> 400 bad request", func(t *testing.T) {
 		body := `{"cuds": [{"fields": {"sys.ID": 1,"FldAllowed":42}}]}`
-		vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect400("failed to parse sys.QName"))
+		vit.PostWS(ws, "c.sys.CUD", body, it.Expect400("failed to parse sys.QName"))
 	})
 }
 

--- a/pkg/sys/it/impl_httpconventions_test.go
+++ b/pkg/sys/it/impl_httpconventions_test.go
@@ -31,7 +31,6 @@ func TestBasicUsage_HTTPConventions(t *testing.T) {
 	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
 
 	t.Run("query", func(t *testing.T) {
-		t.Skip("waiting for https://github.com/voedger/voedger/issues/4027")
 		body := `{"args": {"Input": "world"},"elements": [{"fields": ["Res"]}]}`
 		resp := vit.PostWS(ws, "q.app1pkg.MockQry", body, coreutils.Expect500())
 		require.Equal("world", resp.SectionRow()[0])

--- a/pkg/sys/it/impl_invite_test.go
+++ b/pkg/sys/it/impl_invite_test.go
@@ -198,7 +198,7 @@ func TestInvite_BasicUsage(t *testing.T) {
 		body := fmt.Sprintf(`{"args":{"Email":"%s","Roles":"%s","ExpireDatetime":%d,"EmailTemplate":"%s","EmailSubject":"%s"}}`,
 			email1, initialRoles, vit.Now().UnixMilli(), inviteEmailTemplate, inviteEmailSubject)
 		vit.PostWS(ws, "c.sys.InitiateInvitationByEMail", body,
-			coreutils.Expect400("re-invite not allowed for state State_Joined"))
+			it.Expect400("re-invite not allowed for state State_Joined"))
 	})
 
 	//Update roles
@@ -291,7 +291,7 @@ func TestCancelSentInvite(t *testing.T) {
 		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeCancelled, invite.State_Cancelled)
 	})
 	t.Run("invite not exists -> 400 bad request", func(t *testing.T) {
-		vit.PostWS(ws, "c.sys.CancelSentInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, istructs.NonExistingRecordID), coreutils.Expect400RefIntegrity_Existence())
+		vit.PostWS(ws, "c.sys.CancelSentInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, istructs.NonExistingRecordID), it.Expect400RefIntegrity_Existence())
 	})
 }
 
@@ -361,7 +361,7 @@ func TestRejectInvitationOnDifferentLogin(t *testing.T) {
 	// simulate accepting invitation by different login
 	differentLogin := vit.GetPrincipal(istructs.AppQName_test1_app1, "login")
 	InitiateJoinWorkspace(vit, ws, inviteID, differentLogin, verificationCode,
-		coreutils.Expect400(fmt.Sprintf("invitation was sent to %s but current login is login", email)))
+		it.Expect400(fmt.Sprintf("invitation was sent to %s but current login is login", email)))
 }
 
 func TestWrongEmail(t *testing.T) {

--- a/pkg/sys/it/impl_n10n_test.go
+++ b/pkg/sys/it/impl_n10n_test.go
@@ -217,7 +217,7 @@ func TestN10NSubscribeErrors(t *testing.T) {
 			t.Run(c.body, func(t *testing.T) {
 				vit.POST("api/v2/apps/test1/app1/notifications", c.body,
 					coreutils.WithAuthorizeBy(ws.Owner.Token),
-					coreutils.Expect400(c.expected),
+					it.Expect400(c.expected),
 				).Println()
 			})
 		}

--- a/pkg/sys/it/impl_qpv2_test.go
+++ b/pkg/sys/it/impl_qpv2_test.go
@@ -887,7 +887,7 @@ func TestQueryProcessor2_Include(t *testing.T) {
 		t.Run("Expected error https://github.com/voedger/voedger/issues/3714", func(t *testing.T) {
 			vit.GET(fmt.Sprintf(`api/v2/apps/test1/app1/workspaces/%d/views/%s?where={"Year":{"$in":[1988]},"Month":{"$in":[1]}}&include=EpicFail`, ws.WSID, it.QNameApp1_ViewClients),
 				coreutils.WithAuthorizeBy(ws.Owner.Token),
-				coreutils.Expect400("field expression - 'EpicFail', 'EpicFail' - unexpected field"),
+				it.Expect400("field expression - 'EpicFail', 'EpicFail' - unexpected field"),
 			)
 		})
 		t.Run("Read by PK, include all and select some fields", func(t *testing.T) {
@@ -2397,7 +2397,7 @@ func TestQueryProcessor2_Docs(t *testing.T) {
 
 	t.Run("404 not found", func(t *testing.T) {
 		path := fmt.Sprintf(`api/v2/apps/test1/app1/workspaces/%d/docs/%s/%d`, ws.WSID, it.QNameApp1_CDocCategory, 123)
-		vit.GET(path, coreutils.WithAuthorizeBy(ws.Owner.Token), coreutils.Expect404("document app1pkg.category with ID 123 not found"))
+		vit.GET(path, coreutils.WithAuthorizeBy(ws.Owner.Token), it.Expect404("document app1pkg.category with ID 123 not found"))
 	})
 }
 

--- a/pkg/sys/it/impl_signupin_test.go
+++ b/pkg/sys/it/impl_signupin_test.go
@@ -110,8 +110,8 @@ func TestCreateLoginErrors(t *testing.T) {
 		body := fmt.Sprintf(`{"args":{"Login":"login1","AppName":"test1/app1","SubjectKind":%d,"WSKindInitializationData":"{}","ProfileCluster":1},"unloggedArgs":{"Password":"password"}}`, istructs.SubjectKind_User)
 		crc16 := coreutils.CRC16([]byte("login1")) - 1 // simulate crc16 is calculated wrong
 		pseudoWSID := istructs.NewWSID(istructs.CurrentClusterID(), istructs.WSID(crc16))
-		resp := vit.PostApp(istructs.AppQName_sys_registry, pseudoWSID, "c.registry.CreateLogin", body, coreutils.Expect403())
-		resp.RequireError(t, "wrong AppWSID: 140737488420870 expected, 140737488420869 got")
+		vit.PostApp(istructs.AppQName_sys_registry, pseudoWSID, "c.registry.CreateLogin", body,
+			it.Expect403("wrong AppWSID: 140737488420870 expected, 140737488420869 got"))
 	})
 
 	login := vit.NextName()
@@ -120,14 +120,14 @@ func TestCreateLoginErrors(t *testing.T) {
 	t.Run("unknown application", func(t *testing.T) {
 		body := fmt.Sprintf(`{"args":{"Login":"%s","AppName":"my/unknown","SubjectKind":%d,"WSKindInitializationData":"{}","ProfileCluster":%d},"unloggedArgs":{"Password":"password"}}`,
 			login, istructs.SubjectKind_User, istructs.CurrentClusterID())
-		vit.PostApp(istructs.AppQName_sys_registry, loginPseudoWSID, "c.registry.CreateLogin", body, coreutils.Expect400("my/unknown is not found"))
+		vit.PostApp(istructs.AppQName_sys_registry, loginPseudoWSID, "c.registry.CreateLogin", body, it.Expect400("my/unknown is not found"))
 	})
 
 	t.Run("wrong application name", func(t *testing.T) {
 		body := fmt.Sprintf(`{"args":{"Login":"%s","AppName":"wrong-AppName","SubjectKind":%d,"WSKindInitializationData":"{}","ProfileCluster":1},"unloggedArgs":{"Password":"different"}}`,
 			login, istructs.SubjectKind_User)
-		resp := vit.PostApp(istructs.AppQName_sys_registry, loginPseudoWSID, "c.registry.CreateLogin", body, coreutils.Expect400())
-		resp.RequireContainsError(t, "failed to parse app qualified name")
+		vit.PostApp(istructs.AppQName_sys_registry, loginPseudoWSID, "c.registry.CreateLogin", body,
+			it.Expect400("failed to parse app qualified name"))
 	})
 
 	newLogin := vit.SignUp(login, "1", istructs.AppQName_test1_app1)
@@ -160,8 +160,8 @@ func TestCreateLoginErrors(t *testing.T) {
 			pseudoWSID := coreutils.GetPseudoWSID(istructs.NullWSID, wrongLogin, istructs.CurrentClusterID())
 			body := fmt.Sprintf(`{"args":{"Login":"%s","AppName":"%s","SubjectKind":%d,"WSKindInitializationData":"{}","ProfileCluster":%d},"unloggedArgs":{"Password":"%s"}}`,
 				wrongLogin, istructs.AppQName_test1_app1.String(), istructs.SubjectKind_User, istructs.CurrentClusterID(), "1")
-			resp := vit.PostApp(istructs.AppQName_sys_registry, pseudoWSID, "c.registry.CreateLogin", body, coreutils.Expect400())
-			resp.RequireContainsError(t, "incorrect login format")
+			vit.PostApp(istructs.AppQName_sys_registry, pseudoWSID, "c.registry.CreateLogin", body,
+				it.Expect400("incorrect login format"))
 		}
 	})
 }
@@ -194,7 +194,7 @@ func TestSignInErrors(t *testing.T) {
 		body := fmt.Sprintf(`{"args": {"Login": "%s","Password": "%s","AppName": "%s", "TTLHours":1000},"elements":[{"fields":["PrincipalToken"]}]}`,
 			prn.Name, prn.Pwd, prn.AppQName.String())
 		vit.PostApp(istructs.AppQName_sys_registry, prn.PseudoProfileWSID, "q.registry.IssuePrincipalToken", body,
-			coreutils.Expect400("max token TTL hours is 168 hours"))
+			it.Expect400("max token TTL hours is 168 hours"))
 	})
 }
 

--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -184,14 +184,12 @@ func TestSqlQuery_plog(t *testing.T) {
 	})
 	t.Run("Should return error when field not found in def", func(t *testing.T) {
 		body := `{"args":{"Query":"select abracadabra from sys.plog"}}`
-		resp := vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "field 'abracadabra' not found in def")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("field 'abracadabra' not found in def"))
 	})
 
 	t.Run("select operation is allowed only", func(t *testing.T) {
 		body := `{"args":{"Query":"update sys.plog set a = 1"}}`
-		vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect400("'select' operation is expected"))
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("'select' operation is expected"))
 	})
 }
 
@@ -253,9 +251,7 @@ func TestSqlQuery_wlog(t *testing.T) {
 	})
 	t.Run("Should return error when field not found in def", func(t *testing.T) {
 		body := `{"args":{"Query":"select abracadabra from sys.wlog"}}`
-		resp := vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "field 'abracadabra' not found in def")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("field 'abracadabra' not found in def"))
 	})
 }
 
@@ -267,45 +263,31 @@ func TestSqlQuery_readLogParams(t *testing.T) {
 
 	t.Run("Should return error when limit value not parsable", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog limit 7.1"}}`
-		resp := vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, `strconv.ParseInt: parsing "7.1": invalid syntax`)
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500(`strconv.ParseInt: parsing "7.1": invalid syntax`))
 	})
 	t.Run("Should return error when limit value invalid", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog limit -3"}}`
-		resp := vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "limit must be greater than -2")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("limit must be greater than -2"))
 	})
 	t.Run("Should return error when Offset value not parsable", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog where Offset >= 2.1"}}`
-		resp := vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, `strconv.ParseUint: parsing "2.1": invalid syntax`)
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500(`strconv.ParseUint: parsing "2.1": invalid syntax`))
 	})
 	t.Run("Should return error when Offset value invalid", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog where Offset >= 0"}}`
-		resp := vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "offset must be greater than zero")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("offset must be greater than zero"))
 	})
 	t.Run("Should return error when Offset operation not supported", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog where Offset < 2"}}`
-		resp := vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "unsupported operation: <")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("unsupported operation: <"))
 	})
 	t.Run("Should return error when column name not supported", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog where something >= 1"}}`
-		resp := vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "unsupported column name: something")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("unsupported column name: something"))
 	})
 	t.Run("Should return error when expression not supported", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.wlog where Offset >= 1 and something >= 5"}}`
-		resp := vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "unsupported expression: *sqlparser.AndExpr")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("unsupported expression: *sqlparser.AndExpr"))
 	})
 }
 
@@ -363,7 +345,7 @@ func TestSqlQuery_records(t *testing.T) {
 
 		for query, expectedError := range cases {
 			t.Run(expectedError, func(t *testing.T) {
-				vit.PostWS(ws, "q.sys.SqlQuery", query, coreutils.Expect400(expectedError))
+				vit.PostWS(ws, "q.sys.SqlQuery", query, it.Expect400(expectedError))
 			})
 		}
 	})
@@ -405,27 +387,19 @@ func TestSqlQuery_view_records(t *testing.T) {
 	})
 	t.Run("Should return error when operator not supported", func(t *testing.T) {
 		body = `{"args":{"Query":"select * from sys.CollectionView where partKey > 1"}}`
-		resp = vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "unsupported operator: >")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("unsupported operator: >"))
 	})
 	t.Run("Should return error when expression not supported", func(t *testing.T) {
 		body = `{"args":{"Query":"select * from sys.CollectionView where partKey = 1 or docQname = 'app1pkg.payments'"}}`
-		resp = vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "unsupported expression: *sqlparser.OrExpr")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("unsupported expression: *sqlparser.OrExpr"))
 	})
 	t.Run("Should return error when field does not exist in value def", func(t *testing.T) {
 		body = `{"args":{"Query":"select abracadabra from sys.CollectionView where PartKey = 1"}}`
-		resp = vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "field 'abracadabra' does not exist in 'sys.CollectionView' value def")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("field 'abracadabra' does not exist in 'sys.CollectionView' value def"))
 	})
 	t.Run("Should return error when field does not exist in key def", func(t *testing.T) {
 		body = `{"args":{"Query":"select * from sys.CollectionView where partKey = 1"}}`
-		resp = vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "field 'partKey' does not exist in 'sys.CollectionView' key def")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("field 'partKey' does not exist in 'sys.CollectionView' key def"))
 	})
 }
 
@@ -437,13 +411,11 @@ func TestSqlQuery(t *testing.T) {
 
 	t.Run("Should return error when script invalid", func(t *testing.T) {
 		body := `{"args":{"Query":" "}}`
-		vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect400("invalid query format"))
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("invalid query format"))
 	})
 	t.Run("Should return error when source of data unsupported", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from git.hub"}}`
-		resp := vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect500())
-
-		resp.RequireError(t, "do not know how to read from the requested git.hub, TypeKind_null")
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("do not know how to read from the requested git.hub, TypeKind_null"))
 	})
 	t.Run("Should read sys.wlog from other workspace", func(t *testing.T) {
 		wsOne := vit.PostWS(ws, "q.sys.SqlQuery", fmt.Sprintf(`{"args":{"Query":"select * from %d.sys.wlog"}}`, ws.Owner.ProfileWSID))
@@ -454,7 +426,7 @@ func TestSqlQuery(t *testing.T) {
 
 	t.Run("403 forbidden on read from non-inited workspace", func(t *testing.T) {
 		vit.PostWS(ws, "q.sys.SqlQuery", fmt.Sprintf(`{"args":{"Query":"select * from %d.sys.wlog"}}`, istructs.NonExistingRecordID),
-			coreutils.Expect403(processors.ErrWSNotInited.Message))
+			it.Expect403(processors.ErrWSNotInited.Message))
 	})
 }
 
@@ -581,7 +553,7 @@ func TestAuthnz(t *testing.T) {
 
 		// allowed, just expect 400 not found
 		body = `{"args":{"Query":"select Fld1 from app1pkg.TestCDocWithDeniedFields.123"},"elements":[{"fields":["Result"]}]}`
-		vit.PostWS(ws, "q.sys.SqlQuery", body, coreutils.Expect400("record with ID '123' not found"))
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("record with ID '123' not found"))
 	})
 }
 

--- a/pkg/sys/it/impl_test.go
+++ b/pkg/sys/it/impl_test.go
@@ -236,20 +236,20 @@ func TestTakeQNamesFromWorkspace(t *testing.T) {
 
 			anotherWS := vit.WS(istructs.AppQName_test1_app1, "test_ws_another")
 			body := fmt.Sprintf(`{"args":{"Arg1":%d}}`, 1)
-			// c.app1pkg.TestCmd is not defined in test_ws_anotherWS workspace -> 400 bad request
-			vit.PostWS(anotherWS, "c.app1pkg.TestCmd", body, coreutils.Expect404("command app1pkg.TestCmd does not exist in workspace app1pkg.test_wsWS_another"))
+			// c.app1pkg.TestCmd is not defined in test_ws_anotherWS workspace -> 404 not found
+			vit.PostWS(anotherWS, "c.app1pkg.TestCmd", body, it.Expect404("command app1pkg.TestCmd does not exist in workspace app1pkg.test_wsWS_another"))
 
 			ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
 			body = "{}"
-			// c.app1pkg.testCmd is defined in test_wsWS workspace -> 400 bad request
-			vit.PostWS(ws, "c.app1pkg.testCmd", body, coreutils.Expect404("command app1pkg.testCmd does not exist in workspace app1pkg.test_wsWS"))
+			// c.app1pkg.testCmd is defined in test_wsWS workspace -> 404 not found
+			vit.PostWS(ws, "c.app1pkg.testCmd", body, it.Expect404("command app1pkg.testCmd does not exist in workspace app1pkg.test_wsWS"))
 		})
 
 		t.Run("type", func(t *testing.T) {
 			ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
 			body := "{}"
 			// c.app1pkg.testCmd is defined in test_wsWS workspace -> 400 bad request
-			vit.PostWS(ws, "c.app1pkg.MockQry", body, coreutils.Expect400("app1pkg.MockQry is not a command"))
+			vit.PostWS(ws, "c.app1pkg.MockQry", body, it.Expect400("app1pkg.MockQry is not a command"))
 		})
 	})
 
@@ -258,12 +258,12 @@ func TestTakeQNamesFromWorkspace(t *testing.T) {
 			anotherWS := vit.WS(istructs.AppQName_test1_app1, "test_ws_another")
 			body := `{"args":{"Input":"str"}}`
 			// q.app1pkg.MockQry is not defined in test_ws_anotherWS workspace -> 400 bad request
-			vit.PostWS(anotherWS, "q.app1pkg.MockQry", body, coreutils.Expect400("query app1pkg.MockQry does not exist in Workspace «app1pkg.test_wsWS_another»"))
+			vit.PostWS(anotherWS, "q.app1pkg.MockQry", body, it.Expect400("query app1pkg.MockQry does not exist in Workspace «app1pkg.test_wsWS_another»"))
 		})
 		t.Run("type", func(t *testing.T) {
 			anotherWS := vit.WS(istructs.AppQName_test1_app1, "test_ws_another")
 			body := fmt.Sprintf(`{"args":{"Arg1":%d}}`, 1)
-			vit.PostWS(anotherWS, "q.app1pkg.testCmd", body, coreutils.Expect400("query app1pkg.testCmd does not exist in Workspace «app1pkg.test_wsWS_another»"))
+			vit.PostWS(anotherWS, "q.app1pkg.testCmd", body, it.Expect400("query app1pkg.testCmd does not exist in Workspace «app1pkg.test_wsWS_another»"))
 		})
 	})
 
@@ -271,7 +271,7 @@ func TestTakeQNamesFromWorkspace(t *testing.T) {
 		t.Run("CUD in the request -> 400 bad request", func(t *testing.T) {
 			anotherWS := vit.WS(istructs.AppQName_test1_app1, "test_ws_another")
 			body := `{"cuds":[{"fields":{"sys.ID": 1,"sys.QName":"app1pkg.options"}}]}`
-			vit.PostWS(anotherWS, "c.sys.CUD", body, coreutils.Expect500("not found", "app1pkg.options", "Workspace «app1pkg.test_wsWS_another»"))
+			vit.PostWS(anotherWS, "c.sys.CUD", body, it.Expect500("not found", "app1pkg.options", "Workspace «app1pkg.test_wsWS_another»"))
 		})
 		t.Run("CUD produced by a command -> 500 internal server error", func(t *testing.T) {
 			it.MockCmdExec = func(input string, args istructs.ExecCommandArgs) error {
@@ -288,7 +288,7 @@ func TestTakeQNamesFromWorkspace(t *testing.T) {
 			}
 			body := `{"args":{"Input":"Str"}}`
 			ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
-			vit.PostWS(ws, "c.app1pkg.MockCmd", body, coreutils.WithExpectedCode(500, "app1pkg.docInAnotherWS qname is not defined in workspace app1pkg.test_ws"))
+			vit.PostWS(ws, "c.app1pkg.MockCmd", body, it.Expect500("app1pkg.docInAnotherWS qname is not defined in workspace app1pkg.test_ws"))
 		})
 	})
 }
@@ -342,11 +342,11 @@ func TestErrorFromResponseIntent(t *testing.T) {
 	body := `{"args":{"StatusCodeToReturn": 555}}`
 
 	t.Run("command", func(t *testing.T) {
-		vit.PostWS(ws, "c.app1pkg.CmdWithResponseIntent", body, coreutils.WithExpectedCode(555, "error from response intent"))
+		vit.PostWS(ws, "c.app1pkg.CmdWithResponseIntent", body, it.WithExpectedCode(555, "error from response intent"))
 	})
 
 	t.Run("query", func(t *testing.T) {
-		vit.PostWS(ws, "q.app1pkg.QryWithResponseIntent", body, coreutils.WithExpectedCode(555, "error from response intent"))
+		vit.PostWS(ws, "q.app1pkg.QryWithResponseIntent", body, it.WithExpectedCode(555, "error from response intent"))
 	})
 }
 
@@ -502,22 +502,22 @@ func TestSysFieldsModification(t *testing.T) {
 	t.Run("deny", func(t *testing.T) {
 		t.Run("sys.ID", func(t *testing.T) {
 			body := fmt.Sprintf(`{"cuds":[{"sys.ID": %d,"fields":{"sys.ID": 90000}}]}`, idDep)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect400("unable to update system field", "sys.ID")).Println()
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect400("unable to update system field", "sys.ID")).Println()
 		})
 
 		t.Run("sys.ParentID", func(t *testing.T) {
 			body := fmt.Sprintf(`{"cuds": [{"sys.ID": %d, "fields": {"sys.ParentID": 90000}}]}`, idDepOpts)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect400("unable to update system field", "sys.ParentID")).Println()
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect400("unable to update system field", "sys.ParentID")).Println()
 		})
 
 		t.Run("sys.Container", func(t *testing.T) {
 			body := fmt.Sprintf(`{"cuds": [{"sys.ID": %d, "fields": {"sys.Container": "department_options_2"}}]}`, idDepOpts)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect400("unable to update system field", "sys.Container")).Println()
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect400("unable to update system field", "sys.Container")).Println()
 		})
 
 		t.Run("sys.QName", func(t *testing.T) {
 			body := fmt.Sprintf(`{"cuds": [{"sys.ID": %d, "fields": {"sys.QName": "app1pkg.department"}}]}`, idDepOpts)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect400("unable to update system field", "sys.QName")).Println()
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect400("unable to update system field", "sys.QName")).Println()
 		})
 	})
 

--- a/pkg/sys/it/impl_uniques_test.go
+++ b/pkg/sys/it/impl_uniques_test.go
@@ -193,7 +193,7 @@ func TestFewUniquesOneDoc(t *testing.T) {
 			newNum, _ = getUniqueNumber(vit)
 			body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.DocConstraintsFewUniques",
 				"Int2":%d,"Str2":"str","Bool2":true}}]}`, newNum)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect409(fmt.Sprintf(`"%s" unique constraint violation`, appdef.UniqueQName(it.QNameApp1_DocConstraintsFewUniques, "01")))).Println()
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect409(fmt.Sprintf(`"%s" unique constraint violation`, appdef.UniqueQName(it.QNameApp1_DocConstraintsFewUniques, "01")))).Println()
 		})
 		t.Run("uniq2", func(t *testing.T) {
 
@@ -209,7 +209,7 @@ func TestFewUniquesOneDoc(t *testing.T) {
 			newNum, _ = getUniqueNumber(vit)
 			body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.DocConstraintsFewUniques",
 				"Int1":%d,"Str1":"str","Bool1":true}}]}`, newNum)
-			vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect409(fmt.Sprintf(`"%s" unique constraint violation`, appdef.UniqueQName(it.QNameApp1_DocConstraintsFewUniques, "uniq1")))).Println()
+			vit.PostWS(ws, "c.sys.CUD", body, it.Expect409(fmt.Sprintf(`"%s" unique constraint violation`, appdef.UniqueQName(it.QNameApp1_DocConstraintsFewUniques, "uniq1")))).Println()
 		})
 	})
 }
@@ -329,7 +329,7 @@ func TestMaxUniqueLen(t *testing.T) {
 	longBytes := make([]byte, bigLen)
 	longBytesBase64 := base64.StdEncoding.EncodeToString(longBytes)
 	body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.DocConstraints","Int":%d,"Str":"%s","Bool":true,"Bytes":"%s"}}]}`, num, longString, longBytesBase64)
-	vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect403(uniques.ErrUniqueValueTooLong.Error())).Println()
+	vit.PostWS(ws, "c.sys.CUD", body, it.Expect403(uniques.ErrUniqueValueTooLong.Error())).Println()
 }
 
 func TestBasicUsage_UNIQUEFIELD(t *testing.T) {
@@ -347,7 +347,7 @@ func TestBasicUsage_UNIQUEFIELD(t *testing.T) {
 	// fire the UNIQUEFIELD violation, avoid UNIQUE (Str) violation
 	_, newBts := getUniqueNumber(vit)
 	body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.DocConstraintsOldAndNewUniques","Int":%d,"Str":"%s"}}]}`, num, newBts)
-	vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect409(it.QNameApp1_DocConstraintsOldAndNewUniques.String()))
+	vit.PostWS(ws, "c.sys.CUD", body, it.Expect409(it.QNameApp1_DocConstraintsOldAndNewUniques.String()))
 
 	t.Run("get record id by uniquefield value", func(t *testing.T) {
 		as, err := vit.BuiltIn(istructs.AppQName_test1_app1)
@@ -451,11 +451,11 @@ func TestNullFields(t *testing.T) {
 
 	// 0 for Int field -> conflict
 	body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.DocConstraints","Int":0,"Str":"str","Bool":true,"Bytes":"%s"}}]}`, bts)
-	vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect409(fmt.Sprintf("unique constraint violation with ID %d", expectedRecID)))
+	vit.PostWS(ws, "c.sys.CUD", body, it.Expect409(fmt.Sprintf("unique constraint violation with ID %d", expectedRecID)))
 
 	// null for Int field -> conflict
 	body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.DocConstraints","Int":null,"Str":"str","Bool":true,"Bytes":"%s"}}]}`, bts)
-	vit.PostWS(ws, "c.sys.CUD", body, coreutils.Expect409(fmt.Sprintf("unique constraint violation with ID %d", expectedRecID)))
+	vit.PostWS(ws, "c.sys.CUD", body, it.Expect409(fmt.Sprintf("unique constraint violation with ID %d", expectedRecID)))
 }
 
 func TestGetRecordIDByUniqueCombination_AllKinds(t *testing.T) {

--- a/pkg/sys/it/impl_verifier_test.go
+++ b/pkg/sys/it/impl_verifier_test.go
@@ -132,7 +132,7 @@ func TestVerifierErrors(t *testing.T) {
 
 	t.Run("error 400 on set the raw value instead of verified value token for the verified field", func(t *testing.T) {
 		body := fmt.Sprintf(`{"cuds": [{"fields": {"sys.ID": 1,"sys.QName": "%s","EmailField": "%s"}}]}`, it.QNameApp1_TestEmailVerificationDoc, it.TestEmail)
-		vit.PostProfile(userPrincipal, "c.sys.CUD", body, coreutils.Expect400("invalid token")).Println()
+		vit.PostProfile(userPrincipal, "c.sys.CUD", body, it.Expect400("invalid token")).Println()
 	})
 
 	// issue a token for email field

--- a/pkg/sys/it/impl_vsqlupdate_test.go
+++ b/pkg/sys/it/impl_vsqlupdate_test.go
@@ -233,7 +233,7 @@ func TestVSqlUpdate_BasicUsage_DirectUpdate_View(t *testing.T) {
 		body = fmt.Sprintf(`{"args": {"Query":"unlogged update test1.app1.%d.app1pkg.CategoryIdx set Name = 'any' where IntFld = 43"}}`, ws.WSID)
 		vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
 			coreutils.WithAuthorizeBy(sysPrn.Token),
-			coreutils.Expect400("Dummy", "is empty"),
+			it.Expect400("field is empty", "Dummy"),
 		)
 	})
 
@@ -241,7 +241,7 @@ func TestVSqlUpdate_BasicUsage_DirectUpdate_View(t *testing.T) {
 		body = fmt.Sprintf(`{"args": {"Query":"unlogged update test1.app1.%d.app1pkg.CategoryIdx set Name = 'any' where IntFld = 1 and Dummy = 1"}}`, ws.WSID)
 		vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
 			coreutils.WithAuthorizeBy(sysPrn.Token),
-			coreutils.Expect400(fmt.Sprint(istructs.ErrRecordNotFound)), // `record not found`
+			it.Expect400(fmt.Sprint(istructs.ErrRecordNotFound)), // `record not found`
 		)
 	})
 
@@ -249,7 +249,7 @@ func TestVSqlUpdate_BasicUsage_DirectUpdate_View(t *testing.T) {
 		body = fmt.Sprintf(`{"args": {"Query":"unlogged update test1.app1.%d.app1pkg.CategoryIdx set unexistingField = 'any' where IntFld = 43 and Dummy = 1"}}`, ws.WSID)
 		vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
 			coreutils.WithAuthorizeBy(sysPrn.Token),
-			coreutils.Expect400(istructsmem.ErrNameNotFoundError.Error(), "app1pkg.CategoryIdx", "unexistingField"),
+			it.Expect400(istructsmem.ErrNameNotFoundError.Error(), "unexistingField", "app1pkg.CategoryIdx"),
 		)
 	})
 }
@@ -296,7 +296,7 @@ func TestVSqlUpdate_BasicUsage_DirectUpdate_Record(t *testing.T) {
 		body = fmt.Sprintf(`{"args": {"Query":"unlogged update test1.app1.%d.app1pkg.category.%d set int_fld1 = 44"}}`, ws.WSID, istructs.NonExistingRecordID)
 		vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
 			coreutils.WithAuthorizeBy(sysPrn.Token),
-			coreutils.Expect400(fmt.Sprintf("record ID %d does not exist", istructs.NonExistingRecordID)),
+			it.Expect400(fmt.Sprintf("record ID %d does not exist", istructs.NonExistingRecordID)),
 		)
 	})
 
@@ -304,7 +304,7 @@ func TestVSqlUpdate_BasicUsage_DirectUpdate_Record(t *testing.T) {
 		body = fmt.Sprintf(`{"args": {"Query":"unlogged update test1.app1.%d.app1pkg.category.%d set unknownField = 44"}}`, ws.WSID, categoryID)
 		vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
 			coreutils.WithAuthorizeBy(sysPrn.Token),
-			coreutils.Expect400(istructsmem.ErrNameNotFoundError.Error(), "app1pkg.category", "unknownField"),
+			it.Expect400(istructsmem.ErrNameNotFoundError.Error(), "unknownField", "app1pkg.category"),
 		)
 	})
 }
@@ -349,7 +349,7 @@ func TestVSqlUpdate_BasicUsage_DirectInsert(t *testing.T) {
 		body := fmt.Sprintf(`{"args": {"Query":"unlogged insert test1.app1.%d.app1pkg.CategoryIdx set Name = 'abc', Val = 123, IntFld = 1"}}`, ws.WSID)
 		vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
 			coreutils.WithAuthorizeBy(sysPrn.Token),
-			coreutils.Expect400("Dummy", "is empty"),
+			it.Expect400("is empty", "Dummy"),
 		)
 	})
 
@@ -362,7 +362,7 @@ func TestVSqlUpdate_BasicUsage_DirectInsert(t *testing.T) {
 		// insert the same again -> 409 conflict
 		vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
 			coreutils.WithAuthorizeBy(sysPrn.Token),
-			coreutils.Expect409("view record already exists"),
+			it.Expect409("view record already exists"),
 		)
 	})
 
@@ -372,7 +372,7 @@ func TestVSqlUpdate_BasicUsage_DirectInsert(t *testing.T) {
 		body := fmt.Sprintf(`{"args": {"Query":"unlogged insert test1.app1.%d.app1pkg.CategoryIdx set Name = '%s', Val = 123, IntFld = %d, Dummy = 1, Unexisting = 42"}}`, ws.WSID, newName, intFld)
 		vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
 			coreutils.WithAuthorizeBy(sysPrn.Token),
-			coreutils.Expect400(istructsmem.ErrNameNotFoundError.Error(), "app1pkg.CategoryIdx", "Unexisting"),
+			it.Expect400(istructsmem.ErrNameNotFoundError.Error(), "Unexisting", "app1pkg.CategoryIdx"),
 		)
 	})
 }
@@ -564,7 +564,7 @@ func TestVSqlUpdateValidateErrors(t *testing.T) {
 			body := fmt.Sprintf(`{"args": {"Query":"%s"}}`, sql)
 			vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
 				coreutils.WithAuthorizeBy(sysPrn.Token),
-				coreutils.Expect400(expectedError),
+				it.Expect400(expectedError),
 			).Println()
 		})
 	}

--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -509,11 +509,11 @@ func (vit *VIT) POST(relativeURL string, body string, opts ...coreutils.ReqOptFu
 	url := vit.URLStr() + "/" + relativeURL
 	httpResp, err := vit.httpClient.Req(context.Background(), url, body, o...)
 	require.NoError(vit.T, err)
-	vit.checkExpecationsInHTTPResp(httpResp)
+	vit.checkExpectationsInHTTPResp(httpResp)
 	return httpResp
 }
 
-func (vit *VIT) checkExpecationsInHTTPResp(httpResp *coreutils.HTTPResponse) {
+func (vit *VIT) checkExpectationsInHTTPResp(httpResp *coreutils.HTTPResponse) {
 	if len(httpResp.Opts.(*vitReqOpts).expectedMessages) == 0 {
 		return
 	}

--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -397,8 +398,9 @@ func (vit *VIT) UploadBLOB(appQName appdef.AppQName, wsid istructs.WSID, name st
 		},
 		ReadCloser: io.NopCloser(bytes.NewReader(content)),
 	}
-
-	blobID, err := vit.IFederation.UploadBLOB(appQName, wsid, blobReader, opts...)
+	o := []coreutils.ReqOptFunc{WithVITOpts()}
+	o = append(o, opts...)
+	blobID, err := vit.IFederation.UploadBLOB(appQName, wsid, blobReader, o...)
 	require.NoError(vit.T, err)
 	return blobID
 }
@@ -432,18 +434,21 @@ func (vit *VIT) UploadTempBLOB(appQName appdef.AppQName, wsid istructs.WSID, nam
 		},
 		ReadCloser: io.NopCloser(bytes.NewReader(content)),
 	}
-	blobSUUID, err := vit.IFederation.UploadTempBLOB(appQName, wsid, blobReader, duration, opts...)
+	o := []coreutils.ReqOptFunc{WithVITOpts()}
+	o = append(o, opts...)
+	blobSUUID, err := vit.IFederation.UploadTempBLOB(appQName, wsid, blobReader, duration, o...)
 	require.NoError(vit.T, err)
 	return blobSUUID
 }
 
 func (vit *VIT) Func(url string, body string, opts ...coreutils.ReqOptFunc) *coreutils.FuncResponse {
 	vit.T.Helper()
-	opts = append(opts, coreutils.WithDefaultMethod(http.MethodPost))
-	httpResp, err := vit.httpClient.Req(context.Background(), vit.URLStr()+"/"+url, body, opts...)
-	require.NoError(vit.T, err)
+	o := []coreutils.ReqOptFunc{WithVITOpts(), coreutils.WithOptsValidator(coreutils.DenyGETAndDiscardResponse), coreutils.WithDefaultMethod(http.MethodPost)}
+	o = append(o, opts...)
+	httpResp, err := vit.httpClient.Req(context.Background(), vit.URLStr()+"/"+url, body, o...)
 	funcResp, err := federation.HTTPRespToFuncResp(httpResp, err)
 	require.NoError(vit.T, err)
+	vit.checkExpectationsInFuncResp(funcResp, httpResp.Opts)
 	return funcResp
 }
 
@@ -452,7 +457,9 @@ func (vit *VIT) Func(url string, body string, opts ...coreutils.ReqOptFunc) *cor
 func (vit *VIT) ReadBLOB(appQName appdef.AppQName, wsid istructs.WSID, ownerRecord appdef.QName, ownerRecordField appdef.FieldName, ownerID istructs.RecordID,
 	optFuncs ...coreutils.ReqOptFunc) iblobstorage.BLOBReader {
 	vit.T.Helper()
-	reader, err := vit.IFederation.ReadBLOB(appQName, wsid, ownerRecord, ownerRecordField, ownerID, optFuncs...)
+	o := []coreutils.ReqOptFunc{WithVITOpts()}
+	o = append(o, optFuncs...)
+	reader, err := vit.IFederation.ReadBLOB(appQName, wsid, ownerRecord, ownerRecordField, ownerID, o...)
 	require.NoError(vit.T, err)
 	vit.registerBLOBReaderCleanup(reader)
 	return reader
@@ -487,29 +494,62 @@ func (vit *VIT) ReadTempBLOB(appQName appdef.AppQName, wsid istructs.WSID, blobS
 
 func (vit *VIT) GET(relativeURL string, opts ...coreutils.ReqOptFunc) *coreutils.HTTPResponse {
 	vit.T.Helper()
-	opts = append(opts, coreutils.WithDefaultMethod(http.MethodGet))
+	o := []coreutils.ReqOptFunc{WithVITOpts(), coreutils.WithOptsValidator(coreutils.DenyGETAndDiscardResponse), coreutils.WithDefaultMethod(http.MethodGet)}
+	o = append(o, opts...)
 	url := vit.URLStr() + "/" + relativeURL
-	res, err := vit.httpClient.Req(context.Background(), url, "", opts...)
+	res, err := vit.httpClient.Req(context.Background(), url, "", o...)
 	require.NoError(vit.T, err)
 	return res
 }
 
 func (vit *VIT) POST(relativeURL string, body string, opts ...coreutils.ReqOptFunc) *coreutils.HTTPResponse {
 	vit.T.Helper()
-	opts = append(opts, coreutils.WithDefaultMethod(http.MethodPost))
+	o := []coreutils.ReqOptFunc{WithVITOpts(), coreutils.WithOptsValidator(coreutils.DenyGETAndDiscardResponse), coreutils.WithDefaultMethod(http.MethodPost)}
+	o = append(o, opts...)
 	url := vit.URLStr() + "/" + relativeURL
-	res, err := vit.httpClient.Req(context.Background(), url, body, opts...)
+	httpResp, err := vit.httpClient.Req(context.Background(), url, body, o...)
 	require.NoError(vit.T, err)
-	return res
+	vit.checkExpecationsInHTTPResp(httpResp)
+	return httpResp
+}
+
+func (vit *VIT) checkExpecationsInHTTPResp(httpResp *coreutils.HTTPResponse) {
+	if len(httpResp.Opts.(*vitReqOpts).expectedMessages) == 0 {
+		return
+	}
+	vit.T.Helper()
+	var funcResponse *coreutils.FuncResponse
+	require.NoError(vit.T, json.Unmarshal([]byte(httpResp.Body), &funcResponse))
+	vit.checkExpectationsInFuncResp(funcResponse, httpResp.Opts)
+}
+
+func (vit *VIT) checkExpectationsInFuncResp(funcResp *coreutils.FuncResponse, opts coreutils.IReqOpts) {
+	if len(opts.(*vitReqOpts).expectedMessages) == 0 {
+		return
+	}
+	if funcResp == nil || funcResp.SysError == nil {
+		vit.T.Fatal("expected error messages", opts.(*vitReqOpts).expectedMessages, "but no response or no error in response")
+	}
+	var sysError coreutils.SysError
+	if !errors.As(funcResp.SysError, &sysError) {
+		require.NoError(vit.T, funcResp.SysError)
+	}
+	index := 0
+	for _, expectedMes := range opts.(*vitReqOpts).expectedMessages {
+		require.Containsf(vit.T, sysError.Message[index:], expectedMes, `actual message "%s", ordered expected %#v`, sysError.Message, opts.(*vitReqOpts).expectedMessages)
+		index = strings.Index(sysError.Message[index:], expectedMes) + len(expectedMes)
+	}
 }
 
 func (vit *VIT) PostApp(appQName appdef.AppQName, wsid istructs.WSID, funcName string, body string, opts ...coreutils.ReqOptFunc) *coreutils.FuncResponse {
 	vit.T.Helper()
 	url := fmt.Sprintf("%s/api/%s/%d/%s", vit.URLStr(), appQName, wsid, funcName)
-	opts = append(opts, coreutils.WithDefaultMethod(http.MethodPost))
-	res, err := vit.httpClient.Req(context.Background(), url, body, opts...)
-	funcResp, err := federation.HTTPRespToFuncResp(res, err)
+	o := []coreutils.ReqOptFunc{WithVITOpts(), coreutils.WithOptsValidator(coreutils.DenyGETAndDiscardResponse), coreutils.WithDefaultMethod(http.MethodPost)}
+	o = append(o, opts...)
+	httpResp, err := vit.httpClient.Req(context.Background(), url, body, o...)
+	funcResp, err := federation.HTTPRespToFuncResp(httpResp, err)
 	require.NoError(vit.T, err)
+	vit.checkExpectationsInFuncResp(funcResp, httpResp.Opts)
 	return funcResp
 }
 

--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -452,7 +452,7 @@ func (vit *VIT) Func(url string, body string, opts ...coreutils.ReqOptFunc) *cor
 	httpResp, err := vit.httpClient.Req(context.Background(), vit.URLStr()+"/"+url, body, o...)
 	funcResp, err := federation.HTTPRespToFuncResp(httpResp, err)
 	require.NoError(vit.T, err)
-	vit.checkExpectationsInFuncResp(funcResp, httpResp.Opts)
+	vit.satisfySysErrorExpectations(funcResp, httpResp.Opts)
 	return funcResp
 }
 
@@ -524,10 +524,10 @@ func (vit *VIT) checkExpectationsInHTTPResp(httpResp *coreutils.HTTPResponse) {
 	vit.T.Helper()
 	var funcResponse *coreutils.FuncResponse
 	require.NoError(vit.T, json.Unmarshal([]byte(httpResp.Body), &funcResponse))
-	vit.checkExpectationsInFuncResp(funcResponse, httpResp.Opts)
+	vit.satisfySysErrorExpectations(funcResponse, httpResp.Opts)
 }
 
-func (vit *VIT) checkExpectationsInFuncResp(funcResp *coreutils.FuncResponse, opts coreutils.IReqOpts) {
+func (vit *VIT) satisfySysErrorExpectations(funcResp *coreutils.FuncResponse, opts coreutils.IReqOpts) {
 	if len(opts.(*vitReqOpts).expectedMessages) == 0 {
 		return
 	}
@@ -553,7 +553,7 @@ func (vit *VIT) PostApp(appQName appdef.AppQName, wsid istructs.WSID, funcName s
 	httpResp, err := vit.httpClient.Req(context.Background(), url, body, o...)
 	funcResp, err := federation.HTTPRespToFuncResp(httpResp, err)
 	require.NoError(vit.T, err)
-	vit.checkExpectationsInFuncResp(funcResp, httpResp.Opts)
+	vit.satisfySysErrorExpectations(funcResp, httpResp.Opts)
 	return funcResp
 }
 

--- a/pkg/vit/impl_reqopts.go
+++ b/pkg/vit/impl_reqopts.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025-present unTill Software Development Group B.V.
+ * @author Denis Gribanov
+ */
+
+package vit
+
+import (
+	"net/http"
+
+	"github.com/voedger/voedger/pkg/coreutils"
+)
+
+type vitReqOpts struct {
+	coreutils.IReqOpts // IReqOpts must be included, not defined as a field
+	expectedMessages []string
+}
+
+// must be the first opt
+func WithVITOpts() coreutils.ReqOptFunc {
+	return coreutils.WithCustomOptsProvider(func(internalOpts coreutils.IReqOpts) (customOpts coreutils.IReqOpts) {
+		return &vitReqOpts{IReqOpts: internalOpts}
+	})
+}
+
+func WithExpectedCode(code int, expectedMessages ...string) coreutils.ReqOptFunc {
+	return func(opts coreutils.IReqOpts) {
+		opts.Append(coreutils.WithExpectedCode(code))
+		opts.(*vitReqOpts).expectedMessages = append(opts.(*vitReqOpts).expectedMessages, expectedMessages...)
+	}
+}
+
+func Expect400RefIntegrity_Existence() coreutils.ReqOptFunc {
+	return func(opts coreutils.IReqOpts) {
+		opts.Append(coreutils.Expect400())
+		opts.(*vitReqOpts).expectedMessages = append(opts.(*vitReqOpts).expectedMessages, "referential integrity violation", "does not exist")
+	}
+}
+
+func Expect400RefIntegrity_QName() coreutils.ReqOptFunc {
+	return func(opts coreutils.IReqOpts) {
+		opts.Append(coreutils.Expect400())
+		opts.(*vitReqOpts).expectedMessages = append(opts.(*vitReqOpts).expectedMessages, "referential integrity violation", "QNames are only allowed")
+	}
+}
+
+func Expect400(expectedMessages ...string) coreutils.ReqOptFunc {
+	return WithExpectedCode(http.StatusBadRequest, expectedMessages...)
+}
+
+func Expect403(expectedMessages ...string) coreutils.ReqOptFunc {
+	return WithExpectedCode(http.StatusForbidden, expectedMessages...)
+}
+
+func Expect404(expectedMessages ...string) coreutils.ReqOptFunc {
+	return WithExpectedCode(http.StatusNotFound, expectedMessages...)
+}
+
+func Expect405(expectedMessages ...string) coreutils.ReqOptFunc {
+	return WithExpectedCode(http.StatusMethodNotAllowed, expectedMessages...)
+}
+
+func Expect409(expectedMessages ...string) coreutils.ReqOptFunc {
+	return WithExpectedCode(http.StatusConflict, expectedMessages...)
+}
+
+func Expect500(expectedMessages ...string) coreutils.ReqOptFunc {
+	return WithExpectedCode(http.StatusInternalServerError, expectedMessages...)
+}


### PR DESCRIPTION
Resolves #4027 abstractions leak: high-level `sys.Error` is checked by low-level `IHTTPClient`