### PR TITLE
[AIR-2312] voedger: use new ci.yml, ci_pr.yml instead of ci_reuse_go.yml and _ci_reuse_go_pr.yml

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   call-workflow-ci:
     if: github.repository == 'voedger/voedger'
-    uses: untillpro/ci-action/.github/workflows/ci_reuse_go.yml@main
+    uses: untillpro/ci-action/.github/workflows/ci.yml@main
     with:
       go_race: "true"
       short_test: "false"

--- a/.github/workflows/ci-pkg-cmd.yml
+++ b/.github/workflows/ci-pkg-cmd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   call-workflow-ci-pkg:
     if: github.repository == 'voedger/voedger'
-    uses: untillpro/ci-action/.github/workflows/ci_reuse_go.yml@main
+    uses: untillpro/ci-action/.github/workflows/ci.yml@main
     with:
       test_folder: "pkg"
       short_test: "true"

--- a/.github/workflows/ci-pkg-cmd_pr.yml
+++ b/.github/workflows/ci-pkg-cmd_pr.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   call-workflow-ci-pkg:
     if: github.repository == 'voedger/voedger'
-    uses: untillpro/ci-action/.github/workflows/ci_reuse_go_pr.yml@main
+    uses: untillpro/ci-action/.github/workflows/ci_pr.yml@main
     with:
       test_folder: "pkg"
       short_test: "true"


### PR DESCRIPTION
[AIR-2312] voedger: use new ci.yml, ci_pr.yml instead of ci_reuse_go.yml and _ci_reuse_go_pr.yml
https://untill.atlassian.net/browse/AIR-2312