### PR TITLE
[AIR-2449] voedger: do not provide personal_token to ci-action/ci.yml

### DIFF
--- a/.github/workflows/ci-pkg-cmd.yml
+++ b/.github/workflows/ci-pkg-cmd.yml
@@ -17,7 +17,6 @@ jobs:
       install_tinygo: "true"
     secrets:
       reporeading_token: ${{ secrets.REPOREADING_TOKEN }}
-      personal_token: ${{ secrets.PERSONAL_TOKEN }}
 
 
   call-workflow-cd_voeger:


### PR DESCRIPTION
[AIR-2449] voedger: do not provide personal_token to ci-action/ci.yml
https://untill.atlassian.net/browse/AIR-2449

[AIR-2449]: https://untill.atlassian.net/browse/AIR-2449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ