### PR TITLE
[AIR-3195] APIv2: fix special chars escaping in authnz paths

### DIFF
--- a/pkg/processors/query2/impl_auth_login_handler.go
+++ b/pkg/processors/query2/impl_auth_login_handler.go
@@ -6,6 +6,7 @@ package query2
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -35,13 +36,21 @@ func authLoginHandler() apiPathHandler {
 
 			pseudoWSID := coreutils.GetPseudoWSID(istructs.NullWSID, login, istructs.CurrentClusterID())
 
-			url := fmt.Sprintf(`api/v2/apps/%s/%s/workspaces/%d/queries/registry.IssuePrincipalToken?args=%s`,
+			tokenArgs, err := json.Marshal(map[string]string{
+				"Login":    login,
+				"Password": password,
+				"AppName":  qw.msg.AppQName().String(),
+			})
+			if err != nil {
+				return err
+			}
+			reqURL := fmt.Sprintf(`api/v2/apps/%s/%s/workspaces/%d/queries/registry.IssuePrincipalToken?args=%s`,
 				istructs.SysOwner, istructs.AppQName_sys_registry.Name(), pseudoWSID,
-				url.QueryEscape(fmt.Sprintf(`{"Login":"%s", "Password":"%s", "AppName": "%s"}`, login, password, qw.msg.AppQName())))
+				url.QueryEscape(string(tokenArgs)))
 
-			// WithRetry to avoid WSAECONNREFUSED errors on stress tests on Widnows
+			// WithRetry to avoid WSAECONNREFUSED errors on stress tests on Windows
 			federationWithRetry := qw.federation.WithRetry()
-			resp, err := federationWithRetry.Query(url)
+			resp, err := federationWithRetry.Query(reqURL)
 			if err != nil {
 				return err
 			}

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -196,8 +196,21 @@ func requestHandlerV2_changePassword(numsAppsWorkspaces map[appdef.AppQName]istr
 			return
 		}
 		pseudoWSID := coreutils.GetPseudoWSID(istructs.NullWSID, login, istructs.CurrentClusterID())
-		body := fmt.Sprintf(`{"args":{"Login":"%s","AppName":"%s"},"unloggedArgs":{"OldPassword":"%s","NewPassword":"%s"}}`,
-			login, busRequest.AppQName, oldPassword, newPassword)
+		bodyBytes, err := json.Marshal(map[string]any{
+			"args": map[string]any{
+				"Login":   login,
+				"AppName": busRequest.AppQName.String(),
+			},
+			"unloggedArgs": map[string]any{
+				"OldPassword": oldPassword,
+				"NewPassword": newPassword,
+			},
+		})
+		if err != nil {
+			ReplyCommonError(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		body := string(bodyBytes)
 		url := fmt.Sprintf("api/v2/apps/sys/registry/workspaces/%d/commands/registry.ChangePassword", pseudoWSID)
 		if _, err = federation.Func(url, body, httpu.WithMethod(http.MethodPost), httpu.WithDiscardResponse()); err != nil { // null auth
 			replyErr(rw, err)
@@ -227,8 +240,23 @@ func requestHandlerV2_create_user(numsAppsWorkspaces map[appdef.AppQName]istruct
 		pseudoWSID := coreutils.GetPseudoWSID(istructs.NullWSID, email, istructs.CurrentClusterID())
 		url := fmt.Sprintf("api/v2/apps/sys/registry/workspaces/%d/commands/registry.CreateEmailLogin", pseudoWSID)
 		wsKindInitData := fmt.Sprintf(`{"DisplayName":%q}`, displayName)
-		body := fmt.Sprintf(`{"args":{"Email":"%s","AppName":"%s","SubjectKind":%d,"WSKindInitializationData":%q,"ProfileCluster":%d},"unloggedArgs":{"Password":"%s"}}`,
-			verifiedEmailToken, busRequest.AppQName, istructs.SubjectKind_User, wsKindInitData, istructs.CurrentClusterID(), pwd)
+		bodyBytes, err := json.Marshal(map[string]any{
+			"args": map[string]any{
+				"Email":                    verifiedEmailToken,
+				"AppName":                  busRequest.AppQName.String(),
+				"SubjectKind":              istructs.SubjectKind_User,
+				"WSKindInitializationData": wsKindInitData,
+				"ProfileCluster":           istructs.CurrentClusterID(),
+			},
+			"unloggedArgs": map[string]any{
+				"Password": pwd,
+			},
+		})
+		if err != nil {
+			ReplyCommonError(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		body := string(bodyBytes)
 		sysToken, err := payloads.GetSystemPrincipalToken(iTokens, istructs.AppQName_sys_registry)
 		if err != nil {
 			// notest

--- a/pkg/sys/it/impl_changepassword_test.go
+++ b/pkg/sys/it/impl_changepassword_test.go
@@ -6,6 +6,7 @@
 package sys_it
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -57,6 +58,26 @@ func TestBasicUsage_ChangePassword_APIv2(t *testing.T) {
 	// expect no errors on login with new password
 	login.Pwd = "2"
 	vit.SignIn(login)
+
+	t.Run("passwords with special JSON characters", func(t *testing.T) {
+		vit.TimeAdd(time.Minute) // reset rate-limit window before this password change
+		specialPwd := `p"a\ss`
+		specialLoginName := vit.NextName()
+		specialLogin := vit.SignUp(specialLoginName, specialPwd, istructs.AppQName_test1_app1)
+		vit.SignIn(specialLogin)
+
+		bodyBytes, err := json.Marshal(map[string]any{
+			"login":       specialLogin.Name,
+			"oldPassword": specialPwd,
+			"newPassword": specialPwd + "x",
+		})
+		require.NoError(t, err)
+		resp := vit.POST("api/v2/apps/test1/app1/users/change-password", string(bodyBytes))
+		require.Empty(t, resp.Body)
+
+		specialLogin.Pwd = specialPwd + "x"
+		vit.SignIn(specialLogin)
+	})
 }
 
 func TestChangePasswordErrors_APIv2(t *testing.T) {

--- a/pkg/sys/it/impl_qpv2_test.go
+++ b/pkg/sys/it/impl_qpv2_test.go
@@ -2563,6 +2563,12 @@ func TestQueryProcessor2_AuthLogin(t *testing.T) {
 		require.JSONEq(`{"status":401,"message":"login or password is incorrect"}`, resp.Body)
 	})
 
+	t.Run("Login with special JSON characters in password", func(t *testing.T) {
+		specialLoginName := vit.NextName()
+		specialLogin := vit.SignUp(specialLoginName, `p"a\ss`, istructs.AppQName_test1_app1)
+		vit.SignIn(specialLogin)
+	})
+
 }
 
 // [~server.authnz/it.TestRefresh~impl]

--- a/pkg/sys/it/impl_signupin_test.go
+++ b/pkg/sys/it/impl_signupin_test.go
@@ -75,6 +75,12 @@ func TestBasicUsage_SignUpIn(t *testing.T) {
 		require.NoError(err)
 		require.Equal(authnz.DefaultPrincipalTokenExpiration, gp.Duration)
 	})
+
+	t.Run("sign up and sign in with special JSON characters in password", func(t *testing.T) {
+		specialLoginName := vit.NextName()
+		specialLogin := vit.SignUp(specialLoginName, `p"a\ss`, istructs.AppQName_test1_app1)
+		vit.SignIn(specialLogin)
+	})
 }
 
 func TestTTL(t *testing.T) {

--- a/pkg/vit/utils.go
+++ b/pkg/vit/utils.go
@@ -63,8 +63,13 @@ func (vit *VIT) signUp(login Login, opts ...httpu.ReqOptFunc) {
 	}
 	verifiedEmailToken, err := vit.ITokens.IssueToken(istructs.AppQName_sys_registry, 10*time.Minute, &p)
 	require.NoError(vit.T, err)
-	body := fmt.Sprintf(`{"verifiedEmailToken": "%s","password": "%s","displayName": "%s"}`, verifiedEmailToken, login.Pwd, login.Name)
-	vit.Func(fmt.Sprintf("api/v2/apps/%s/%s/users", login.AppQName.Owner(), login.AppQName.Name()), body, opts...)
+	bodyBytes, err := json.Marshal(map[string]any{
+		"verifiedEmailToken": verifiedEmailToken,
+		"password":           login.Pwd,
+		"displayName":        login.Name,
+	})
+	require.NoError(vit.T, err)
+	vit.Func(fmt.Sprintf("api/v2/apps/%s/%s/users", login.AppQName.Owner(), login.AppQName.Name()), string(bodyBytes), opts...)
 }
 
 func WithClusterID(clusterID istructs.ClusterID) signUpOptFunc {
@@ -291,7 +296,9 @@ func (vit *VIT) SignIn(login Login, optFuncs ...signInOptFunc) (prn *Principal) 
 	}
 	deadline := time.Now().Add(getWorkspaceInitAwaitTimeout())
 	for time.Now().Before(deadline) {
-		body := fmt.Sprintf(`{"login": "%s","password": "%s"}`, login.Name, login.Pwd)
+		bodyBytes, err := json.Marshal(map[string]any{"login": login.Name, "password": login.Pwd})
+		require.NoError(vit.T, err)
+		body := string(bodyBytes)
 		resp := vit.POST(fmt.Sprintf("api/v2/apps/%s/%s/auth/login", login.AppQName.Owner(), login.AppQName.Name()), body,
 			httpu.Expect409(),
 			httpu.Expect503(),
@@ -303,7 +310,7 @@ func (vit *VIT) SignIn(login Login, optFuncs ...signInOptFunc) (prn *Principal) 
 		}
 		require.Equal(vit.T, http.StatusOK, resp.HTTPResp.StatusCode)
 		result := make(map[string]interface{})
-		err := json.Unmarshal([]byte(resp.Body), &result)
+		err = json.Unmarshal([]byte(resp.Body), &result)
 		require.NoError(vit.T, err)
 		profileWSID := istructs.WSID(result["profileWSID"].(float64))
 		token := result["principalToken"].(string)

--- a/uspecs/changes/2603111331-special-chars-authnz-paths/change.md
+++ b/uspecs/changes/2603111331-special-chars-authnz-paths/change.md
@@ -1,0 +1,19 @@
+---
+registered_at: 2026-03-11T13:31:14Z
+change_id: 2603111331-special-chars-authnz-paths
+baseline: 0d7582b825ebbb003ffb61ded265d9e8fe12b84d
+---
+
+# Change request: Special chars in authnz paths of API v2
+
+## Why
+
+Special characters (e.g. `"`, `\`) can be provided in user-supplied fields such as login, password, or display name. When these values are embedded into JSON strings for internal API calls they are formatted with `fmt.Sprintf("%s", ...)` without JSON escaping, causing the resulting JSON to be malformed.
+
+## What
+
+Properly escape user-supplied string values before embedding them into JSON arguments for internal API calls. The following handlers are affected:
+
+- `auth/login` (`pkg/processors/query2/impl_auth_login_handler.go`): `login` and `password` are embedded unescaped into the args JSON passed to `registry.IssuePrincipalToken`
+- `users/change-password` (`pkg/router/impl_apiv2.go`): `login`, `oldPassword`, and `newPassword` are embedded unescaped into the body JSON passed to `registry.ChangePassword`
+- `users` create (`pkg/router/impl_apiv2.go`): `pwd` is embedded unescaped into the body JSON passed to `registry.CreateEmailLogin`

--- a/uspecs/changes/2603111331-special-chars-authnz-paths/impl.md
+++ b/uspecs/changes/2603111331-special-chars-authnz-paths/impl.md
@@ -1,0 +1,18 @@
+# Implementation plan: Special chars in authnz paths of API v2
+
+## Construction
+
+- [x] update: [pkg/processors/query2/impl_auth_login_handler.go](../../../pkg/processors/query2/impl_auth_login_handler.go)
+  - fix: use `encoding/json` marshaling instead of `fmt.Sprintf` when building the JSON args for `registry.IssuePrincipalToken`; `login` and `password` must be properly escaped
+- [x] update: [pkg/router/impl_apiv2.go](../../../pkg/router/impl_apiv2.go)
+  - fix: in `requestHandlerV2_changePassword` — escape `login`, `oldPassword`, `newPassword` before embedding into the body JSON for `registry.ChangePassword`
+  - fix: in `requestHandlerV2_create_user` — escape `pwd` before embedding into the body JSON for `registry.CreateEmailLogin`
+- [x] update: [pkg/vit/utils.go](../../../pkg/vit/utils.go)
+  - fix: `signUp` — use `json.Marshal` instead of `fmt.Sprintf` for the request body so that special characters in `password` and `displayName` are properly escaped
+  - fix: `SignIn` — use `json.Marshal` instead of `fmt.Sprintf` for the request body so that special characters in `login` and `password` are properly escaped
+- [x] update: [pkg/sys/it/impl_qpv2_test.go](../../../pkg/sys/it/impl_qpv2_test.go)
+  - add: subtest in `TestQueryProcessor2_AuthLogin` covering login and password containing JSON special characters (e.g. `"`, `\`)
+- [x] update: [pkg/sys/it/impl_changepassword_test.go](../../../pkg/sys/it/impl_changepassword_test.go)
+  - add: subtest in `TestBasicUsage_ChangePassword_APIv2` covering oldPassword/newPassword containing JSON special characters
+- [x] update: [pkg/sys/it/impl_signupin_test.go](../../../pkg/sys/it/impl_signupin_test.go)
+  - add: subtest in `TestBasicUsage_SignUpIn` covering password containing JSON special characters (exercises `requestHandlerV2_create_user` via `vit.SignUp`)


### PR DESCRIPTION
APIv2: fix special chars escaping in authnz paths
https://untill.atlassian.net/browse/AIR-3195