### PR TITLE
relocate `coreutils/zip.go` to `goutils/zipu`

### DIFF
--- a/cmd/vpm/build.go
+++ b/cmd/vpm/build.go
@@ -20,10 +20,10 @@ import (
 	"golang.org/x/mod/semver"
 
 	"github.com/voedger/voedger/pkg/compile"
-	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/goutils/exec"
 	"github.com/voedger/voedger/pkg/goutils/filesu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/zipu"
 	"github.com/voedger/voedger/pkg/parser"
 )
 
@@ -88,7 +88,7 @@ func build(compileRes *compile.Result, params *vpmParams) error {
 	tempDirWithoutBuild := filepath.Dir(tempDir)
 
 	// zip build info directory along with vsql and wasm files
-	return coreutils.Zip(tempDirWithoutBuild, varFile)
+	return zipu.Zip(tempDirWithoutBuild, varFile)
 }
 
 // buildDir creates a directory structure with vsql and wasm files

--- a/cmd/vpm/main_test.go
+++ b/cmd/vpm/main_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/voedger/voedger/pkg/goutils/filesu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/goutils/testingu"
+	"github.com/voedger/voedger/pkg/goutils/zipu"
 )
 
 func TestCompileBasicUsage(t *testing.T) {
@@ -504,7 +505,7 @@ func TestBuildBasicUsage(t *testing.T) {
 				err = os.Mkdir(filepath.Join(dir, "unzipped"), filesu.FileMode_DefaultForDir)
 				require.NoError(err)
 
-				err = coreutils.Unzip(filepath.Join(dir, "qwerty.var"), filepath.Join(dir, "unzipped"))
+				err = zipu.Unzip(filepath.Join(dir, "qwerty.var"), filepath.Join(dir, "unzipped"))
 				require.NoError(err)
 				wasmFiles := findWasmFiles(filepath.Join(dir, "unzipped", buildDirName))
 				require.Len(wasmFiles, len(tc.expectedWasmFiles))

--- a/pkg/goutils/zipu/README.md
+++ b/pkg/goutils/zipu/README.md
@@ -1,0 +1,100 @@
+# zipu
+
+Simple directory compression and extraction utilities with automatic
+conflict detection and cross-platform path handling.
+
+## Problem
+
+Standard Go archive operations require extensive boilerplate for
+directory compression and lack built-in safeguards against common
+pitfalls like overwriting existing files or including target files.
+
+<details>
+<summary>Without zipu</summary>
+
+```go
+// Manual zip creation with all the boilerplate
+zipFile, err := os.Create("archive.zip")
+if err != nil {
+    return err
+}
+defer zipFile.Close()
+
+zipWriter := zip.NewWriter(zipFile)
+defer zipWriter.Close()
+
+err = filepath.WalkDir(sourceDir, func(path string, d fs.DirEntry, err error) error {
+    if err != nil {
+        return err
+    }
+    
+    // Skip root directory - easy to forget this check
+    if path == sourceDir {
+        return nil
+    }
+    
+    // Manual relative path calculation - error prone
+    relPath, err := filepath.Rel(sourceDir, path)
+    if err != nil {
+        return err
+    }
+    
+    info, err := d.Info()
+    if err != nil {
+        return err
+    }
+    
+    header, err := zip.FileInfoHeader(info)
+    if err != nil {
+        return err
+    }
+    
+    // Cross-platform path handling - often forgotten
+    header.Name = filepath.ToSlash(relPath)
+    
+    if info.IsDir() {
+        header.Name += "/"
+        _, err := zipWriter.CreateHeader(header)
+        return err
+    }
+    
+    header.Method = zip.Deflate
+    writer, err := zipWriter.CreateHeader(header)
+    if err != nil {
+        return err
+    }
+    
+    file, err := os.Open(path)
+    if err != nil {
+        return err
+    }
+    defer file.Close()
+    
+    _, err = io.Copy(writer, file)
+    return err
+})
+```
+</details>
+
+<details>
+<summary>With zipu</summary>
+
+```go
+import "github.com/voedger/voedger/pkg/goutils/zipu"
+
+// Compress directory
+err := zipu.Zip("source/dir", "archive.zip")
+
+// Extract archive
+err = zipu.Unzip("archive.zip", "destination/dir")
+```
+</details>
+
+## Features
+
+- **[Zip](zip.go#L19)** - Compress directories with conflict detection
+- **[Unzip](zip.go#L89)** - Extract archives with automatic directory creation
+
+## Use
+
+See [basic usage test](zip_test.go)

--- a/pkg/goutils/zipu/zip.go
+++ b/pkg/goutils/zipu/zip.go
@@ -3,7 +3,7 @@
  * @author Denis Gribanov
  */
 
-package coreutils
+package zipu
 
 import (
 	"archive/zip"

--- a/pkg/goutils/zipu/zip_test.go
+++ b/pkg/goutils/zipu/zip_test.go
@@ -3,7 +3,7 @@
  * @author Denis Gribanov
  */
 
-package coreutils
+package zipu
 
 import (
 	"io/fs"
@@ -15,7 +15,7 @@ import (
 	"github.com/voedger/voedger/pkg/goutils/testingu/require"
 )
 
-func TestZipAndUnzip(t *testing.T) {
+func TestBasicUsage_ZipAndUnzip(t *testing.T) {
 	require := require.New(t)
 	tmpDir := t.TempDir()
 	srcDir := filepath.Join(tmpDir, "src")


### PR DESCRIPTION
Resolves #4119 relocate `coreutils/zip.go` to `goutils/zipu`