### PR TITLE
[AIR-2390] vmp: return the actual error on schemas compile failure

### DIFF
--- a/cmd/vpm/build.go
+++ b/cmd/vpm/build.go
@@ -49,7 +49,7 @@ func newBuildCmd(params *vpmParams) *cobra.Command {
 					return errors.New("failed to build, app schema not found")
 				}
 
-				return errors.New("failed to compile, check schemas")
+				return fmt.Errorf("failed to compile: %w", err)
 			}
 
 			if len(compileRes.NotFoundDeps) > 0 {


### PR DESCRIPTION
[AIR-2390] vmp: return the actual error on schemas compile failure
https://untill.atlassian.net/browse/AIR-2390