### PR TITLE
create state options as a ready-to-use struct instead of build from opt funcs

### DIFF
--- a/pkg/iextengine/wazero/impl_test.go
+++ b/pkg/iextengine/wazero/impl_test.go
@@ -150,8 +150,8 @@ func Test_BasicUsage(t *testing.T) {
 	wlogOffsetFunc := func() istructs.Offset { return event.WLogOffset() }
 
 	// Create states for Command processor and Actualizer
-	actualizerState := stateprovide.ProvideAsyncActualizerStateFactory()(context.Background(), appFunc, nil, state.SimpleWSIDFunc(ws), nil, nil, eventFunc, nil, nil, intentsLimit, bundlesLimit)
-	cmdProcState := stateprovide.ProvideCommandProcessorStateFactory()(context.Background(), appFunc, nil, state.SimpleWSIDFunc(ws), nil, cudFunc, nil, nil, intentsLimit, nil, cmdPrepareArgsFunc, argFunc, unloggedArgFunc, wlogOffsetFunc)
+	actualizerState := stateprovide.ProvideAsyncActualizerStateFactory()(context.Background(), appFunc, nil, state.SimpleWSIDFunc(ws), nil, nil, eventFunc, nil, nil, intentsLimit, bundlesLimit, state.NullOpts)
+	cmdProcState := stateprovide.ProvideCommandProcessorStateFactory()(context.Background(), appFunc, nil, state.SimpleWSIDFunc(ws), nil, cudFunc, nil, nil, intentsLimit, nil, cmdPrepareArgsFunc, argFunc, unloggedArgFunc, wlogOffsetFunc, state.NullOpts)
 
 	// Create extension package from WASM
 	ctx := context.Background()
@@ -782,7 +782,7 @@ func Test_WithState(t *testing.T) {
 
 	// build app
 	appFunc := func() istructs.IAppStructs { return app }
-	state := stateprovide.ProvideAsyncActualizerStateFactory()(context.Background(), appFunc, nil, state.SimpleWSIDFunc(ws), nil, nil, nil, nil, nil, intentsLimit, bundlesLimit)
+	state := stateprovide.ProvideAsyncActualizerStateFactory()(context.Background(), appFunc, nil, state.SimpleWSIDFunc(ws), nil, nil, nil, nil, nil, intentsLimit, bundlesLimit, state.NullOpts)
 
 	// build packages
 	moduleURL := testModuleURL("./_testdata/basicusage/pkg.wasm")
@@ -855,7 +855,7 @@ func Test_StatePanic(t *testing.T) {
 			cfg.AddAsyncProjectors(istructs.Projector{Name: dummyProj})
 		})
 	appFunc := func() istructs.IAppStructs { return app }
-	state := stateprovide.ProvideAsyncActualizerStateFactory()(context.Background(), appFunc, nil, state.SimpleWSIDFunc(ws), nil, nil, nil, nil, nil, intentsLimit, bundlesLimit)
+	state := stateprovide.ProvideAsyncActualizerStateFactory()(context.Background(), appFunc, nil, state.SimpleWSIDFunc(ws), nil, nil, nil, nil, nil, intentsLimit, bundlesLimit, state.NullOpts)
 
 	const extname = "wrongFieldName"
 	const undefinedPackage = "undefinedPackage"

--- a/pkg/processors/actualizers/async.go
+++ b/pkg/processors/actualizers/async.go
@@ -186,7 +186,8 @@ func (a *asyncActualizer) init(ctx context.Context) (err error) {
 		a.conf.Federation,
 		a.conf.IntentsLimit,
 		a.conf.BundlesLimit,
-		a.conf.Opts...)
+		a.conf.StateCfg,
+	)
 
 	a.name = fmt.Sprintf("%v [%d]", p.name, a.conf.PartitionID)
 

--- a/pkg/processors/actualizers/impl.go
+++ b/pkg/processors/actualizers/impl.go
@@ -63,7 +63,9 @@ func newSyncBranch(conf SyncActualizerConf, projector istructs.Projector, servic
 		conf.N10nFunc,
 		conf.SecretReader,
 		service.getEvent,
-		conf.IntentsLimit)
+		conf.IntentsLimit,
+		state.NullOpts,
+	)
 	fn = pipeline.ForkBranch(pipeline.NewSyncPipeline(conf.Ctx, pipelineName,
 		pipeline.WireFunc("Projector",
 			func(ctx context.Context, work pipeline.IWorkpiece) error {

--- a/pkg/processors/actualizers/interface.go
+++ b/pkg/processors/actualizers/interface.go
@@ -34,7 +34,7 @@ type BasicAsyncActualizerConfig struct {
 	Broker       in10n.IN10nBroker
 	Federation   federation.IFederation
 
-	Opts []state.StateOptFunc
+	StateCfg state.StateConfig
 
 	// Optional. Default value: `core-logger.Error`
 	LogError LogErrorFunc

--- a/pkg/processors/command/types.go
+++ b/pkg/processors/command/types.go
@@ -145,7 +145,7 @@ func newHostStateProvider(ctx context.Context, secretReader isecrets.ISecretRead
 	p := &hostStateProvider{}
 	p.state = stateprovide.ProvideCommandProcessorStateFactory()(ctx, p.getAppStructs, p.getPartititonID,
 		p.getWSID, secretReader, p.getCUD, p.getPrincipals, p.getToken, actualizers.DefaultIntentsLimit,
-		p.getCmdResultBuilder, p.getCmdPrepareArgs, p.getArgs, p.getUnloggedArgs, p.getWLogOffset)
+		p.getCmdResultBuilder, p.getCmdPrepareArgs, p.getArgs, p.getUnloggedArgs, p.getWLogOffset, state.NullOpts)
 	return p
 }
 

--- a/pkg/processors/query/impl.go
+++ b/pkg/processors/query/impl.go
@@ -322,6 +322,7 @@ func newQueryProcessorPipeline(requestCtx context.Context, authn iauthnz.IAuthen
 				func() istructs.ExecQueryCallback {
 					return qw.callbackFunc
 				},
+				state.NullOpts,
 			)
 			qw.execQueryArgs.State = qw.state
 			qw.execQueryArgs.Intents = qw.state

--- a/pkg/processors/query2/impl.go
+++ b/pkg/processors/query2/impl.go
@@ -268,6 +268,7 @@ func newQueryProcessorPipeline(requestCtx context.Context, authn iauthnz.IAuthen
 				func() istructs.ExecQueryCallback {
 					return qw.callbackFunc
 				},
+				state.NullOpts,
 			)
 			qw.execQueryArgs.State = qw.state
 			qw.execQueryArgs.Intents = qw.state

--- a/pkg/processors/schedulers/impl_scheduler.go
+++ b/pkg/processors/schedulers/impl_scheduler.go
@@ -104,7 +104,7 @@ func (a *scheduler) runJob() {
 		a.conf.Federation,
 		func() int64 { return a.conf.Time.Now().Unix() },
 		a.conf.IntentsLimit,
-		a.conf.Opts...)
+		a.conf.stateCfg)
 
 	if err = borrowedPartition.Invoke(a.ctx, a.job, state, state); err != nil {
 		return

--- a/pkg/processors/schedulers/interface.go
+++ b/pkg/processors/schedulers/interface.go
@@ -33,7 +33,7 @@ type BasicSchedulerConfig struct {
 	Federation   federation.IFederation
 	Time         timeu.ITime
 
-	Opts []state.StateOptFunc
+	stateCfg state.StateConfig
 
 	// Optional. Default value: `core-logger.Error`
 	LogError LogErrorFunc

--- a/pkg/state/consts.go
+++ b/pkg/state/consts.go
@@ -53,6 +53,8 @@ var (
 
 	// Deprecated: use sys.Storage_Uniq instead
 	Uniq = sys.Storage_Uniq
+
+	NullOpts = StateConfig{}
 )
 
 const (

--- a/pkg/state/stateprovide/impl_async_actualizer_state.go
+++ b/pkg/state/stateprovide/impl_async_actualizer_state.go
@@ -28,12 +28,7 @@ func (s *asyncActualizerState) PLogEvent() istructs.IPLogEvent {
 
 func implProvideAsyncActualizerState(ctx context.Context, appStructsFunc state.AppStructsFunc, partitionIDFunc state.PartitionIDFunc, wsidFunc state.WSIDFunc, n10nFunc state.N10nFunc,
 	secretReader isecrets.ISecretReader, eventFunc state.PLogEventFunc, tokensFunc itokens.ITokens, federationFunc federation.IFederation,
-	intentsLimit, bundlesLimit int, optFuncs ...state.StateOptFunc) state.IBundledHostState {
-
-	opts := &state.StateOpts{}
-	for _, optFunc := range optFuncs {
-		optFunc(opts)
-	}
+	intentsLimit, bundlesLimit int, stateCfg state.StateConfig) state.IBundledHostState {
 
 	state := &asyncActualizerState{
 		bundledHostState: &bundledHostState{
@@ -52,12 +47,12 @@ func implProvideAsyncActualizerState(ctx context.Context, appStructsFunc state.A
 	state.addStorage(sys.Storage_Record, storages.NewRecordsStorage(appStructsFunc, wsidFunc, nil), S_GET|S_GET_BATCH)
 	state.addStorage(sys.Storage_Event, storages.NewEventStorage(eventFunc), S_GET)
 	state.addStorage(sys.Storage_WLog, storages.NewWLogStorage(ctx, ieventsFunc, wsidFunc), S_GET|S_READ)
-	state.addStorage(sys.Storage_SendMail, storages.NewSendMailStorage(opts.MessagesSenderOverride), S_GET|S_INSERT)
-	state.addStorage(sys.Storage_HTTP, storages.NewHTTPStorage(opts.CustomHTTPClient), S_READ)
-	state.addStorage(sys.Storage_FederationCommand, storages.NewFederationCommandStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, opts.FederationCommandHandler), S_GET)
-	state.addStorage(sys.Storage_FederationBlob, storages.NewFederationBlobStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, opts.FederationBlobHandler), S_READ)
+	state.addStorage(sys.Storage_SendMail, storages.NewSendMailStorage(stateCfg.MessagesSenderOverride), S_GET|S_INSERT)
+	state.addStorage(sys.Storage_HTTP, storages.NewHTTPStorage(stateCfg.CustomHTTPClient), S_READ)
+	state.addStorage(sys.Storage_FederationCommand, storages.NewFederationCommandStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, stateCfg.FederationCommandHandler), S_GET)
+	state.addStorage(sys.Storage_FederationBlob, storages.NewFederationBlobStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, stateCfg.FederationBlobHandler), S_READ)
 	state.addStorage(sys.Storage_AppSecret, storages.NewAppSecretsStorage(secretReader), S_GET)
-	state.addStorage(sys.Storage_Uniq, storages.NewUniquesStorage(appStructsFunc, wsidFunc, opts.UniquesHandler), S_GET)
+	state.addStorage(sys.Storage_Uniq, storages.NewUniquesStorage(appStructsFunc, wsidFunc, stateCfg.UniquesHandler), S_GET)
 	state.addStorage(sys.Storage_Logger, storages.NewLoggerStorage(), S_INSERT)
 
 	return state

--- a/pkg/state/stateprovide/impl_bundled_host_state_test.go
+++ b/pkg/state/stateprovide/impl_bundled_host_state_test.go
@@ -24,7 +24,7 @@ func TestBundledHostState_BasicUsage(t *testing.T) {
 	n10nFn := func(view appdef.QName, wsid istructs.WSID, offset istructs.Offset) {}
 
 	// Create instance of async actualizer state
-	aaState := factory(context.Background(), mockedAppStructs, nil, state.SimpleWSIDFunc(istructs.WSID(1)), n10nFn, nil, nil, nil, nil, 2, 1)
+	aaState := factory(context.Background(), mockedAppStructs, nil, state.SimpleWSIDFunc(istructs.WSID(1)), n10nFn, nil, nil, nil, nil, 2, 1, state.NullOpts)
 
 	// Declare simple extension
 	extension := func(s istructs.IState, intents istructs.IIntents) {
@@ -397,7 +397,7 @@ func TestAsyncActualizerState_Read(t *testing.T) {
 				_ = args.Get(3).(istructs.ValuesCallback)(&nilKey{}, &nilValue{})
 			})
 
-		s := ProvideAsyncActualizerStateFactory()(context.Background(), func() istructs.IAppStructs { return mockedStructs }, nil, state.SimpleWSIDFunc(istructs.WSID(1)), nil, nil, nil, nil, nil, 10, 10)
+		s := ProvideAsyncActualizerStateFactory()(context.Background(), func() istructs.IAppStructs { return mockedStructs }, nil, state.SimpleWSIDFunc(istructs.WSID(1)), nil, nil, nil, nil, nil, 10, 10, state.NullOpts)
 		kb1, err := s.KeyBuilder(sys.Storage_View, testViewRecordQName1)
 		require.NoError(err)
 		kb2, err := s.KeyBuilder(sys.Storage_View, testViewRecordQName2)
@@ -427,7 +427,7 @@ func TestAsyncActualizerState_Read(t *testing.T) {
 			On("NewValueBuilder", testViewRecordQName1).Return(&nilValueBuilder{}).
 			On("NewValueBuilder", testViewRecordQName2).Return(&nilValueBuilder{}).
 			On("PutBatch", istructs.WSID(1), mock.AnythingOfType("[]istructs.ViewKV")).Return(errTest)
-		s := ProvideAsyncActualizerStateFactory()(context.Background(), func() istructs.IAppStructs { return mockedStructs }, nil, state.SimpleWSIDFunc(istructs.WSID(1)), nil, nil, nil, nil, nil, 10, 10)
+		s := ProvideAsyncActualizerStateFactory()(context.Background(), func() istructs.IAppStructs { return mockedStructs }, nil, state.SimpleWSIDFunc(istructs.WSID(1)), nil, nil, nil, nil, nil, 10, 10, state.NullOpts)
 		kb1, err := s.KeyBuilder(sys.Storage_View, testViewRecordQName1)
 		require.NoError(err)
 		kb2, err := s.KeyBuilder(sys.Storage_View, testViewRecordQName2)
@@ -450,7 +450,7 @@ func TestAsyncActualizerState_Read(t *testing.T) {
 	})
 }
 func asyncActualizerStateWithTestStateStorage(s *mockStorage) istructs.IState {
-	as := ProvideAsyncActualizerStateFactory()(context.Background(), nilAppStructsFunc, nil, nil, nil, nil, nil, nil, nil, 10, 10)
+	as := ProvideAsyncActualizerStateFactory()(context.Background(), nilAppStructsFunc, nil, nil, nil, nil, nil, nil, nil, 10, 10, state.NullOpts)
 	as.(*asyncActualizerState).addStorage(testStorage, s, S_GET_BATCH|S_READ)
 	return as
 }

--- a/pkg/state/stateprovide/impl_command_processor_state.go
+++ b/pkg/state/stateprovide/impl_command_processor_state.go
@@ -38,12 +38,7 @@ func implProvideCommandProcessorState(
 	argFunc state.ArgFunc,
 	unloggedArgFunc state.UnloggedArgFunc,
 	wlogOffsetFunc state.WLogOffsetFunc,
-	options ...state.StateOptFunc) state.IHostState {
-
-	opts := &state.StateOpts{}
-	for _, optFunc := range options {
-		optFunc(opts)
-	}
+	stateCfg state.StateConfig) state.IHostState {
 
 	state := &commandProcessorState{
 		hostState:          newHostState("CommandProcessor", intentsLimit, appStructsFunc),
@@ -60,7 +55,7 @@ func implProvideCommandProcessorState(
 	state.addStorage(sys.Storage_AppSecret, storages.NewAppSecretsStorage(secretReader), S_GET)
 	state.addStorage(sys.Storage_RequestSubject, storages.NewSubjectStorage(principalsFunc, tokenFunc), S_GET)
 	state.addStorage(sys.Storage_Result, storages.NewResultStorage(cmdResultBuilderFunc), S_INSERT)
-	state.addStorage(sys.Storage_Uniq, storages.NewUniquesStorage(appStructsFunc, wsidFunc, opts.UniquesHandler), S_GET)
+	state.addStorage(sys.Storage_Uniq, storages.NewUniquesStorage(appStructsFunc, wsidFunc, stateCfg.UniquesHandler), S_GET)
 	state.addStorage(sys.Storage_Response, storages.NewResponseStorage(), S_INSERT)
 	state.addStorage(sys.Storage_CommandContext, storages.NewCommandContextStorage(argFunc, unloggedArgFunc, wsidFunc, wlogOffsetFunc), S_GET)
 	state.addStorage(sys.Storage_Logger, storages.NewLoggerStorage(), S_INSERT)

--- a/pkg/state/stateprovide/impl_host_state_test.go
+++ b/pkg/state/stateprovide/impl_host_state_test.go
@@ -23,7 +23,7 @@ func TestHostState_BasicUsage(t *testing.T) {
 	require := require.New(t)
 
 	factory := ProvideQueryProcessorStateFactory()
-	hostState := factory(context.Background(), mockedHostStateStructs, nil, state.SimpleWSIDFunc(istructs.WSID(1)), nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	hostState := factory(context.Background(), mockedHostStateStructs, nil, state.SimpleWSIDFunc(istructs.WSID(1)), nil, nil, nil, nil, nil, nil, nil, nil, nil, state.NullOpts)
 
 	// Declare simple extension
 	extension := func(state istructs.IState) {
@@ -629,7 +629,7 @@ func hostStateForTest(s state.IStateStorage) state.IHostState {
 	return hs
 }
 func emptyHostStateForTest(s state.IStateStorage) (istructs.IState, istructs.IIntents) {
-	bs := ProvideQueryProcessorStateFactory()(context.Background(), nilAppStructsFunc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).(*queryProcessorState)
+	bs := ProvideQueryProcessorStateFactory()(context.Background(), nilAppStructsFunc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, state.NullOpts).(*queryProcessorState)
 	bs.addStorage(testStorage, s, math.MinInt)
 	return bs, bs
 }

--- a/pkg/state/stateprovide/impl_query_processor_state.go
+++ b/pkg/state/stateprovide/impl_query_processor_state.go
@@ -85,12 +85,7 @@ func implProvideQueryProcessorState(
 	resultBuilderFunc state.ObjectBuilderFunc,
 	federation federation.IFederation,
 	queryCallbackFunc state.ExecQueryCallbackFunc,
-	options ...state.StateOptFunc) state.IHostState {
-
-	opts := &state.StateOpts{}
-	for _, optFunc := range options {
-		optFunc(opts)
-	}
+	stateCfg state.StateConfig) state.IHostState {
 
 	state := &queryProcessorState{
 		hostState:     newHostState("QueryProcessor", queryProcessorStateMaxIntents, appStructsFunc),
@@ -105,15 +100,15 @@ func implProvideQueryProcessorState(
 	state.addStorage(sys.Storage_View, storages.NewViewRecordsStorage(ctx, appStructsFunc, wsidFunc, nil), S_GET|S_GET_BATCH|S_READ)
 	state.addStorage(sys.Storage_Record, storages.NewRecordsStorage(appStructsFunc, wsidFunc, nil), S_GET|S_GET_BATCH)
 	state.addStorage(sys.Storage_WLog, storages.NewWLogStorage(ctx, ieventsFunc, wsidFunc), S_GET|S_READ)
-	state.addStorage(sys.Storage_HTTP, storages.NewHTTPStorage(opts.CustomHTTPClient), S_READ)
-	state.addStorage(sys.Storage_FederationCommand, storages.NewFederationCommandStorage(appStructsFunc, wsidFunc, federation, itokens, opts.FederationCommandHandler), S_GET)
-	state.addStorage(sys.Storage_FederationBlob, storages.NewFederationBlobStorage(appStructsFunc, wsidFunc, federation, itokens, opts.FederationBlobHandler), S_READ)
+	state.addStorage(sys.Storage_HTTP, storages.NewHTTPStorage(stateCfg.CustomHTTPClient), S_READ)
+	state.addStorage(sys.Storage_FederationCommand, storages.NewFederationCommandStorage(appStructsFunc, wsidFunc, federation, itokens, stateCfg.FederationCommandHandler), S_GET)
+	state.addStorage(sys.Storage_FederationBlob, storages.NewFederationBlobStorage(appStructsFunc, wsidFunc, federation, itokens, stateCfg.FederationBlobHandler), S_READ)
 	state.addStorage(sys.Storage_AppSecret, storages.NewAppSecretsStorage(secretReader), S_GET)
 	state.addStorage(sys.Storage_RequestSubject, storages.NewSubjectStorage(principalsFunc, tokenFunc), S_GET)
 	state.addStorage(sys.Storage_QueryContext, storages.NewQueryContextStorage(argFunc, wsidFunc), S_GET)
 	state.addStorage(sys.Storage_Response, storages.NewResponseStorage(), S_INSERT)
 	state.addStorage(sys.Storage_Result, storages.NewResultStorage(resultBuilderFunc), S_INSERT)
-	state.addStorage(sys.Storage_Uniq, storages.NewUniquesStorage(appStructsFunc, wsidFunc, opts.UniquesHandler), S_GET)
+	state.addStorage(sys.Storage_Uniq, storages.NewUniquesStorage(appStructsFunc, wsidFunc, stateCfg.UniquesHandler), S_GET)
 	state.addStorage(sys.Storage_Logger, storages.NewLoggerStorage(), S_INSERT)
 
 	return state

--- a/pkg/state/stateprovide/impl_query_processor_state_test.go
+++ b/pkg/state/stateprovide/impl_query_processor_state_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/state"
 	"github.com/voedger/voedger/pkg/sys"
 )
 
@@ -27,7 +28,7 @@ func TestQueryProcessorState(t *testing.T) {
 		}
 	}
 
-	qps := ProvideQueryProcessorStateFactory()(context.Background(), nil, nil, nil, nil, nil, nil, nil, nil, nil, istructs.NewNullObjectBuilder, nil, execQueryCallbackFunc)
+	qps := ProvideQueryProcessorStateFactory()(context.Background(), nil, nil, nil, nil, nil, nil, nil, nil, nil, istructs.NewNullObjectBuilder, nil, execQueryCallbackFunc, state.StateConfig{})
 	kb, err := qps.KeyBuilder(sys.Storage_Result, appdef.NullQName)
 	require.NoError(err)
 	require.NotNil(kb)

--- a/pkg/state/stateprovide/impl_scheduler_state.go
+++ b/pkg/state/stateprovide/impl_scheduler_state.go
@@ -23,12 +23,7 @@ type schedulerState struct {
 
 func implProvideSchedulerState(ctx context.Context, appStructsFunc state.AppStructsFunc, wsidFunc state.WSIDFunc, n10nFunc state.N10nFunc,
 	secretReader isecrets.ISecretReader, tokensFunc itokens.ITokens, federationFunc federation.IFederation, unixTimeFunc state.UnixTimeFunc,
-	intentsLimit int, optFuncs ...state.StateOptFunc) state.IHostState {
-
-	opts := &state.StateOpts{}
-	for _, optFunc := range optFuncs {
-		optFunc(opts)
-	}
+	intentsLimit int, stateCfg state.StateConfig) state.IHostState {
 
 	state := &schedulerState{
 		hostState: newHostState("Scheduler", intentsLimit, appStructsFunc),
@@ -41,12 +36,12 @@ func implProvideSchedulerState(ctx context.Context, appStructsFunc state.AppStru
 	state.addStorage(sys.Storage_View, storages.NewViewRecordsStorage(ctx, appStructsFunc, wsidFunc, n10nFunc), S_GET|S_GET_BATCH|S_READ|S_INSERT|S_UPDATE)
 	state.addStorage(sys.Storage_Record, storages.NewRecordsStorage(appStructsFunc, wsidFunc, nil), S_GET|S_GET_BATCH)
 	state.addStorage(sys.Storage_WLog, storages.NewWLogStorage(ctx, ieventsFunc, wsidFunc), S_GET|S_READ)
-	state.addStorage(sys.Storage_SendMail, storages.NewSendMailStorage(opts.MessagesSenderOverride), S_GET|S_INSERT)
-	state.addStorage(sys.Storage_HTTP, storages.NewHTTPStorage(opts.CustomHTTPClient), S_READ)
-	state.addStorage(sys.Storage_FederationCommand, storages.NewFederationCommandStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, opts.FederationCommandHandler), S_GET)
-	state.addStorage(sys.Storage_FederationBlob, storages.NewFederationBlobStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, opts.FederationBlobHandler), S_READ)
+	state.addStorage(sys.Storage_SendMail, storages.NewSendMailStorage(stateCfg.MessagesSenderOverride), S_GET|S_INSERT)
+	state.addStorage(sys.Storage_HTTP, storages.NewHTTPStorage(stateCfg.CustomHTTPClient), S_READ)
+	state.addStorage(sys.Storage_FederationCommand, storages.NewFederationCommandStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, stateCfg.FederationCommandHandler), S_GET)
+	state.addStorage(sys.Storage_FederationBlob, storages.NewFederationBlobStorage(appStructsFunc, wsidFunc, federationFunc, tokensFunc, stateCfg.FederationBlobHandler), S_READ)
 	state.addStorage(sys.Storage_AppSecret, storages.NewAppSecretsStorage(secretReader), S_GET)
-	state.addStorage(sys.Storage_Uniq, storages.NewUniquesStorage(appStructsFunc, wsidFunc, opts.UniquesHandler), S_GET)
+	state.addStorage(sys.Storage_Uniq, storages.NewUniquesStorage(appStructsFunc, wsidFunc, stateCfg.UniquesHandler), S_GET)
 	state.addStorage(sys.Storage_JobContext, storages.NewJobContextStorage(wsidFunc, unixTimeFunc), S_GET)
 	state.addStorage(sys.Storage_Logger, storages.NewLoggerStorage(), S_INSERT)
 

--- a/pkg/state/stateprovide/impl_sync_actualizer_state.go
+++ b/pkg/state/stateprovide/impl_sync_actualizer_state.go
@@ -24,11 +24,7 @@ func (s *syncActualizerState) PLogEvent() istructs.IPLogEvent {
 }
 
 func implProvideSyncActualizerState(ctx context.Context, appStructsFunc state.AppStructsFunc, partitionIDFunc state.PartitionIDFunc,
-	wsidFunc state.WSIDFunc, n10nFunc state.N10nFunc, secretReader isecrets.ISecretReader, eventFunc state.PLogEventFunc, intentsLimit int, options ...state.StateOptFunc) state.IHostState {
-	opts := &state.StateOpts{}
-	for _, optFunc := range options {
-		optFunc(opts)
-	}
+	wsidFunc state.WSIDFunc, n10nFunc state.N10nFunc, secretReader isecrets.ISecretReader, eventFunc state.PLogEventFunc, intentsLimit int, stateCfg state.StateConfig) state.IHostState {
 	hs := &syncActualizerState{
 		hostState: newHostState("SyncActualizer", intentsLimit, appStructsFunc),
 		eventFunc: eventFunc,
@@ -40,7 +36,7 @@ func implProvideSyncActualizerState(ctx context.Context, appStructsFunc state.Ap
 	hs.addStorage(sys.Storage_Record, storages.NewRecordsStorage(appStructsFunc, wsidFunc, nil), S_GET|S_GET_BATCH)
 	hs.addStorage(sys.Storage_WLog, storages.NewWLogStorage(ctx, ieventsFunc, wsidFunc), S_GET)
 	hs.addStorage(sys.Storage_AppSecret, storages.NewAppSecretsStorage(secretReader), S_GET)
-	hs.addStorage(sys.Storage_Uniq, storages.NewUniquesStorage(appStructsFunc, wsidFunc, opts.UniquesHandler), S_GET)
+	hs.addStorage(sys.Storage_Uniq, storages.NewUniquesStorage(appStructsFunc, wsidFunc, stateCfg.UniquesHandler), S_GET)
 	hs.addStorage(sys.Storage_Logger, storages.NewLoggerStorage(), S_INSERT)
 	return hs
 }

--- a/pkg/state/teststate/impl.go
+++ b/pkg/state/teststate/impl.go
@@ -294,15 +294,29 @@ func (ts *testState) buildState(processorKind int) {
 
 	switch processorKind {
 	case ProcKind_Actualizer:
+		state := state.StateConfig{
+			CustomHTTPClient:         ts,
+			FederationCommandHandler: ts.emulateFederationCmd,
+			UniquesHandler:           ts.emulateUniquesHandler,
+			FederationBlobHandler:    ts.emulateFederationBlob,
+		}
 		ts.IState = stateprovide.ProvideAsyncActualizerStateFactory()(ts.ctx, appFunc, partitionIDFunc, wsidFunc, nil, ts.secretReader, eventFunc, nil, nil,
-			IntentsLimit, BundlesLimit, state.WithCustomHTTPClient(ts), state.WithFedearationCommandHandler(ts.emulateFederationCmd), state.WithUniquesHandler(ts.emulateUniquesHandler), state.WithFederationBlobHandler(ts.emulateFederationBlob))
+			IntentsLimit, BundlesLimit, state)
 	case ProcKind_CommandProcessor:
+		state := state.StateConfig{
+			UniquesHandler: ts.emulateUniquesHandler,
+		}
 		ts.IState = stateprovide.ProvideCommandProcessorStateFactory()(ts.ctx, appFunc, partitionIDFunc, wsidFunc, ts.secretReader, cudFunc, principalsFunc, tokenFunc,
-			IntentsLimit, resultBuilderFunc, commandPrepareArgs, argFunc, unloggedArgFunc, wlogOffsetFunc, state.WithUniquesHandler(ts.emulateUniquesHandler))
+			IntentsLimit, resultBuilderFunc, commandPrepareArgs, argFunc, unloggedArgFunc, wlogOffsetFunc, state)
 	case ProcKind_QueryProcessor:
+		state := state.StateConfig{
+			CustomHTTPClient:         ts,
+			FederationCommandHandler: ts.emulateFederationCmd,
+			UniquesHandler:           ts.emulateUniquesHandler,
+			FederationBlobHandler:    ts.emulateFederationBlob,
+		}
 		ts.IState = stateprovide.ProvideQueryProcessorStateFactory()(ts.ctx, appFunc, partitionIDFunc, wsidFunc, ts.secretReader, principalsFunc, tokenFunc, nil,
-			execQueryArgsFunc, argFunc, qryResultBuilderFunc, nil, execQueryCallback,
-			state.WithCustomHTTPClient(ts), state.WithFedearationCommandHandler(ts.emulateFederationCmd), state.WithUniquesHandler(ts.emulateUniquesHandler), state.WithFederationBlobHandler(ts.emulateFederationBlob))
+			execQueryArgsFunc, argFunc, qryResultBuilderFunc, nil, execQueryCallback, state)
 	}
 }
 

--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -95,7 +95,7 @@ func newVit(t testing.TB, vitCfg *VITConfig, useCas bool, vvmLaunchOnly bool) *V
 	cfg.AsyncActualizersRetryDelay = actualizers.RetryDelay(100 * time.Millisecond)
 
 	emailMessagesChan := make(chan smtptest.Message, 1) // must be buffered
-	cfg.ActualizerStateOpts = append(cfg.ActualizerStateOpts, state.WithEmailSenderOverride(emailMessagesChan))
+	cfg.ActualizerStateConfig = state.StateConfig{MessagesSenderOverride: emailMessagesChan}
 
 	cfg.KeyspaceIsolationSuffix = provider.NewTestKeyspaceIsolationSuffix()
 

--- a/pkg/vit/impl_test.go
+++ b/pkg/vit/impl_test.go
@@ -242,7 +242,7 @@ func TestEmailExpectation(t *testing.T) {
 
 	// provide VIT email sending chan to the IBundledHostState, then use it to send an email
 	s := stateprovide.ProvideAsyncActualizerStateFactory()(context.Background(), func() istructs.IAppStructs { return &nilAppStructs{} }, nil, nil, nil, nil, nil, nil, nil, 1, 0,
-		state.WithEmailSenderOverride(vit.emailCaptor))
+		state.StateConfig{MessagesSenderOverride: vit.emailCaptor})
 	k, err := s.KeyBuilder(sys.Storage_SendMail, appdef.NullQName)
 	require.NoError(err)
 

--- a/pkg/vvm/provide.go
+++ b/pkg/vvm/provide.go
@@ -238,7 +238,7 @@ func wireVVM(vvmCtx context.Context, vvmConfig *VVMConfig) (*VVM, func(), error)
 			"SendTimeout",
 			"VVMPort",
 			"MetricsServicePort",
-			"ActualizerStateOpts",
+			"ActualizerStateConfig",
 			"SecretsReader",
 			"SequencesTrustLevel",
 			"AsyncActualizersRetryDelay",
@@ -319,7 +319,7 @@ func provideBasicAsyncActualizerConfig(
 	broker in10n.IN10nBroker,
 	federation federation.IFederation,
 	asyncActualizersRetryDelay actualizers.RetryDelay,
-	opts ...state.StateOptFunc,
+	stateCfg state.StateConfig,
 
 ) actualizers.BasicAsyncActualizerConfig {
 	return actualizers.BasicAsyncActualizerConfig{
@@ -329,7 +329,7 @@ func provideBasicAsyncActualizerConfig(
 		Metrics:       metrics,
 		Broker:        broker,
 		Federation:    federation,
-		Opts:          opts,
+		StateCfg:      stateCfg,
 		IntentsLimit:  actualizers.DefaultIntentsLimit,
 		FlushInterval: actualizerFlushInterval,
 		RetryDelay:    asyncActualizersRetryDelay,

--- a/pkg/vvm/types.go
+++ b/pkg/vvm/types.go
@@ -51,7 +51,7 @@ type OperatorBLOBProcessors pipeline.ISyncOperator
 type OperatorQueryProcessor pipeline.ISyncOperator
 type AppPartitionFactory func(ctx context.Context, appQName appdef.AppQName, asyncProjectors istructs.Projectors, partitionID istructs.PartitionID) pipeline.ISyncOperator
 type AsyncActualizersFactory func(ctx context.Context, appQName appdef.AppQName, asyncProjectors istructs.Projectors, partitionID istructs.PartitionID,
-	tokens itokens.ITokens, federation federation.IFederation, opts []state.StateOptFunc) pipeline.ISyncOperator
+	tokens itokens.ITokens, federation federation.IFederation, stateCfg state.StateConfig) pipeline.ISyncOperator
 type OperatorAppServicesFactory func(ctx context.Context) pipeline.ISyncOperator
 type CommandChannelFactory func(channelIdx uint) commandprocessor.CommandChannel
 type QueryChannel_V1 iprocbus.ServiceChannel
@@ -156,7 +156,7 @@ type VVMConfig struct {
 	MaxPrepareQueries          MaxPrepareQueriesType
 	StorageCacheSize           StorageCacheSizeType
 	processorsChannels         []ProcesorChannel
-	ActualizerStateOpts        []state.StateOptFunc
+	ActualizerStateConfig      state.StateConfig
 	SecretsReader              isecrets.ISecretReader
 	SMTPConfig                 smtp.Cfg
 	WSPostInitFunc             workspace.WSPostInitFunc


### PR DESCRIPTION
Resolves #4087 create state options as a ready-to-use struct instead of build from options