### PR TITLE
`FuncResponse.UnmarshalJSON()`: eliminate `HTTPResponse` field check

### DIFF
--- a/pkg/coreutils/types.go
+++ b/pkg/coreutils/types.go
@@ -177,13 +177,6 @@ func (resp *FuncResponse) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if raw, ok := m["HTTPResponse"]; ok && len(raw) > 0 {
-		panic("sd")
-		if err := json.Unmarshal(raw, &resp.HTTPResponse); err != nil {
-			return err
-		}
-	}
-
 	var commandResp CommandResponse
 	if err := commandResp.UnmarshalJSON(data); err != nil {
 		return err

--- a/pkg/coreutils/types.go
+++ b/pkg/coreutils/types.go
@@ -178,6 +178,7 @@ func (resp *FuncResponse) UnmarshalJSON(data []byte) error {
 	}
 
 	if raw, ok := m["HTTPResponse"]; ok && len(raw) > 0 {
+		panic("sd")
 		if err := json.Unmarshal(raw, &resp.HTTPResponse); err != nil {
 			return err
 		}

--- a/pkg/router/impl_test.go
+++ b/pkg/router/impl_test.go
@@ -390,6 +390,7 @@ func TestAdminService(t *testing.T) {
 		}
 		// hostport
 		_, err = net.DialTimeout("tcp", fmt.Sprintf("%v:%d", nonLocalhostIP, router.adminPort()), 1*time.Second)
+		require.Error(err)
 		if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "connection refused") &&
 			!strings.Contains(err.Error(), "i/o timeout") {
 			t.Fatal(err)


### PR DESCRIPTION
Resolves #4074 `FuncResponse.UnmarshalJSON()`: eliminate `HTTPResponse` field check