### PR TITLE
goutils/strconvu: implement and use `ParseUint`, eliminate unclear `BitSize64` and `DecimalBase` consts

### DIFF
--- a/pkg/coreutils/federation/utils.go
+++ b/pkg/coreutils/federation/utils.go
@@ -13,14 +13,13 @@ import (
 	"fmt"
 	"io"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/in10n"
 	"github.com/voedger/voedger/pkg/istructs"
 )
@@ -61,7 +60,7 @@ func ListenSSEEvents(ctx context.Context, body io.Reader) (offsetsChan OffsetsCh
 				channelID = in10n.ChannelID(data)
 				close(subscribed)
 			} else {
-				offset, err := strconv.ParseUint(data, utils.DecimalBase, utils.BitSize64)
+				offset, err := strconvu.ParseUint64(data)
 				if err != nil {
 					// notest
 					panic(fmt.Sprint("failed to parse offset", data, err))

--- a/pkg/coreutils/utils/consts.go
+++ b/pkg/coreutils/utils/consts.go
@@ -7,7 +7,6 @@ package utils
 
 const (
 	DecimalBase = 10
-	BitSize64   = 64
 	Uint64Size  = 8
 	Uint32Size  = 4
 )

--- a/pkg/dml/impl.go
+++ b/pkg/dml/impl.go
@@ -8,12 +8,11 @@ package dml
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/istructs"
 )
 
@@ -66,7 +65,7 @@ func ParseQuery(query string) (op Op, err error) {
 
 	if offsetStr := parts[offsetOrIDIdx]; len(offsetStr) > 0 {
 		offsetStr = offsetStr[1:]
-		offsetUint, err := strconv.ParseUint(offsetStr, utils.DecimalBase, utils.BitSize64)
+		offsetUint, err := strconvu.ParseUint64(offsetStr)
 		if err != nil {
 			return op, err
 		}
@@ -115,14 +114,14 @@ func parseWorkspace(workspaceStr string) (workspace Workspace, err error) {
 	switch workspaceStr[:1] {
 	case "a":
 		appWSNumStr := workspaceStr[1:]
-		workspace.ID, err = strconv.ParseUint(appWSNumStr, utils.DecimalBase, utils.BitSize64)
+		workspace.ID, err = strconvu.ParseUint64(appWSNumStr)
 		workspace.Kind = WorkspaceKind_AppWSNum
 	case `"`:
 		login := workspaceStr[1 : len(workspaceStr)-1]
 		workspace.ID = uint64(coreutils.GetPseudoWSID(istructs.NullWSID, login, istructs.CurrentClusterID()))
 		workspace.Kind = WorkspaceKind_PseudoWSID
 	default:
-		workspace.ID, err = strconv.ParseUint(workspaceStr, utils.DecimalBase, utils.BitSize64)
+		workspace.ID, err = strconvu.ParseUint64(workspaceStr)
 		workspace.Kind = WorkspaceKind_WSID
 	}
 	return workspace, err

--- a/pkg/goutils/strconvu/README.md
+++ b/pkg/goutils/strconvu/README.md
@@ -1,23 +1,81 @@
 # strconvu
 
-Type-safe string conversion utilities for Go integer types using generics.
+Type-safe string conversion utilities for Go integer types using
+generics.
 
 ## Problem
 
-Standard library string conversions require explicit type casting and 
+Standard library string conversions require verbose type casting and
 lack compile-time type safety for custom integer types.
+
+<details>
+<summary>Without strconvu</summary>
+
+```go
+type UserID uint64
+type OrderID int64
+
+func processOrder(userStr, orderStr string) error {
+    // Verbose casting for custom types - boilerplate here
+    userVal, err := strconv.ParseUint(userStr, 10, 64)
+    if err != nil {
+        return fmt.Errorf("invalid user ID: %w", err)
+    }
+    userID := UserID(userVal) // Manual casting required
+
+    // Different functions for different sizes - easy to get wrong
+    orderVal, err := strconv.ParseInt(orderStr, 10, 64)
+    if err != nil {
+        return fmt.Errorf("invalid order ID: %w", err)
+    }
+    orderID := OrderID(orderVal) // More manual casting
+
+    // Converting back requires more casting
+    log.Printf("User %s placed order %s",
+        strconv.FormatUint(uint64(userID), 10), // Verbose conversion
+        strconv.FormatInt(int64(orderID), 10))  // More verbose conversion
+
+    return nil
+}
+```
+</details>
+
+<details>
+<summary>With strconvu</summary>
+
+```go
+type UserID uint64
+type OrderID int32
+
+func processOrder(userStr, orderStr string) error {
+    userID, err := ParseUint64(userStr)
+    if err != nil {
+        return fmt.Errorf("invalid user ID: %w", err)
+    }
+
+    orderID, err := ParseInt64(orderStr)
+    if err != nil {
+        return fmt.Errorf("invalid order ID: %w", err)
+    }
+
+    log.Printf("User %s placed order %s",
+        UintToString(UserID(userID)), IntToString(OrderID(orderID)))
+
+    return nil
+}
+```
+</details>
 
 ## Features
 
-- **[UintToString](impl.go#L14)** - Generic unsigned integer to string conversion
+- **[UintToString](impl.go#L14)** - Generic unsigned integer to string
   - [Generic type constraints: impl.go#L14](impl.go#L14)
-  - [Decimal base formatting: impl.go#L15](impl.go#L15)
-- **[IntToString](impl.go#L18)** - Generic signed integer to string conversion
+- **[IntToString](impl.go#L18)** - Generic signed integer to string
   - [Generic type constraints: impl.go#L18](impl.go#L18)
-  - [Decimal base formatting: impl.go#L19](impl.go#L19)
-- **[StringToUint8](impl.go#L22)** - String to uint8 with range validation
+- **[StringToUint8](impl.go#L22)** - String to uint8 with validation
   - [Range validation logic: impl.go#L27](impl.go#L27)
-  - [Error handling strategy: impl.go#L28](impl.go#L28)
+- **[ParseUint64](impl.go#L33)** - String to uint64 parsing
+- **[ParseInt64](impl.go#L37)** - String to int64 parsing
 
 ## Use
 

--- a/pkg/goutils/strconvu/consts.go
+++ b/pkg/goutils/strconvu/consts.go
@@ -5,4 +5,7 @@
 
 package strconvu
 
-const decimalBase = 10
+const (
+	decimalBase = 10
+	bitSize64   = 64
+)

--- a/pkg/goutils/strconvu/example_test.go
+++ b/pkg/goutils/strconvu/example_test.go
@@ -129,3 +129,75 @@ func ExampleStringToUint8() {
 	// Error for '256': out of range: value must be between 0 and 255
 	// Error for 'abc': strconv.Atoi: parsing "abc": invalid syntax
 }
+
+// ExampleParseUint64 demonstrates parsing strings to uint64 values
+func ExampleParseUint64() {
+	// Valid conversions
+	validStrings := []string{"0", "42", "18446744073709551615"}
+
+	for _, s := range validStrings {
+		if value, err := ParseUint64(s); err == nil {
+			fmt.Printf("'%s' -> %d\n", s, value)
+		}
+	}
+
+	// Invalid conversions - negative numbers
+	if _, err := ParseUint64("-1"); err != nil {
+		fmt.Println("Error for '-1':", err)
+	}
+
+	// Invalid conversions - out of range
+	if _, err := ParseUint64("18446744073709551616"); err != nil {
+		fmt.Println("Error for '18446744073709551616':", err)
+	}
+
+	// Invalid conversions - non-numeric
+	if _, err := ParseUint64("abc"); err != nil {
+		fmt.Println("Error for 'abc':", err)
+	}
+
+	// Output:
+	// '0' -> 0
+	// '42' -> 42
+	// '18446744073709551615' -> 18446744073709551615
+	// Error for '-1': strconv.ParseUint: parsing "-1": invalid syntax
+	// Error for '18446744073709551616': strconv.ParseUint: parsing "18446744073709551616": value out of range
+	// Error for 'abc': strconv.ParseUint: parsing "abc": invalid syntax
+}
+
+// ExampleParseInt64 demonstrates parsing strings to int64 values
+func ExampleParseInt64() {
+	// Valid conversions
+	validStrings := []string{"-9223372036854775808", "-42", "0", "42", "9223372036854775807"}
+
+	for _, s := range validStrings {
+		if value, err := ParseInt64(s); err == nil {
+			fmt.Printf("'%s' -> %d\n", s, value)
+		}
+	}
+
+	// Invalid conversions - out of range (positive)
+	if _, err := ParseInt64("9223372036854775808"); err != nil {
+		fmt.Println("Error for '9223372036854775808':", err)
+	}
+
+	// Invalid conversions - out of range (negative)
+	if _, err := ParseInt64("-9223372036854775809"); err != nil {
+		fmt.Println("Error for '-9223372036854775809':", err)
+	}
+
+	// Invalid conversions - non-numeric
+	if _, err := ParseInt64("xyz"); err != nil {
+		fmt.Println("Error for 'xyz':", err)
+	}
+
+	// Output:
+	// '-9223372036854775808' -> -9223372036854775808
+	// '-42' -> -42
+	// '0' -> 0
+	// '42' -> 42
+	// '9223372036854775807' -> 9223372036854775807
+	// Error for '9223372036854775808': strconv.ParseInt: parsing "9223372036854775808": value out of range
+	// Error for '-9223372036854775809': strconv.ParseInt: parsing "-9223372036854775809": value out of range
+	// Error for 'xyz': strconv.ParseInt: parsing "xyz": invalid syntax
+}

--- a/pkg/goutils/strconvu/impl.go
+++ b/pkg/goutils/strconvu/impl.go
@@ -29,3 +29,11 @@ func StringToUint8(s string) (uint8, error) {
 	}
 	return uint8(value), nil
 }
+
+func ParseUint64(s string) (uint64, error) {
+	return strconv.ParseUint(s, decimalBase, bitSize64)
+}
+
+func ParseInt64(s string) (int64, error) {
+	return strconv.ParseInt(s, decimalBase, bitSize64)
+}

--- a/pkg/istorage/amazondb/impl.go
+++ b/pkg/istorage/amazondb/impl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
 	"github.com/voedger/voedger/pkg/coreutils/utils"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istorage"
 )
@@ -174,7 +175,7 @@ func (s *implIAppStorage) QueryTTL(pKey []byte, cCols []byte) (ttlInSeconds int,
 	}
 
 	// Parse expireAt timestamp
-	expireAtInSeconds, err := strconv.ParseInt(expireAtStr, utils.DecimalBase, utils.BitSize64)
+	expireAtInSeconds, err := strconvu.ParseInt64(expireAtStr)
 	if err != nil {
 		return 0, false, err
 	}
@@ -536,7 +537,7 @@ func isExpired(expireAtValue types.AttributeValue, now time.Time) bool {
 		return false
 	}
 
-	expireAtInSeconds, err := strconv.ParseInt(expireAtValue.(*types.AttributeValueMemberN).Value, utils.DecimalBase, utils.BitSize64)
+	expireAtInSeconds, err := strconvu.ParseInt64(expireAtValue.(*types.AttributeValueMemberN).Value)
 	if err != nil {
 		return false
 	}

--- a/pkg/processors/blobber/impl_read.go
+++ b/pkg/processors/blobber/impl_read.go
@@ -10,11 +10,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/voedger/voedger/pkg/bus"
 	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/goutils/strconvu"
@@ -29,7 +27,7 @@ import (
 func getBLOBKeyRead(ctx context.Context, work pipeline.IWorkpiece) (err error) {
 	bw := work.(*blobWorkpiece)
 	if bw.isPersistent() {
-		existingBLOBIDUint, err := strconv.ParseUint(bw.blobMessageRead.existingBLOBIDOrSUUID, utils.DecimalBase, utils.BitSize64)
+		existingBLOBIDUint, err := strconvu.ParseUint64(bw.blobMessageRead.existingBLOBIDOrSUUID)
 		if err != nil {
 			// validated already by router
 			// notest

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -19,9 +18,9 @@ import (
 	"github.com/voedger/voedger/pkg/bus"
 	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/coreutils/federation"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/iblobstorage"
 	"github.com/voedger/voedger/pkg/in10n"
 	"github.com/voedger/voedger/pkg/istructs"
@@ -481,7 +480,7 @@ func requestHandlerV2_blobs_read(blobRequestHandler blobprocessor.IRequestHandle
 		vars := mux.Vars(req)
 		ownerRecord := appdef.NewQName(vars[URLPlaceholder_pkg], vars[URLPlaceholder_table])
 		ownerRecordField := vars[URLPlaceholder_field]
-		ownerID, err := strconv.ParseUint(vars[URLPlaceholder_id], utils.DecimalBase, utils.BitSize64)
+		ownerID, err := strconvu.ParseUint64(vars[URLPlaceholder_id])
 		if err != nil {
 			// notest: checked by router url rule
 			panic(err)
@@ -590,7 +589,7 @@ func requestHandlerV2_table(reqSender bus.IRequestSender, apiPath processors.API
 	return withRequestValidation(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(req.Method, data, req)
 		if recordIDStr, hasDocID := data.vars[URLPlaceholder_id]; hasDocID {
-			docID, err := strconv.ParseUint(recordIDStr, utils.DecimalBase, utils.BitSize64)
+			docID, err := strconvu.ParseUint64(recordIDStr)
 			if err != nil {
 				// notest
 				panic(err)

--- a/pkg/router/impl_blob.go
+++ b/pkg/router/impl_blob.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/voedger/voedger/pkg/appdef"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/istructs"
 )
 
@@ -63,7 +63,7 @@ func (s *httpService) blobHTTPRequestHandler_Read() http.HandlerFunc {
 
 func parseURLParams(req *http.Request, resp http.ResponseWriter) (appQName appdef.AppQName, wsid istructs.WSID, headers map[string]string, ok bool) {
 	vars := mux.Vars(req)
-	wsidUint, err := strconv.ParseUint(vars[URLPlaceholder_wsid], utils.DecimalBase, utils.BitSize64)
+	wsidUint, err := strconvu.ParseUint64(vars[URLPlaceholder_wsid])
 	if err != nil {
 		// notest: checked by router url rule
 		panic(err)

--- a/pkg/router/impl_n10n.go
+++ b/pkg/router/impl_n10n.go
@@ -11,11 +11,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/goutils/strconvu"
 
@@ -193,7 +191,7 @@ func (s *httpService) updateHandler() http.HandlerFunc {
 
 		params := mux.Vars(req)
 		offset := params["offset"]
-		if off, err := strconv.ParseUint(offset, utils.DecimalBase, utils.BitSize64); err == nil {
+		if off, err := strconvu.ParseUint64(offset); err == nil {
 			s.n10n.Update(p, istructs.Offset(off))
 		}
 	}

--- a/pkg/router/impl_reply_v2.go
+++ b/pkg/router/impl_reply_v2.go
@@ -12,15 +12,14 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"strconv"
 
 	"github.com/gorilla/mux"
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/bus"
 	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/istructs"
 )
 
@@ -89,7 +88,7 @@ func createBusRequest(reqMethod string, data validatedData, req *http.Request) b
 	}
 
 	if docIDStr, hasDocID := data.vars[URLPlaceholder_id]; hasDocID {
-		docIDUint64, err := strconv.ParseUint(docIDStr, utils.DecimalBase, utils.BitSize64)
+		docIDUint64, err := strconvu.ParseUint64(docIDStr)
 		if err != nil {
 			// notest: parsed already by route regexp
 			panic(err)

--- a/pkg/sys/it/impl_blob_test.go
+++ b/pkg/sys/it/impl_blob_test.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"strconv"
 	"testing"
 	"time"
 
@@ -20,8 +19,8 @@ import (
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/goutils/testingu"
 	"github.com/voedger/voedger/pkg/iblobstorage"
 	"github.com/voedger/voedger/pkg/istructs"
@@ -361,7 +360,7 @@ func TestAPIv1v2BackwardCompatibility(t *testing.T) {
 		httpu.WithAuthorizeBy(ws.Owner.Token),
 	)
 	require.NoError(err)
-	blobID, err := strconv.ParseUint(resp.Body, utils.DecimalBase, utils.BitSize64)
+	blobID, err := strconvu.ParseUint64(resp.Body)
 	require.NoError(err)
 
 	// put the blob into the owner field

--- a/pkg/sys/sqlquery/impl.go
+++ b/pkg/sys/sqlquery/impl.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
-	"strconv"
 
 	"github.com/blastrain/vitess-sqlparser/sqlparser"
 
@@ -18,10 +17,10 @@ import (
 	"github.com/voedger/voedger/pkg/appparts"
 	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/coreutils/federation"
-	"github.com/voedger/voedger/pkg/coreutils/utils"
 	"github.com/voedger/voedger/pkg/dml"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/itokens"
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
@@ -211,7 +210,7 @@ func lim(limit *sqlparser.Limit) (int, error) {
 	if limit == nil {
 		return DefaultLimit, nil
 	}
-	v, err := parseInt64(limit.Rowcount.(*sqlparser.SQLVal).Val)
+	v, err := strconvu.ParseInt64(string(limit.Rowcount.(*sqlparser.SQLVal).Val))
 	if err != nil {
 		return 0, err
 	}
@@ -235,7 +234,7 @@ func offs(expr sqlparser.Expr, simpleOffset istructs.Offset) (istructs.Offset, b
 		if simpleOffset > 0 {
 			return 0, false, errors.New("both .Offset and 'where offset ...' clause can not be provided in one query")
 		}
-		v, e := parseUint64(r.Right.(*sqlparser.SQLVal).Val)
+		v, e := strconvu.ParseUint64(string(r.Right.(*sqlparser.SQLVal).Val))
 		if e != nil {
 			return 0, false, e
 		}
@@ -261,14 +260,6 @@ func offs(expr sqlparser.Expr, simpleOffset istructs.Offset) (istructs.Offset, b
 		return 0, false, fmt.Errorf("unsupported expression: %T", r)
 	}
 	return o, eq, nil
-}
-
-func parseInt64(bb []byte) (int64, error) {
-	return strconv.ParseInt(string(bb), utils.DecimalBase, utils.BitSize64)
-}
-
-func parseUint64(bb []byte) (uint64, error) {
-	return strconv.ParseUint(string(bb), utils.DecimalBase, utils.BitSize64)
 }
 
 func getFilter(f func(string) bool) coreutils.MapperOpt {

--- a/pkg/sys/sqlquery/impl_records.go
+++ b/pkg/sys/sqlquery/impl_records.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/istructs"
 )
 
@@ -36,14 +37,14 @@ func readRecords(wsid istructs.WSID, qName appdef.QName, expr sqlparser.Expr, ap
 		}
 		switch compExpr.Operator {
 		case sqlparser.EqualStr:
-			id, err := parseUint64(compExpr.Right.(*sqlparser.SQLVal).Val)
+			id, err := strconvu.ParseUint64(string(compExpr.Right.(*sqlparser.SQLVal).Val))
 			if err != nil {
 				return err
 			}
 			whereIDs = append(whereIDs, istructs.RecordID(id))
 		case sqlparser.InStr:
 			for _, v := range compExpr.Right.(sqlparser.ValTuple) {
-				id, err := parseUint64(v.(*sqlparser.SQLVal).Val)
+				id, err := strconvu.ParseUint64(string(v.(*sqlparser.SQLVal).Val))
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Resolves #4106 goutils/strconvu: implement and use `ParseUint`, eliminate unclear `BitSize64` and `DecimalBase` consts