### PR TITLE
get rid of `IsTest()` usage in router on defining the Admin endpoint port

### DIFF
--- a/pkg/coreutils/consts.go
+++ b/pkg/coreutils/consts.go
@@ -27,7 +27,6 @@ const (
 	ContentType_MultipartFormData                = "multipart/form-data"
 	BearerPrefix                                 = "Bearer "
 	BlobName                                     = "Blob-Name"
-	Localhost                                    = "127.0.0.1"
 	CRC16Mask                                    = uint32(math.MaxUint32 >> 16)
 	EmailTemplatePrefix_Text                     = "text:"
 	emailTemplatePrefix_Resource                 = "resource:"

--- a/pkg/coreutils/utils.go
+++ b/pkg/coreutils/utils.go
@@ -43,7 +43,7 @@ func IsDynamoDBStorage() bool {
 func ServerAddress(port int) string {
 	addr := ""
 	if IsTest() {
-		addr = "127.0.0.1"
+		addr = LocalhostIP.String()
 	}
 	return fmt.Sprintf("%s:%d", addr, port)
 }

--- a/pkg/istorage/provider/test_utils.go
+++ b/pkg/istorage/provider/test_utils.go
@@ -7,7 +7,9 @@ package provider
 
 import "github.com/google/uuid"
 
+const testTeyspaceIsloationSuffixLen = 8
+
 func NewTestKeyspaceIsolationSuffix() string {
 	res := uuid.NewString()
-	return res[:8]
+	return res[:testTeyspaceIsloationSuffixLen]
 }

--- a/pkg/processors/blobber/impl_read.go
+++ b/pkg/processors/blobber/impl_read.go
@@ -94,7 +94,7 @@ func downloadBLOBHelper(ctx context.Context, work pipeline.IWorkpiece) (err erro
 		AppQName: bw.blobMessageRead.appQName,
 		Header:   bw.blobMessageRead.header,
 		Body:     []byte(`{}`),
-		Host:     coreutils.Localhost,
+		Host:     coreutils.LocalhostIP.String(),
 		APIPath:  int(processors.APIPath_Queries),
 		IsAPIV2:  true,
 		QName:    downloadPersistentBLOBFuncQName,
@@ -134,7 +134,7 @@ func getBLOBIDFromOwner(_ context.Context, work pipeline.IWorkpiece) (err error)
 		APIPath:  int(processors.APIPath_Docs),
 		DocID:    istructs.IDType(bw.blobMessageRead.ownerID),
 		QName:    bw.blobMessageRead.ownerRecord,
-		Host:     coreutils.Localhost,
+		Host:     coreutils.LocalhostIP.String(),
 		IsAPIV2:  true,
 		Query: map[string]string{
 			"keys": bw.blobMessageRead.ownerRecordField,

--- a/pkg/processors/blobber/impl_write.go
+++ b/pkg/processors/blobber/impl_write.go
@@ -93,7 +93,7 @@ func setBLOBStatusCompleted(ctx context.Context, work pipeline.IWorkpiece) (err 
 		Resource: "c.sys.CUD",
 		Body:     []byte(fmt.Sprintf(`{"cuds":[{"sys.ID": %d,"fields":{"status":%d}}]}`, bw.newBLOBID, iblobstorage.BLOBStatus_Completed)),
 		Header:   bw.blobMessageWrite.header,
-		Host:     coreutils.Localhost,
+		Host:     coreutils.LocalhostIP.String(),
 	}
 	_, _, err = bus.GetCommandResponse(bw.blobMessageWrite.requestCtx, bw.blobMessageWrite.requestSender, req)
 	return err
@@ -107,7 +107,7 @@ func registerBLOB(ctx context.Context, work pipeline.IWorkpiece) (err error) {
 		AppQName: bw.blobMessageWrite.appQName,
 		Header:   bw.blobMessageWrite.header,
 		Body:     []byte(bw.registerFuncBody),
-		Host:     coreutils.Localhost,
+		Host:     coreutils.LocalhostIP.String(),
 		APIPath:  int(processors.APIPath_Commands),
 		QName:    bw.registerFuncName,
 		IsAPIV2:  true,

--- a/pkg/router/consts.go
+++ b/pkg/router/consts.go
@@ -18,7 +18,6 @@ const (
 	DefaultConnectionsLimit         = 10000
 	DefaultRouterReadTimeout        = 15
 	DefaultRouterWriteTimeout       = 15
-	localhost                       = "127.0.0.1"
 	URLPlaceholder_wsid             = "wsid"
 	URLPlaceholder_appOwner         = "appOwner"
 	URLPlaceholder_appName          = "appName"
@@ -42,7 +41,6 @@ const (
 
 var (
 	onRequestCtxClosed func() = nil // used in tests
-	adminEndpoint             = "127.0.0.1:55555"
 )
 
 const (

--- a/pkg/router/provide.go
+++ b/pkg/router/provide.go
@@ -6,6 +6,7 @@
 package router
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
@@ -29,10 +30,7 @@ func Provide(rp RouterParams, broker in10n.IN10nBroker, blobRequestHandler blobp
 	federation federation.IFederation, appTokensFactory payloads.IAppTokensFactory) (httpSrv IHTTPService, acmeSrv IACMEService, adminSrv IAdminService) {
 	httpServ := getHTTPService("HTTP server", coreutils.ServerAddress(rp.Port), rp, broker, blobRequestHandler,
 		requestSender, numsAppsWorkspaces, iTokens, federation, appTokensFactory)
-
-	if coreutils.IsTest() {
-		adminEndpoint = "127.0.0.1:0"
-	}
+	adminEndpoint := fmt.Sprintf("%s:%d", coreutils.LocalhostIP, rp.AdminPort)
 	adminSrv = getHTTPService("Admin HTTP server", adminEndpoint, RouterParams{
 		WriteTimeout:     rp.WriteTimeout,
 		ReadTimeout:      rp.ReadTimeout,

--- a/pkg/router/types.go
+++ b/pkg/router/types.go
@@ -28,6 +28,7 @@ import (
 
 type RouterParams struct {
 	Port                 int
+	AdminPort            int
 	WriteTimeout         int
 	ReadTimeout          int
 	ConnectionsLimit     int

--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -84,6 +84,7 @@ func newVit(t testing.TB, vitCfg *VITConfig, useCas bool, vvmLaunchOnly bool) *V
 	// only dynamic ports are used in tests
 	cfg.VVMPort = 0
 	cfg.MetricsServicePort = 0
+	cfg.AdminPort = 0
 
 	// [~server.design.sequences/tuc.VVMConfig.ConfigureSequencesTrustLevel~impl]
 	cfg.SequencesTrustLevel = isequencer.SequencesTrustLevel_0

--- a/pkg/vvm/consts.go
+++ b/pkg/vvm/consts.go
@@ -30,6 +30,7 @@ const (
 	actualizerFlushInterval                                            = time.Millisecond * 500
 	DefaultLeadershipDurationSeconds                                   = ielections.LeadershipDurationSeconds(20)
 	DefaultLeadershipAcquisitionDuration                               = LeadershipAcquisitionDuration(120 * time.Second)
+	DefaultAdminPort                                                   = 55555
 )
 
 const (

--- a/pkg/vvm/impl_cfg.go
+++ b/pkg/vvm/impl_cfg.go
@@ -58,6 +58,7 @@ func NewVVMDefaultConfig() VVMConfig {
 		SecretsReader: isecretsimpl.ProvideSecretReader(),
 		IP:            coreutils.LocalhostIP,
 		NumVVM:        1,
+		AdminPort:     DefaultAdminPort,
 
 		// [~server.design.sequences/tuc.VVMConfig.ConfigureSequencesTrustLevel~impl]
 		SequencesTrustLevel: isequencer.SequencesTrustLevel_0,

--- a/pkg/vvm/types.go
+++ b/pkg/vvm/types.go
@@ -163,6 +163,7 @@ type VVMConfig struct {
 	DataPath                   string
 	MetricsServicePort         metrics.MetricsServicePort
 	AsyncActualizersRetryDelay actualizers.RetryDelay
+	AdminPort                  int
 
 	// 0 -> dynamic port will be used, new on each vvmIdx
 	// >0 -> vVMPort+vvmIdx will be actually used


### PR DESCRIPTION
Resolves #4068 get rid of `IsTest()` usage in router on defining the Admin endpoint port