### PR TITLE
get rid of `IsTest()` on schemas cache in VVMAppsBuilder

### DIFF
--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -30,6 +30,7 @@ import (
 	"github.com/voedger/voedger/pkg/iblobstorage"
 	"github.com/voedger/voedger/pkg/isequencer"
 	"github.com/voedger/voedger/pkg/itokensjwt"
+	"github.com/voedger/voedger/pkg/parser"
 	"github.com/voedger/voedger/pkg/processors/actualizers"
 	"github.com/wneessen/go-mail"
 
@@ -47,6 +48,9 @@ import (
 	"github.com/voedger/voedger/pkg/sys/verifier"
 	vvmpkg "github.com/voedger/voedger/pkg/vvm"
 )
+
+// shared among all VIT instances
+var sysAppsSchemasCache = &implISchemasCache_sysApps{schemas: map[appdef.AppQName]*parser.AppSchemaAST{}}
 
 func NewVIT(t testing.TB, vitCfg *VITConfig, opts ...vitOptFunc) (vit *VIT) {
 	useCas := coreutils.IsCassandraStorage()
@@ -94,6 +98,7 @@ func newVit(t testing.TB, vitCfg *VITConfig, useCas bool, vvmLaunchOnly bool) *V
 
 	cfg.Time = testingu.MockTime
 	cfg.AsyncActualizersRetryDelay = actualizers.RetryDelay(100 * time.Millisecond)
+	cfg.SchemasCache = sysAppsSchemasCache
 
 	emailCaptor := &implIEmailSender_captor{
 		emailCaptorCh: make(chan state.EmailMessage, 1), // must be buffered

--- a/pkg/vit/types.go
+++ b/pkg/vit/types.go
@@ -15,6 +15,7 @@ import (
 	"github.com/voedger/voedger/pkg/goutils/testingu"
 	"github.com/voedger/voedger/pkg/isecrets"
 	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/parser"
 	"github.com/voedger/voedger/pkg/state"
 	"github.com/voedger/voedger/pkg/vvm"
 )
@@ -149,4 +150,14 @@ type implVITISecretsReader struct {
 
 type implIEmailSender_captor struct {
 	emailCaptorCh chan state.EmailMessage
+}
+
+// cache for sys/registry, sys/cluster
+// to make the constant schemas be reused among tests to speed up
+// other app schemas could be changed among tests so it is wron gto cache non-sys apps
+// normally should be used in VIT tests only
+// vvm.NullSchemasCache is default in VVM
+type implISchemasCache_sysApps struct {
+	schemas map[appdef.AppQName]*parser.AppSchemaAST
+	lock    sync.Mutex
 }

--- a/pkg/vit/utils.go
+++ b/pkg/vit/utils.go
@@ -28,6 +28,7 @@ import (
 	"github.com/voedger/voedger/pkg/istorage/provider"
 	"github.com/voedger/voedger/pkg/istructs"
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
+	"github.com/voedger/voedger/pkg/parser"
 	"github.com/voedger/voedger/pkg/registry"
 	"github.com/voedger/voedger/pkg/sys/authnz"
 	"github.com/voedger/voedger/pkg/vvm"
@@ -456,4 +457,22 @@ func TestRestartPreservingStorage(t *testing.T, cfg *VITConfig, testBeforeRestar
 	vit := NewVIT(t, cfg)
 	defer vit.TearDown()
 	testAfterRestart(t, vit)
+}
+
+func (c *implISchemasCache_sysApps) Get(appQName appdef.AppQName) *parser.AppSchemaAST {
+	if !appQName.IsSys() {
+		return nil
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.schemas[appQName]
+}
+
+func (c *implISchemasCache_sysApps) Put(appQName appdef.AppQName, schema *parser.AppSchemaAST) {
+	if !appQName.IsSys() {
+		return
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.schemas[appQName] = schema
 }

--- a/pkg/vvm/builtin/clusterapp/provide.go
+++ b/pkg/vvm/builtin/clusterapp/provide.go
@@ -33,7 +33,6 @@ func Provide() builtinapps.Builder {
 				EnginePoolSize:   appparts.PoolSize(uint(ClusterAppNumPartitions), 1, uint(ClusterAppNumPartitions), 1),
 				NumAppWorkspaces: ClusterAppNumAppWS,
 			},
-			CacheAppSchemASTInTests: true,
 		}
 	}
 }

--- a/pkg/vvm/builtin/registryapp/provide.go
+++ b/pkg/vvm/builtin/registryapp/provide.go
@@ -46,7 +46,6 @@ func Provide(smtpCfg smtp.Cfg, numCP istructs.NumCommandProcessors) builtinapps.
 				EnginePoolSize:   appparts.PoolSize(uint(numCP), DefDeploymentQPCount, uint(numCP), DefDeploymentSPCount),
 				NumAppWorkspaces: istructs.DefaultNumAppWorkspaces,
 			},
-			CacheAppSchemASTInTests: true,
 		}
 	}
 }

--- a/pkg/vvm/builtin/types.go
+++ b/pkg/vvm/builtin/types.go
@@ -23,14 +23,8 @@ type Builder func(apis APIs, cfg *istructsmem.AppConfigType, ep extensionpoints.
 
 type Def struct {
 	appparts.AppDeploymentDescriptor
-	AppQName                appdef.AppQName
-	Packages                []parser.PackageFS
-
-	// true -> schema AST will be built once per process and then reused on the same app
-	// normally could be used for sys/registry, sys/cluster etc
-	// normally should not be used for e.g. test1/app1 because schemas for such apps differs from test to test
-	// ignored if !coreutils.IsTest()
-	CacheAppSchemASTInTests bool
+	AppQName appdef.AppQName
+	Packages []parser.PackageFS
 }
 
 type APIs struct {

--- a/pkg/vvm/impl_cfg.go
+++ b/pkg/vvm/impl_cfg.go
@@ -60,6 +60,7 @@ func NewVVMDefaultConfig() VVMConfig {
 		NumVVM:        1,
 		AdminPort:     DefaultAdminPort,
 		EmailSender:   storages.NewIEmailSenderSMTP(),
+		SchemasCache:  &NullSchemasCache{},
 
 		// [~server.design.sequences/tuc.VVMConfig.ConfigureSequencesTrustLevel~impl]
 		SequencesTrustLevel: isequencer.SequencesTrustLevel_0,

--- a/pkg/vvm/provide.go
+++ b/pkg/vvm/provide.go
@@ -244,6 +244,7 @@ func wireVVM(vvmCtx context.Context, vvmConfig *VVMConfig) (*VVM, func(), error)
 			"SecretsReader",
 			"SequencesTrustLevel",
 			"AsyncActualizersRetryDelay",
+			"SchemasCache",
 		),
 	))
 }
@@ -568,8 +569,8 @@ func provideVVMApps(builtInApps []appparts.BuiltInApp) (vvmApps VVMApps) {
 }
 
 func provideBuiltInAppsArtefacts(vvmConfig *VVMConfig, apis builtinapps.APIs, cfgs AppConfigsTypeEmpty,
-	appEPs map[appdef.AppQName]extensionpoints.IExtensionPoint) (BuiltInAppsArtefacts, error) {
-	return vvmConfig.VVMAppsBuilder.BuildAppsArtefacts(apis, cfgs, appEPs)
+	appEPs map[appdef.AppQName]extensionpoints.IExtensionPoint, schemasCache ISchemasCache) (BuiltInAppsArtefacts, error) {
+	return vvmConfig.VVMAppsBuilder.BuildAppsArtefacts(apis, cfgs, appEPs, schemasCache)
 }
 
 // extModuleURLs is filled here

--- a/pkg/vvm/wire_gen.go
+++ b/pkg/vvm/wire_gen.go
@@ -146,7 +146,8 @@ func wireVVM(vvmCtx context.Context, vvmConfig *VVMConfig) (*VVM, func(), error)
 		ITime:               iTime,
 		SidecarApps:         v4,
 	}
-	builtInAppsArtefacts, err := provideBuiltInAppsArtefacts(vvmConfig, apIs, appConfigsTypeEmpty, v2)
+	iSchemasCache := vvmConfig.SchemasCache
+	builtInAppsArtefacts, err := provideBuiltInAppsArtefacts(vvmConfig, apIs, appConfigsTypeEmpty, v2, iSchemasCache)
 	if err != nil {
 		cleanup2()
 		cleanup()
@@ -627,8 +628,8 @@ func provideVVMApps(builtInApps []appparts.BuiltInApp) (vvmApps VVMApps) {
 }
 
 func provideBuiltInAppsArtefacts(vvmConfig *VVMConfig, apis builtinapps.APIs, cfgs AppConfigsTypeEmpty,
-	appEPs map[appdef.AppQName]extensionpoints.IExtensionPoint) (BuiltInAppsArtefacts, error) {
-	return vvmConfig.VVMAppsBuilder.BuildAppsArtefacts(apis, cfgs, appEPs)
+	appEPs map[appdef.AppQName]extensionpoints.IExtensionPoint, schemasCache ISchemasCache) (BuiltInAppsArtefacts, error) {
+	return vvmConfig.VVMAppsBuilder.BuildAppsArtefacts(apis, cfgs, appEPs, schemasCache)
 }
 
 // extModuleURLs is filled here


### PR DESCRIPTION
Resolves #4121 get rid of `IsTest()` on schemas cache in VVMAppsBuilder