### PR TITLE
goutils/strconvu: implement and use `ParseUint`, eliminate unclear `BitSize64` and `DecimalBase` consts

### DIFF
--- a/pkg/appdef/utils_field.go
+++ b/pkg/appdef/utils_field.go
@@ -58,7 +58,7 @@ func (k *VerificationKind) UnmarshalJSON(data []byte) (err error) {
 		}
 	}
 
-	uint8Val, err := strconvu.StringToUint8(text)
+	uint8Val, err := strconvu.ParseUint8(text)
 	if err == nil {
 		*k = VerificationKind(uint8Val)
 	}

--- a/pkg/coreutils/federation/utils.go
+++ b/pkg/coreutils/federation/utils.go
@@ -13,14 +13,13 @@ import (
 	"fmt"
 	"io"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/in10n"
 	"github.com/voedger/voedger/pkg/istructs"
 )
@@ -61,7 +60,7 @@ func ListenSSEEvents(ctx context.Context, body io.Reader) (offsetsChan OffsetsCh
 				channelID = in10n.ChannelID(data)
 				close(subscribed)
 			} else {
-				offset, err := strconv.ParseUint(data, utils.DecimalBase, utils.BitSize64)
+				offset, err := strconvu.ParseUint64(data)
 				if err != nil {
 					// notest
 					panic(fmt.Sprint("failed to parse offset", data, err))

--- a/pkg/coreutils/utils/consts.go
+++ b/pkg/coreutils/utils/consts.go
@@ -6,8 +6,6 @@
 package utils
 
 const (
-	DecimalBase = 10
-	BitSize64   = 64
-	Uint64Size  = 8
-	Uint32Size  = 4
+	Uint64Size = 8
+	Uint32Size = 4
 )

--- a/pkg/dml/impl.go
+++ b/pkg/dml/impl.go
@@ -8,12 +8,11 @@ package dml
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/istructs"
 )
 
@@ -66,7 +65,7 @@ func ParseQuery(query string) (op Op, err error) {
 
 	if offsetStr := parts[offsetOrIDIdx]; len(offsetStr) > 0 {
 		offsetStr = offsetStr[1:]
-		offsetUint, err := strconv.ParseUint(offsetStr, utils.DecimalBase, utils.BitSize64)
+		offsetUint, err := strconvu.ParseUint64(offsetStr)
 		if err != nil {
 			return op, err
 		}
@@ -115,14 +114,14 @@ func parseWorkspace(workspaceStr string) (workspace Workspace, err error) {
 	switch workspaceStr[:1] {
 	case "a":
 		appWSNumStr := workspaceStr[1:]
-		workspace.ID, err = strconv.ParseUint(appWSNumStr, utils.DecimalBase, utils.BitSize64)
+		workspace.ID, err = strconvu.ParseUint64(appWSNumStr)
 		workspace.Kind = WorkspaceKind_AppWSNum
 	case `"`:
 		login := workspaceStr[1 : len(workspaceStr)-1]
 		workspace.ID = uint64(coreutils.GetPseudoWSID(istructs.NullWSID, login, istructs.CurrentClusterID()))
 		workspace.Kind = WorkspaceKind_PseudoWSID
 	default:
-		workspace.ID, err = strconv.ParseUint(workspaceStr, utils.DecimalBase, utils.BitSize64)
+		workspace.ID, err = strconvu.ParseUint64(workspaceStr)
 		workspace.Kind = WorkspaceKind_WSID
 	}
 	return workspace, err

--- a/pkg/goutils/strconvu/README.md
+++ b/pkg/goutils/strconvu/README.md
@@ -4,20 +4,26 @@ Type-safe string conversion utilities for Go integer types using generics.
 
 ## Problem
 
-Standard library string conversions require explicit type casting and 
+Standard library string conversions require explicit type casting and
 lack compile-time type safety for custom integer types.
 
 ## Features
 
-- **[UintToString](impl.go#L14)** - Generic unsigned integer to string conversion
-  - [Generic type constraints: impl.go#L14](impl.go#L14)
-  - [Decimal base formatting: impl.go#L15](impl.go#L15)
-- **[IntToString](impl.go#L18)** - Generic signed integer to string conversion
-  - [Generic type constraints: impl.go#L18](impl.go#L18)
-  - [Decimal base formatting: impl.go#L19](impl.go#L19)
-- **[StringToUint8](impl.go#L22)** - String to uint8 with range validation
-  - [Range validation logic: impl.go#L27](impl.go#L27)
-  - [Error handling strategy: impl.go#L28](impl.go#L28)
+- **[UintToString](impl.go#L12)** - Generic unsigned integer to string conversion
+  - [Generic type constraints: impl.go#L12](impl.go#L12)
+  - [Decimal base formatting: impl.go#L13](impl.go#L13)
+- **[IntToString](impl.go#L16)** - Generic signed integer to string conversion
+  - [Generic type constraints: impl.go#L16](impl.go#L16)
+  - [Decimal base formatting: impl.go#L17](impl.go#L17)
+- **[ParseUint8](impl.go#L20)** - String to uint8 parsing
+  - [Decimal base parsing: impl.go#L21](impl.go#L21)
+  - [8-bit size constraint: impl.go#L21](impl.go#L21)
+- **[ParseUint64](impl.go#L25)** - String to uint64 parsing
+  - [Decimal base parsing: impl.go#L26](impl.go#L26)
+  - [64-bit size constraint: impl.go#L26](impl.go#L26)
+- **[ParseInt64](impl.go#L29)** - String to int64 parsing
+  - [Decimal base parsing: impl.go#L30](impl.go#L30)
+  - [64-bit size constraint: impl.go#L30](impl.go#L30)
 
 ## Use
 

--- a/pkg/goutils/strconvu/consts.go
+++ b/pkg/goutils/strconvu/consts.go
@@ -5,4 +5,8 @@
 
 package strconvu
 
-const decimalBase = 10
+const (
+	decimalBase = 10
+	bitSize64   = 64
+	bitSize8    = 8
+)

--- a/pkg/goutils/strconvu/example_test.go
+++ b/pkg/goutils/strconvu/example_test.go
@@ -94,29 +94,29 @@ func ExampleIntToString() {
 	// CustomInt64: 2000
 }
 
-// ExampleStringToUint8 demonstrates converting strings to uint8 with validation
-func ExampleStringToUint8() {
+// ExampleParseUint8 demonstrates converting strings to uint8 with validation
+func ExampleParseUint8() {
 	// Valid conversions
 	validStrings := []string{"0", "1", "127", "255"}
 
 	for _, s := range validStrings {
-		if value, err := StringToUint8(s); err == nil {
+		if value, err := ParseUint8(s); err == nil {
 			fmt.Printf("'%s' -> %d\n", s, value)
 		}
 	}
 
 	// Invalid conversions - negative numbers
-	if _, err := StringToUint8("-1"); err != nil {
+	if _, err := ParseUint8("-1"); err != nil {
 		fmt.Println("Error for '-1':", err)
 	}
 
 	// Invalid conversions - out of range
-	if _, err := StringToUint8("256"); err != nil {
+	if _, err := ParseUint8("256"); err != nil {
 		fmt.Println("Error for '256':", err)
 	}
 
 	// Invalid conversions - non-numeric
-	if _, err := StringToUint8("abc"); err != nil {
+	if _, err := ParseUint8("abc"); err != nil {
 		fmt.Println("Error for 'abc':", err)
 	}
 
@@ -125,7 +125,91 @@ func ExampleStringToUint8() {
 	// '1' -> 1
 	// '127' -> 127
 	// '255' -> 255
-	// Error for '-1': out of range: value must be between 0 and 255
-	// Error for '256': out of range: value must be between 0 and 255
-	// Error for 'abc': strconv.Atoi: parsing "abc": invalid syntax
+	// Error for '-1': strconv.ParseUint: parsing "-1": invalid syntax
+	// Error for '256': strconv.ParseUint: parsing "256": value out of range
+	// Error for 'abc': strconv.ParseUint: parsing "abc": invalid syntax
+}
+
+// ExampleParseUint64 demonstrates converting strings to uint64
+func ExampleParseUint64() {
+	// Valid conversions
+	validStrings := []string{"0", "1", "2423423424234", "255"}
+
+	for _, s := range validStrings {
+		if value, err := ParseUint64(s); err == nil {
+			fmt.Printf("'%s' -> %d\n", s, value)
+		}
+	}
+
+	// Invalid conversions - negative numbers
+	if _, err := ParseUint64("-1"); err != nil {
+		fmt.Println("Error for '-1':", err)
+	}
+
+	// Invalid conversions - out of range
+	if _, err := ParseUint64("18446744073709551616"); err != nil {
+		fmt.Println("Error for '18446744073709551616':", err)
+	}
+
+	// Invalid conversions - non-numeric
+	if _, err := ParseUint64("abc"); err != nil {
+		fmt.Println("Error for 'abc':", err)
+	}
+
+	// Output:
+	// '0' -> 0
+	// '1' -> 1
+	// '2423423424234' -> 2423423424234
+	// '255' -> 255
+	// Error for '-1': strconv.ParseUint: parsing "-1": invalid syntax
+	// Error for '18446744073709551616': strconv.ParseUint: parsing "18446744073709551616": value out of range
+	// Error for 'abc': strconv.ParseUint: parsing "abc": invalid syntax
+}
+
+// ExampleParseInt64 demonstrates converting strings to int64
+func ExampleParseInt64() {
+	// Valid conversions - positive numbers
+	validPositive := []string{"0", "1", "9223372036854775807", "42"}
+
+	for _, s := range validPositive {
+		if value, err := ParseInt64(s); err == nil {
+			fmt.Printf("'%s' -> %d\n", s, value)
+		}
+	}
+
+	// Valid conversions - negative numbers
+	validNegative := []string{"-1", "-9223372036854775808", "-42"}
+
+	for _, s := range validNegative {
+		if value, err := ParseInt64(s); err == nil {
+			fmt.Printf("'%s' -> %d\n", s, value)
+		}
+	}
+
+	// Invalid conversions - out of range (too large)
+	if _, err := ParseInt64("9223372036854775808"); err != nil {
+		fmt.Println("Error for '9223372036854775808':", err)
+	}
+
+	// Invalid conversions - out of range (too small)
+	if _, err := ParseInt64("-9223372036854775809"); err != nil {
+		fmt.Println("Error for '-9223372036854775809':", err)
+	}
+
+	// Invalid conversions - non-numeric
+	if _, err := ParseInt64("abc"); err != nil {
+		fmt.Println("Error for 'abc':", err)
+	}
+
+	// Output:
+	// '0' -> 0
+	// '1' -> 1
+	// '9223372036854775807' -> 9223372036854775807
+	// '42' -> 42
+	// '-1' -> -1
+	// '-9223372036854775808' -> -9223372036854775808
+	// '-42' -> -42
+	// Error for '9223372036854775808': strconv.ParseInt: parsing "9223372036854775808": value out of range
+	// Error for '-9223372036854775809': strconv.ParseInt: parsing "-9223372036854775809": value out of range
+	// Error for 'abc': strconv.ParseInt: parsing "abc": invalid syntax
 }

--- a/pkg/goutils/strconvu/impl.go
+++ b/pkg/goutils/strconvu/impl.go
@@ -6,8 +6,6 @@
 package strconvu
 
 import (
-	"errors"
-	"math"
 	"strconv"
 )
 
@@ -19,13 +17,15 @@ func IntToString[T ~int | ~int8 | ~int16 | ~int32 | ~int64](n T) string {
 	return strconv.FormatInt(int64(n), decimalBase)
 }
 
-func StringToUint8(s string) (uint8, error) {
-	value, err := strconv.Atoi(s)
-	if err != nil {
-		return 0, err
-	}
-	if value < 0 || value > math.MaxUint8 {
-		return 0, errors.New("out of range: value must be between 0 and 255")
-	}
-	return uint8(value), nil
+func ParseUint8(s string) (uint8, error) {
+	uint64Val, err := strconv.ParseUint(s, decimalBase, bitSize8)
+	return uint8(uint64Val), err
+}
+
+func ParseUint64(s string) (uint64, error) {
+	return strconv.ParseUint(s, decimalBase, bitSize64)
+}
+
+func ParseInt64(s string) (int64, error) {
+	return strconv.ParseInt(s, decimalBase, bitSize64)
 }

--- a/pkg/goutils/strconvu/impl_test.go
+++ b/pkg/goutils/strconvu/impl_test.go
@@ -25,7 +25,7 @@ func TestStringToUint8_edgeCases(t *testing.T) {
 			{"007", 7},
 		}
 		for _, c := range cases {
-			actual, err := StringToUint8(c.str)
+			actual, err := ParseUint8(c.str)
 			require.NoError(err)
 			require.Equal(c.expected, actual)
 		}
@@ -37,7 +37,7 @@ func TestStringToUint8_edgeCases(t *testing.T) {
 			"",
 		}
 		for _, c := range cases {
-			actual, err := StringToUint8(c)
+			actual, err := ParseUint8(c)
 			require.Error(err)
 			require.Zero(actual)
 		}

--- a/pkg/istorage/amazondb/impl.go
+++ b/pkg/istorage/amazondb/impl.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -18,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
-	"github.com/voedger/voedger/pkg/coreutils/utils"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istorage"
 )
@@ -174,7 +173,7 @@ func (s *implIAppStorage) QueryTTL(pKey []byte, cCols []byte) (ttlInSeconds int,
 	}
 
 	// Parse expireAt timestamp
-	expireAtInSeconds, err := strconv.ParseInt(expireAtStr, utils.DecimalBase, utils.BitSize64)
+	expireAtInSeconds, err := strconvu.ParseInt64(expireAtStr)
 	if err != nil {
 		return 0, false, err
 	}
@@ -368,7 +367,7 @@ func (s *implIAppStorage) put(pKey []byte, cCols []byte, value []byte, ttlSecond
 
 	if ttlSeconds > 0 {
 		putItemParams.Item[expireAtAttributeName] = &types.AttributeValueMemberN{
-			Value: strconv.FormatInt(s.iTime.Now().Add(time.Duration(ttlSeconds)*time.Second).Unix(), utils.DecimalBase),
+			Value: strconvu.IntToString(s.iTime.Now().Add(time.Duration(ttlSeconds) * time.Second).Unix()),
 		}
 	}
 	_, err = s.client.PutItem(context.Background(), &putItemParams)
@@ -536,7 +535,7 @@ func isExpired(expireAtValue types.AttributeValue, now time.Time) bool {
 		return false
 	}
 
-	expireAtInSeconds, err := strconv.ParseInt(expireAtValue.(*types.AttributeValueMemberN).Value, utils.DecimalBase, utils.BitSize64)
+	expireAtInSeconds, err := strconvu.ParseInt64(expireAtValue.(*types.AttributeValueMemberN).Value)
 	if err != nil {
 		return false
 	}

--- a/pkg/processors/blobber/impl_read.go
+++ b/pkg/processors/blobber/impl_read.go
@@ -10,11 +10,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/voedger/voedger/pkg/bus"
 	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/goutils/strconvu"
@@ -29,7 +27,7 @@ import (
 func getBLOBKeyRead(ctx context.Context, work pipeline.IWorkpiece) (err error) {
 	bw := work.(*blobWorkpiece)
 	if bw.isPersistent() {
-		existingBLOBIDUint, err := strconv.ParseUint(bw.blobMessageRead.existingBLOBIDOrSUUID, utils.DecimalBase, utils.BitSize64)
+		existingBLOBIDUint, err := strconvu.ParseUint64(bw.blobMessageRead.existingBLOBIDOrSUUID)
 		if err != nil {
 			// validated already by router
 			// notest

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -19,9 +18,9 @@ import (
 	"github.com/voedger/voedger/pkg/bus"
 	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/coreutils/federation"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/iblobstorage"
 	"github.com/voedger/voedger/pkg/in10n"
 	"github.com/voedger/voedger/pkg/istructs"
@@ -481,7 +480,7 @@ func requestHandlerV2_blobs_read(blobRequestHandler blobprocessor.IRequestHandle
 		vars := mux.Vars(req)
 		ownerRecord := appdef.NewQName(vars[URLPlaceholder_pkg], vars[URLPlaceholder_table])
 		ownerRecordField := vars[URLPlaceholder_field]
-		ownerID, err := strconv.ParseUint(vars[URLPlaceholder_id], utils.DecimalBase, utils.BitSize64)
+		ownerID, err := strconvu.ParseUint64(vars[URLPlaceholder_id])
 		if err != nil {
 			// notest: checked by router url rule
 			panic(err)
@@ -590,7 +589,7 @@ func requestHandlerV2_table(reqSender bus.IRequestSender, apiPath processors.API
 	return withRequestValidation(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(req.Method, data, req)
 		if recordIDStr, hasDocID := data.vars[URLPlaceholder_id]; hasDocID {
-			docID, err := strconv.ParseUint(recordIDStr, utils.DecimalBase, utils.BitSize64)
+			docID, err := strconvu.ParseUint64(recordIDStr)
 			if err != nil {
 				// notest
 				panic(err)

--- a/pkg/router/impl_blob.go
+++ b/pkg/router/impl_blob.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/voedger/voedger/pkg/appdef"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/istructs"
 )
 
@@ -63,7 +63,7 @@ func (s *httpService) blobHTTPRequestHandler_Read() http.HandlerFunc {
 
 func parseURLParams(req *http.Request, resp http.ResponseWriter) (appQName appdef.AppQName, wsid istructs.WSID, headers map[string]string, ok bool) {
 	vars := mux.Vars(req)
-	wsidUint, err := strconv.ParseUint(vars[URLPlaceholder_wsid], utils.DecimalBase, utils.BitSize64)
+	wsidUint, err := strconvu.ParseUint64(vars[URLPlaceholder_wsid])
 	if err != nil {
 		// notest: checked by router url rule
 		panic(err)

--- a/pkg/router/impl_n10n.go
+++ b/pkg/router/impl_n10n.go
@@ -11,11 +11,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/goutils/strconvu"
 
@@ -193,7 +191,7 @@ func (s *httpService) updateHandler() http.HandlerFunc {
 
 		params := mux.Vars(req)
 		offset := params["offset"]
-		if off, err := strconv.ParseUint(offset, utils.DecimalBase, utils.BitSize64); err == nil {
+		if off, err := strconvu.ParseUint64(offset); err == nil {
 			s.n10n.Update(p, istructs.Offset(off))
 		}
 	}

--- a/pkg/router/impl_reply_v2.go
+++ b/pkg/router/impl_reply_v2.go
@@ -12,15 +12,14 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"strconv"
 
 	"github.com/gorilla/mux"
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/bus"
 	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/istructs"
 )
 
@@ -89,7 +88,7 @@ func createBusRequest(reqMethod string, data validatedData, req *http.Request) b
 	}
 
 	if docIDStr, hasDocID := data.vars[URLPlaceholder_id]; hasDocID {
-		docIDUint64, err := strconv.ParseUint(docIDStr, utils.DecimalBase, utils.BitSize64)
+		docIDUint64, err := strconvu.ParseUint64(docIDStr)
 		if err != nil {
 			// notest: parsed already by route regexp
 			panic(err)

--- a/pkg/sys/it/impl_blob_test.go
+++ b/pkg/sys/it/impl_blob_test.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"strconv"
 	"testing"
 	"time"
 
@@ -20,8 +19,8 @@ import (
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/goutils/testingu"
 	"github.com/voedger/voedger/pkg/iblobstorage"
 	"github.com/voedger/voedger/pkg/istructs"
@@ -361,7 +360,7 @@ func TestAPIv1v2BackwardCompatibility(t *testing.T) {
 		httpu.WithAuthorizeBy(ws.Owner.Token),
 	)
 	require.NoError(err)
-	blobID, err := strconv.ParseUint(resp.Body, utils.DecimalBase, utils.BitSize64)
+	blobID, err := strconvu.ParseUint64(resp.Body)
 	require.NoError(err)
 
 	// put the blob into the owner field

--- a/pkg/sys/sqlquery/impl.go
+++ b/pkg/sys/sqlquery/impl.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
-	"strconv"
 
 	"github.com/blastrain/vitess-sqlparser/sqlparser"
 
@@ -18,10 +17,10 @@ import (
 	"github.com/voedger/voedger/pkg/appparts"
 	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/coreutils/federation"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/dml"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/itokens"
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
@@ -211,7 +210,7 @@ func lim(limit *sqlparser.Limit) (int, error) {
 	if limit == nil {
 		return DefaultLimit, nil
 	}
-	v, err := parseInt64(limit.Rowcount.(*sqlparser.SQLVal).Val)
+	v, err := strconvu.ParseInt64(string(limit.Rowcount.(*sqlparser.SQLVal).Val))
 	if err != nil {
 		return 0, err
 	}
@@ -263,12 +262,8 @@ func offs(expr sqlparser.Expr, simpleOffset istructs.Offset) (istructs.Offset, b
 	return o, eq, nil
 }
 
-func parseInt64(bb []byte) (int64, error) {
-	return strconv.ParseInt(string(bb), utils.DecimalBase, utils.BitSize64)
-}
-
 func parseUint64(bb []byte) (uint64, error) {
-	return strconv.ParseUint(string(bb), utils.DecimalBase, utils.BitSize64)
+	return strconvu.ParseUint64(string(bb))
 }
 
 func getFilter(f func(string) bool) coreutils.MapperOpt {


### PR DESCRIPTION
Resolves #4106 goutils/strconvu: implement and use `ParseUint`, eliminate unclear `BitSize64` and `DecimalBase` consts