### PR TITLE
QPv2: support principal token in cookies

### DIFF
--- a/pkg/router/impl_validation.go
+++ b/pkg/router/impl_validation.go
@@ -19,7 +19,7 @@ import (
 )
 
 func withValidateForFuncs(numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces, handler func(req *http.Request, rw http.ResponseWriter, data validatedData)) http.HandlerFunc {
-	return withValidate(numsAppsWorkspaces, handler, readBody)
+	return withValidate(numsAppsWorkspaces, handler, readBody, cookiesTokenToHeaders)
 }
 
 func withValidateForN10N(numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces, handler func(req *http.Request, rw http.ResponseWriter, data validatedData)) http.HandlerFunc {


### PR DESCRIPTION
Resolves #3629 QPv2: support principal token in cookies