### PR TITLE
[AIR-2902] sys.vsql: fix BLOBUploader grant

### DIFF
--- a/pkg/sys/sys.vsql
+++ b/pkg/sys/sys.vsql
@@ -479,7 +479,7 @@ ABSTRACT WORKSPACE Workspace (
 	GRANT WorkspaceOwner TO RoleWorkspaceOwner; --backward compatibility
 	GRANT Everyone TO Anonymous;
 	GRANT Everyone TO AuthenticatedUser;
-	GRANT WorkspaceOwner TO BLOBUploader;
+	GRANT BLOBUploader TO WorkspaceOwner;
 
 	GRANT SELECT, INSERT, UPDATE, ACTIVATE, DEACTIVATE ON ALL TABLES WITH TAG WorkspaceOwnerTableTag TO WorkspaceOwner;
 


### PR DESCRIPTION
[AIR-2902] sys.vsql: fix BLOBUploader grant
https://untill.atlassian.net/browse/AIR-2902

[AIR-2902]: https://untill.atlassian.net/browse/AIR-2902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ