### PR TITLE
[AIR-2529] voedger: get rid of unused personal_token arg for ci_pr.yml

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -16,7 +16,6 @@ jobs:
       install_tinygo: "true"
     secrets:
       reporeading_token: ${{ secrets.REPOREADING_TOKEN }}
-      personal_token: ${{ secrets.PERSONAL_TOKEN }}
   auto-merge-pr:
     needs: call-workflow-ci
     uses: ./.github/workflows/merge.yml


### PR DESCRIPTION
[AIR-2529] voedger: get rid of unused personal_token arg for ci_pr.yml
https://untill.atlassian.net/browse/AIR-2529

[AIR-2529]: https://untill.atlassian.net/browse/AIR-2529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ