### PR TITLE
[AIR-2132] do not log workspaces init on VIT launch

### DIFF
--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -163,6 +163,10 @@ func newVit(t testing.TB, vitCfg *VITConfig, useCas bool, vvmLaunchOnly bool) *V
 	vit.cleanups = append(vit.cleanups, vitPreConfig.cleanups...)
 	vit.cleanups = append(vit.cleanups, func(vit *VIT) { httpClientCleanup() })
 
+	// get rid of huge amount of logs reporting about workspaces init process
+	loggerRestore := logger.SetLogLevelWithRestore(logger.LogLevelWarning)
+	defer loggerRestore()
+
 	// launch the server
 	// leadership duration - ten years to avoid leadership expiration when time bumps in tests (including 1 day add on each test)
 	vit.vvmProblemCtx = vit.Launch(10*365*24*60*60, vvmpkg.DefaultLeadershipAcquisitionDuration)


### PR DESCRIPTION
[AIR-2132] do not log workspaces init on VIT launch
https://untill.atlassian.net/browse/AIR-2132