### PR TITLE
[AIR-3446] Replace anonymous workpiece casts with named processor interfaces

### DIFF
--- a/pkg/cluster/impl_vsqlupdate.go
+++ b/pkg/cluster/impl_vsqlupdate.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/blastrain/vitess-sqlparser/sqlparser"
 	"github.com/voedger/voedger/pkg/appdef"
-	"github.com/voedger/voedger/pkg/appparts"
 	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/coreutils/federation"
 	"github.com/voedger/voedger/pkg/dml"
@@ -22,6 +21,7 @@ import (
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/istructsmem"
 	"github.com/voedger/voedger/pkg/itokens"
+	"github.com/voedger/voedger/pkg/processors"
 )
 
 func provideExecCmdVSqlUpdate(federation federation.IFederation, itokens itokens.ITokens, time timeu.ITime,
@@ -57,9 +57,7 @@ func parseAndValidateQuery(args istructs.ExecCommandArgs, query string, asp istr
 		return update, errors.New("'update' or 'insert' clause expected")
 	}
 
-	update.appParts = args.Workpiece.(interface {
-		AppPartitions() appparts.IAppPartitions
-	}).AppPartitions()
+	update.appParts = args.Workpiece.(processors.IProcessorWorkpiece).AppPartitions()
 
 	if update.appStructs, err = asp.BuiltIn(update.AppQName); err != nil {
 		// notest

--- a/pkg/processors/actualizers/impl.go
+++ b/pkg/processors/actualizers/impl.go
@@ -11,22 +11,13 @@ import (
 	"fmt"
 
 	"github.com/voedger/voedger/pkg/appdef"
-	"github.com/voedger/voedger/pkg/appparts"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/pipeline"
+	"github.com/voedger/voedger/pkg/processors"
 	"github.com/voedger/voedger/pkg/state"
 	"github.com/voedger/voedger/pkg/state/stateprovide"
 )
-
-type syncActualizerWorkpiece interface {
-	pipeline.IWorkpiece
-	Event() istructs.IPLogEvent
-	AppPartition() appparts.IAppPartition
-	Context() context.Context                // is cmd.cmdMes.RequestCtx() from command processor
-	LogCtxForSyncProjector() context.Context // is cmd.cmdMes.RequestCtx() from cmd proc enriched with woffset, poffset, evqname attribs
-	PLogOffset() istructs.Offset
-}
 
 func syncActualizerFactory(conf SyncActualizerConf, projectors istructs.Projectors) pipeline.ISyncOperator {
 	if conf.IntentsLimit == 0 {
@@ -42,11 +33,11 @@ func syncActualizerFactory(conf SyncActualizerConf, projectors istructs.Projecto
 	}
 	h := &syncErrorHandler{ss: ss}
 	return pipeline.NewSyncPipeline(conf.Ctx, "PartitionSyncActualizer",
-		pipeline.WireFunc("Update event", func(_ context.Context, work syncActualizerWorkpiece) (err error) {
+		pipeline.WireFunc("Update event", func(_ context.Context, work processors.IProjectorWorkpiece) (err error) {
 			service.event = work.Event()
 			return nil
 		}),
-		pipeline.WireFunc("Update IAppStructs", func(_ context.Context, work syncActualizerWorkpiece) (err error) {
+		pipeline.WireFunc("Update IAppStructs", func(_ context.Context, work processors.IProjectorWorkpiece) (err error) {
 			service.appStructs = work.AppPartition().AppStructs()
 			return nil
 		}),
@@ -78,7 +69,7 @@ func newSyncBranch(conf SyncActualizerConf, projector istructs.Projector, servic
 	)
 	fn = pipeline.ForkBranch(pipeline.NewSyncPipeline(conf.Ctx, pipelineName,
 		pipeline.WireFunc("Projector",
-			func(ctx context.Context, work syncActualizerWorkpiece) error {
+			func(ctx context.Context, work processors.IProjectorWorkpiece) error {
 				appPart := work.AppPartition()
 				appDef := appPart.AppStructs().AppDef()
 				prj := appdef.Projector(appDef.Type, projector.Name)
@@ -87,7 +78,7 @@ func newSyncBranch(conf SyncActualizerConf, projector istructs.Projector, servic
 				if triggeredByQName == appdef.NullQName {
 					return nil
 				}
-				projLogCtx := logger.WithContextAttrs(work.LogCtxForSyncProjector(),
+				projLogCtx := logger.WithContextAttrs(work.LogCtx(),
 					map[string]any{logger.LogAttr_Extension: "p." + projector.Name.String()})
 				logger.VerboseCtx(projLogCtx, "sp.triggeredby", triggeredByQName)
 				if err := appPart.Invoke(projLogCtx, projector.Name, s, s); err != nil {

--- a/pkg/processors/actualizers/impl_helpers_test.go
+++ b/pkg/processors/actualizers/impl_helpers_test.go
@@ -49,12 +49,12 @@ type cmdWorkpieceMock struct {
 	event   istructs.IPLogEvent
 }
 
-func (w *cmdWorkpieceMock) AppPartition() appparts.IAppPartition    { return w.appPart }
-func (w *cmdWorkpieceMock) Event() istructs.IPLogEvent              { return w.event }
-func (w *cmdWorkpieceMock) Release()                                {}
-func (w *cmdWorkpieceMock) Context() context.Context                { return context.Background() }
-func (w *cmdWorkpieceMock) LogCtxForSyncProjector() context.Context { return context.Background() }
-func (w *cmdWorkpieceMock) PLogOffset() istructs.Offset             { return 0 }
+func (w *cmdWorkpieceMock) AppPartition() appparts.IAppPartition { return w.appPart }
+func (w *cmdWorkpieceMock) Event() istructs.IPLogEvent           { return w.event }
+func (w *cmdWorkpieceMock) Release()                             {}
+func (w *cmdWorkpieceMock) Context() context.Context             { return context.Background() }
+func (w *cmdWorkpieceMock) LogCtx() context.Context              { return context.Background() }
+func (w *cmdWorkpieceMock) PLogOffset() istructs.Offset          { return 0 }
 
 type cmdProcMock struct {
 	appParts appparts.IAppPartitions

--- a/pkg/processors/command/impl.go
+++ b/pkg/processors/command/impl.go
@@ -87,9 +87,8 @@ func (c *cmdWorkpiece) Context() context.Context {
 	return c.cmdMes.RequestCtx()
 }
 
-// need for sync projectors for logging
-func (c *cmdWorkpiece) LogCtxForSyncProjector() context.Context {
-	return c.logCtxForSyncProjectors
+func (c *cmdWorkpiece) LogCtx() context.Context {
+	return c.logCtx
 }
 
 // used in projectors.NewSyncActualizerFactoryFactory
@@ -105,6 +104,18 @@ func (c *cmdWorkpiece) GetAppStructs() istructs.IAppStructs {
 // need for sync projectors for logging
 func (c *cmdWorkpiece) PLogOffset() istructs.Offset {
 	return c.pLogOffset
+}
+
+func (c *cmdWorkpiece) GetPrincipals() []iauthnz.Principal {
+	return c.principals
+}
+
+func (c *cmdWorkpiece) ResetRateLimit(resource appdef.QName, operation appdef.OperationKind) {
+	c.appPart.ResetRateLimit(resource, operation, c.cmdMes.WSID(), c.cmdMes.Host())
+}
+
+func (c *cmdWorkpiece) Roles() []appdef.QName {
+	return c.roles
 }
 
 // https://github.com/voedger/voedger/issues/3163
@@ -312,7 +323,7 @@ func (cmdProc *cmdProc) recovery(ctx context.Context, cmd *cmdWorkpiece) (ap *ap
 
 	if lastPLogEvent != nil {
 		// re-apply the last event
-		cmd.logCtxForSyncProjectors, err = processors.LogEventAndCUDs(recoveryCtx, lastPLogEvent, lastPLogOffset, cmd.appStructs.AppDef(), 0,
+		cmd.logCtx, err = processors.LogEventAndCUDs(recoveryCtx, lastPLogEvent, lastPLogOffset, cmd.appStructs.AppDef(), 0,
 			"cp.partition_recovery.reapply", nil, "")
 		if err != nil {
 			logger.ErrorCtx(recoveryCtx, "cp.partition_recovery.logeventandcuds.error", err)
@@ -331,7 +342,7 @@ func (cmdProc *cmdProc) recovery(ctx context.Context, cmd *cmdWorkpiece) (ap *ap
 		cmd.reapplier = nil
 		cmd.workspace = nil
 		cmd.pLogEvent = nil
-		cmd.logCtxForSyncProjectors = nil
+		cmd.logCtx = nil
 		lastPLogEvent.Release() // TODO: eliminate if there will be a better solution, see https://github.com/voedger/voedger/issues/1348
 	}
 
@@ -389,7 +400,7 @@ func logEventAndCUDs(_ context.Context, cmd *cmdWorkpiece) (err error) {
 		"",
 	)
 
-	cmd.logCtxForSyncProjectors = enrichedLogCtx
+	cmd.logCtx = enrichedLogCtx
 	return err
 }
 

--- a/pkg/processors/command/provide.go
+++ b/pkg/processors/command/provide.go
@@ -77,9 +77,9 @@ func ProvideServiceFactory(appParts appparts.IAppPartitions, tm timeu.ITime,
 							cmd.syncProjectorsStart = tm.Now()
 							if err != nil {
 								cmd.appPartitionRestartScheduled = true
-								logger.ErrorCtx(cmd.logCtxForSyncProjectors, "sp.error", err)
+								logger.ErrorCtx(cmd.logCtx, "sp.error", err)
 							} else {
-								logger.VerboseCtx(cmd.logCtxForSyncProjectors, "sp.success")
+								logger.VerboseCtx(cmd.logCtx, "sp.success")
 							}
 							return err
 						}),

--- a/pkg/processors/command/types.go
+++ b/pkg/processors/command/types.go
@@ -96,6 +96,8 @@ type cmdWorkpiece struct {
 	logCtx                       context.Context // enriched log ctx from logEventAndCUDs (woffset, poffset, evqname)
 }
 
+var _ processors.IProcessorWorkpiece = (*cmdWorkpiece)(nil)
+
 type implIDGeneratorReporter struct {
 	istructs.IIDGenerator
 	generatedIDs map[istructs.RecordID]istructs.RecordID

--- a/pkg/processors/command/types.go
+++ b/pkg/processors/command/types.go
@@ -93,7 +93,7 @@ type cmdWorkpiece struct {
 	commandCtxStorage            istructs.IStateValue
 	cmdResToLog                  string
 	pLogOffset                   istructs.Offset // need for logging
-	logCtxForSyncProjectors      context.Context // enriched log ctx from logEventAndCUDs (woffset, poffset, evqname), used by sync projectors
+	logCtx                       context.Context // enriched log ctx from logEventAndCUDs (woffset, poffset, evqname)
 }
 
 type implIDGeneratorReporter struct {

--- a/pkg/processors/consts.go
+++ b/pkg/processors/consts.go
@@ -5,6 +5,8 @@
 
 package processors
 
+import "github.com/voedger/voedger/pkg/appdef"
+
 const Field_RawObject_Body = "Body"
 
 const (
@@ -21,4 +23,8 @@ const (
 	APIPath_Auth_Refresh
 	APIPath_Users
 	APIPath_N10N_SubscribeAndWatch
+)
+
+var (
+	qNameCDocWorkspaceDescriptor = appdef.NewQName(appdef.SysPackage, "WorkspaceDescriptor")
 )

--- a/pkg/processors/query/impl.go
+++ b/pkg/processors/query/impl.go
@@ -520,6 +520,10 @@ func (qw *queryWork) SetPrincipals(prns []iauthnz.Principal) {
 	qw.principals = prns
 }
 
+func (qw *queryWork) LogCtx() context.Context {
+	return qw.msg.RequestCtx()
+}
+
 func borrowAppPart(_ context.Context, qw *queryWork) error {
 	switch err := qw.borrow(); {
 	case err == nil:

--- a/pkg/processors/query/impl.go
+++ b/pkg/processors/query/impl.go
@@ -450,6 +450,8 @@ type queryWork struct {
 	responseWriterGetter func() bus.IResponseWriter
 }
 
+var _ processors.IProcessorWorkpiece = (*queryWork)(nil)
+
 func newQueryWork(msg IQueryMessage, appParts appparts.IAppPartitions,
 	maxPrepareQueries int, metrics *queryProcessorMetrics, secretReader isecrets.ISecretReader) *queryWork {
 	return &queryWork{

--- a/pkg/processors/query2/util.go
+++ b/pkg/processors/query2/util.go
@@ -83,9 +83,16 @@ type queryWork struct {
 	profileWSID          istructs.WSID
 }
 
-var _ pipeline.IWorkpiece = (*queryWork)(nil) // ensure that queryWork implements pipeline.IWorkpiece
+var _ processors.IProcessorWorkpiece = (*queryWork)(nil)
 
-// used by e.g. q.sys.IssueVerifiedValueToken
+func (qw *queryWork) AppPartitions() appparts.IAppPartitions { return qw.appParts }
+
+func (qw *queryWork) AppPartition() appparts.IAppPartition { return qw.appPart }
+
+func (qw *queryWork) GetPrincipals() []iauthnz.Principal { return qw.principals }
+
+func (qw *queryWork) Roles() []appdef.QName { return qw.roles }
+
 func (qw *queryWork) ResetRateLimit(resource appdef.QName, operation appdef.OperationKind) {
 	qw.appPart.ResetRateLimit(resource, operation, qw.msg.WSID(), qw.msg.Host())
 }

--- a/pkg/processors/query2/util.go
+++ b/pkg/processors/query2/util.go
@@ -202,3 +202,7 @@ func (qw *queryWork) getObjectSender() pipeline.IAsyncOperator {
 func (qw *queryWork) SetPrincipals(prns []iauthnz.Principal) {
 	qw.principals = prns
 }
+
+func (qw *queryWork) LogCtx() context.Context {
+	return qw.msg.RequestCtx()
+}

--- a/pkg/processors/types.go
+++ b/pkg/processors/types.go
@@ -5,6 +5,34 @@
 
 package processors
 
+import (
+	"context"
+
+	"github.com/voedger/voedger/pkg/appdef"
+	"github.com/voedger/voedger/pkg/appparts"
+	"github.com/voedger/voedger/pkg/iauthnz"
+	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/pipeline"
+)
+
 type VVMName string
 
 type APIPath int
+
+type IProcessorWorkpiece interface {
+	pipeline.IWorkpiece
+	AppPartitions() appparts.IAppPartitions
+	AppPartition() appparts.IAppPartition
+	GetPrincipals() []iauthnz.Principal
+	Roles() []appdef.QName
+	ResetRateLimit(appdef.QName, appdef.OperationKind)
+	LogCtx() context.Context
+}
+
+type IProjectorWorkpiece interface {
+	pipeline.IWorkpiece
+	AppPartition() appparts.IAppPartition
+	Event() istructs.IPLogEvent
+	LogCtx() context.Context
+	PLogOffset() istructs.Offset
+}

--- a/pkg/processors/utils.go
+++ b/pkg/processors/utils.go
@@ -20,7 +20,6 @@ import (
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/state"
 	"github.com/voedger/voedger/pkg/sys"
-	"github.com/voedger/voedger/pkg/sys/authnz"
 )
 
 // CheckUnexpectedFields validates that all keys in args are known fields of argsType.
@@ -67,7 +66,7 @@ func CheckResponseIntent(st state.IHostState) error {
 
 // returns ErrWSNotInited
 func GetWSDesc(wsid istructs.WSID, appStructs istructs.IAppStructs) (wsDesc istructs.IRecord, err error) {
-	wsDesc, err = appStructs.Records().GetSingleton(wsid, authnz.QNameCDocWorkspaceDescriptor)
+	wsDesc, err = appStructs.Records().GetSingleton(wsid, qNameCDocWorkspaceDescriptor)
 	if err == nil && wsDesc.QName() == appdef.NullQName {
 		err = ErrWSNotInited
 	}

--- a/pkg/registry/impl_createlogin.go
+++ b/pkg/registry/impl_createlogin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/voedger/voedger/pkg/appparts"
 	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/processors"
 	"github.com/voedger/voedger/pkg/sys"
 	"github.com/voedger/voedger/pkg/sys/authnz"
 )
@@ -45,9 +46,7 @@ func createLogin(args istructs.ExecCommandArgs, login string) (err error) {
 		return coreutils.NewHTTPErrorf(http.StatusBadRequest, "failed to parse app qualified name", appQName.String(), ":", err)
 	}
 
-	appParts := args.Workpiece.(interface {
-		AppPartitions() appparts.IAppPartitions
-	}).AppPartitions()
+	appParts := args.Workpiece.(processors.IProcessorWorkpiece).AppPartitions()
 	if _, err = appParts.AppDef(appQName); err != nil {
 		if errors.Is(err, appparts.ErrNotFound) {
 			return coreutils.NewHTTPErrorf(http.StatusBadRequest, fmt.Sprintf("target app %s is not found", appQName))

--- a/pkg/sys/authnz/impl_enrichprincipaltoken.go
+++ b/pkg/sys/authnz/impl_enrichprincipaltoken.go
@@ -11,6 +11,7 @@ import (
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/istructsmem"
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
+	"github.com/voedger/voedger/pkg/processors"
 	"github.com/voedger/voedger/pkg/sys/storages"
 
 	"golang.org/x/exp/slices"
@@ -41,7 +42,7 @@ func provideExecQryEnrichPrincipalToken(atf payloads.IAppTokensFactory) istructs
 			return err
 		}
 
-		principals := args.Workpiece.(interface{ GetPrincipals() []iauthnz.Principal }).GetPrincipals()
+		principals := args.Workpiece.(processors.IProcessorWorkpiece).GetPrincipals()
 		for _, prn := range principals {
 			if prn.Kind != iauthnz.PrincipalKind_Role {
 				continue

--- a/pkg/sys/collection/collection_utils_test.go
+++ b/pkg/sys/collection/collection_utils_test.go
@@ -146,9 +146,9 @@ func (w *testCmdWorkpiece) Release() {
 	}
 }
 
-func (w *testCmdWorkpiece) Context() context.Context { return context.Background() }
+func (w *testCmdWorkpiece) Context() context.Context    { return context.Background() }
 func (w *testCmdWorkpiece) PLogOffset() istructs.Offset { return 0 }
-func (w *testCmdWorkpiece) LogCtxForSyncProjector() context.Context { return context.Background() }
+func (w *testCmdWorkpiece) LogCtx() context.Context     { return context.Background() }
 
 type testCmdProc struct {
 	pipeline.ISyncPipeline

--- a/pkg/sys/sqlquery/impl.go
+++ b/pkg/sys/sqlquery/impl.go
@@ -15,7 +15,6 @@ import (
 	"github.com/blastrain/vitess-sqlparser/sqlparser"
 
 	"github.com/voedger/voedger/pkg/appdef"
-	"github.com/voedger/voedger/pkg/appparts"
 	"github.com/voedger/voedger/pkg/bus"
 	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/coreutils/federation"
@@ -26,6 +25,7 @@ import (
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/itokens"
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
+	"github.com/voedger/voedger/pkg/processors"
 	blobprocessor "github.com/voedger/voedger/pkg/processors/blobber"
 	"github.com/voedger/voedger/pkg/sys"
 	"github.com/voedger/voedger/pkg/sys/authnz"
@@ -183,8 +183,9 @@ func provideExecQrySQLQuery(federation federation.IFederation, itokens itokens.I
 				for f := range f.fields {
 					fields = append(fields, f)
 				}
-				apppart := args.Workpiece.(interface{ AppPartition() appparts.IAppPartition }).AppPartition()
-				roles := args.Workpiece.(interface{ Roles() []appdef.QName }).Roles()
+				wp := args.Workpiece.(processors.IProcessorWorkpiece)
+				apppart := wp.AppPartition()
+				roles := wp.Roles()
 				ok, err := apppart.IsOperationAllowed(args.Workspace, appdef.OperationKind_Select, sourceTableName, fields, roles)
 				if err != nil {
 					// notest
@@ -223,9 +224,7 @@ func provideExecQrySQLQuery(federation federation.IFederation, itokens itokens.I
 			if e != nil {
 				return e
 			}
-			appParts := args.Workpiece.(interface {
-				AppPartitions() appparts.IAppPartitions
-			}).AppPartitions()
+			appParts := args.Workpiece.(processors.IProcessorWorkpiece).AppPartitions()
 			if sourceTableName == plog {
 				return coreutils.WrapSysError(readPlog(ctx, wsID, offset, limit, appStructs, f, callback, appStructs.AppDef(), appParts),
 					http.StatusBadRequest)

--- a/pkg/sys/verifier/impl.go
+++ b/pkg/sys/verifier/impl.go
@@ -21,6 +21,7 @@ import (
 	"github.com/voedger/voedger/pkg/istructsmem"
 	"github.com/voedger/voedger/pkg/itokens"
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
+	"github.com/voedger/voedger/pkg/processors"
 	"github.com/voedger/voedger/pkg/state"
 	"github.com/voedger/voedger/pkg/sys"
 	"github.com/voedger/voedger/pkg/sys/smtp"
@@ -160,10 +161,7 @@ func provideIVVTExec(itokens itokens.ITokens, asp istructs.IAppStructsProvider) 
 		}
 
 		// code ok -> reset per-profile rate limit
-		limitsResetter := args.Workpiece.(interface {
-			ResetRateLimit(appdef.QName, appdef.OperationKind)
-		})
-		limitsResetter.ResetRateLimit(QNameQueryIssueVerifiedValueToken, appdef.OperationKind_Execute)
+		args.Workpiece.(processors.IProcessorWorkpiece).ResetRateLimit(QNameQueryIssueVerifiedValueToken, appdef.OperationKind_Execute)
 
 		return callback(&ivvtResult{verifiedValueToken: verifiedValueToken})
 	}

--- a/pkg/sys/workspace/impl.go
+++ b/pkg/sys/workspace/impl.go
@@ -5,7 +5,6 @@
 package workspace
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -122,7 +121,7 @@ func execCmdCreateWorkspaceID(args istructs.ExecCommandArgs) (err error) {
 
 	// Get new WSID from View<NextBaseWSID>
 	as := args.State.AppStructs()
-	newWSID, err := GetNextWSID(args.Workpiece.(interface{ Context() context.Context }).Context(), as, args.WSID.ClusterID())
+	newWSID, err := GetNextWSID(args.State.Context(), as, args.WSID.ClusterID())
 	if err != nil {
 		return err
 	}

--- a/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/change.md
+++ b/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/change.md
@@ -1,0 +1,32 @@
+---
+registered_at: 2026-04-03T07:32:17Z
+change_id: 2604030732-expose-workpiece-interfaces
+baseline: 5860bbfcd545246903d6a74ffcd40a2162abc828
+issue_url: https://untill.atlassian.net/browse/AIR-3446
+archived_at: 2026-04-03T14:00:42Z
+---
+
+# Change request: Replace anonymous workpiece casts with named processor interfaces
+
+## Why
+
+Command handlers, query handlers, and projectors cast `args.Workpiece` (typed `interface{}`) to anonymous interfaces to access processor-level methods like `AppPartitions()`, `ResetRateLimit()`, and `GetPrincipals()`. These anonymous casts are not discoverable, not checked against the workpiece implementation at a single definition point, and duplicated across multiple files. `LogCtx` also needs to be exposed for structured logging in extensions (AIR-3469).
+
+See [issue.md](issue.md) for details.
+
+## What
+
+Define named interfaces in `pkg/processors`:
+
+- `IProcessorWorkpiece` for command and query handlers — provides `AppPartitions()`, `AppPartition()`, `GetPrincipals()`, `Roles()`, `ResetRateLimit()`, `LogCtx()`
+- `IProjectorWorkpiece` for sync actualizer projectors — provides `AppPartition()`, `Event()`, `LogCtx()`, `PLogOffset()`
+
+Replace anonymous casts with named interface casts at all affected call sites:
+
+- `pkg/cluster/impl_vsqlupdate.go` — `AppPartitions()`
+- `pkg/registry/impl_createlogin.go` — `AppPartitions()`
+- `pkg/sys/sqlquery/impl.go` — `AppPartitions()`, `AppPartition()`, `Roles()`
+- `pkg/sys/verifier/impl.go` — `ResetRateLimit()`
+- `pkg/sys/authnz/impl_enrichprincipaltoken.go` — `GetPrincipals()`
+- `pkg/sys/workspace/impl.go` — replace `Workpiece` cast with `args.State.Context()` (already available on `IState`)
+- `pkg/processors/actualizers/impl.go` — replace `syncActualizerWorkpiece` with `IProjectorWorkpiece`

--- a/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/change.md
+++ b/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/change.md
@@ -30,3 +30,15 @@ Replace anonymous casts with named interface casts at all affected call sites:
 - `pkg/sys/authnz/impl_enrichprincipaltoken.go` — `GetPrincipals()`
 - `pkg/sys/workspace/impl.go` — replace `Workpiece` cast with `args.State.Context()` (already available on `IState`)
 - `pkg/processors/actualizers/impl.go` — replace `syncActualizerWorkpiece` with `IProjectorWorkpiece`
+
+Add compile-time assertions and missing interface methods:
+
+- `pkg/processors/command/types.go` — compile-time assertion `var _ processors.IProcessorWorkpiece = (*cmdWorkpiece)(nil)`
+- `pkg/processors/command/impl.go` — rename `logCtxForSyncProjectors`/`LogCtxForSyncProjector()` to `logCtx`/`LogCtx()`, add `GetPrincipals()`, `ResetRateLimit()`, `Roles()` methods
+- `pkg/processors/query/impl.go` — compile-time assertion, add `LogCtx()` method
+- `pkg/processors/query2/util.go` — compile-time assertion upgraded from `pipeline.IWorkpiece` to `processors.IProcessorWorkpiece`, add `AppPartitions()`, `AppPartition()`, `GetPrincipals()`, `Roles()`, `LogCtx()` methods
+
+Move `qNameCDocWorkspaceDescriptor` to break import cycle:
+
+- `pkg/processors/consts.go` — add `qNameCDocWorkspaceDescriptor`
+- `pkg/processors/utils.go` — replace `authnz.QNameCDocWorkspaceDescriptor` with local `qNameCDocWorkspaceDescriptor`

--- a/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/how.md
+++ b/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/how.md
@@ -1,0 +1,47 @@
+# How: Replace anonymous workpiece casts with named processor interfaces
+
+## Approach
+
+Define two named interfaces in `pkg/processors/types.go` that replace all anonymous workpiece casts:
+
+```go
+type IProcessorWorkpiece interface {
+    pipeline.IWorkpiece
+    AppPartitions() appparts.IAppPartitions
+    AppPartition() appparts.IAppPartition
+    GetPrincipals() []iauthnz.Principal
+    Roles() []appdef.QName
+    ResetRateLimit(appdef.QName, appdef.OperationKind)
+    LogCtx() context.Context
+}
+
+type IProjectorWorkpiece interface {
+    pipeline.IWorkpiece
+    AppPartition() appparts.IAppPartition
+    Event() istructs.IPLogEvent
+    LogCtx() context.Context
+    PLogOffset() istructs.Offset
+}
+```
+
+No import cycles: `pkg/processors` already imports `appparts`, `iauthnz`, `istructs`, and `pipeline`.
+
+At each call site, replace `args.Workpiece.(interface{ Method() Type })` with `args.Workpiece.(processors.IProcessorWorkpiece)`. For the sync actualizer, replace the local `syncActualizerWorkpiece` interface in `pkg/processors/actualizers/impl.go` with `processors.IProjectorWorkpiece`.
+
+Special case: `pkg/sys/workspace/impl.go` casts workpiece for `Context()` which is already available on `istructs.IState` — replace with `args.State.Context()`, no workpiece cast needed.
+
+No changes to `istructs.IState`, `PrepareArgs`, `ExecCommandArgs`, `ExecQueryArgs`, or any factory functions.
+
+References:
+
+- [pkg/processors/types.go](../../../../pkg/processors/types.go)
+- [pkg/processors/command/impl.go](../../../../pkg/processors/command/impl.go)
+- [pkg/processors/query/impl.go](../../../../pkg/processors/query/impl.go)
+- [pkg/processors/query2/util.go](../../../../pkg/processors/query2/util.go)
+- [pkg/processors/actualizers/impl.go](../../../../pkg/processors/actualizers/impl.go)
+- [pkg/cluster/impl_vsqlupdate.go](../../../../pkg/cluster/impl_vsqlupdate.go)
+- [pkg/registry/impl_createlogin.go](../../../../pkg/registry/impl_createlogin.go)
+- [pkg/sys/sqlquery/impl.go](../../../../pkg/sys/sqlquery/impl.go)
+- [pkg/sys/verifier/impl.go](../../../../pkg/sys/verifier/impl.go)
+- [pkg/sys/authnz/impl_enrichprincipaltoken.go](../../../../pkg/sys/authnz/impl_enrichprincipaltoken.go)
+- [pkg/sys/workspace/impl.go](../../../../pkg/sys/workspace/impl.go)

--- a/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/impl.md
+++ b/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/impl.md
@@ -1,0 +1,44 @@
+# Implementation plan: Replace anonymous workpiece casts with named processor interfaces
+
+## Construction
+
+### Interface definitions
+
+- [x] update: [pkg/processors/types.go](../../../../pkg/processors/types.go)
+  - add: `IProcessorWorkpiece` interface (embeds `pipeline.IWorkpiece`, exposes `AppPartitions()`, `AppPartition()`, `GetPrincipals()`, `Roles()`, `ResetRateLimit()`, `LogCtx()`)
+  - add: `IProjectorWorkpiece` interface (embeds `pipeline.IWorkpiece`, exposes `AppPartition()`, `Event()`, `LogCtx()`, `PLogOffset()`)
+
+### Call site updates
+
+- [x] update: [pkg/cluster/impl_vsqlupdate.go](../../../../pkg/cluster/impl_vsqlupdate.go)
+  - replace: anonymous cast to `interface{ AppPartitions() }` with `processors.IProcessorWorkpiece`
+
+- [x] update: [pkg/registry/impl_createlogin.go](../../../../pkg/registry/impl_createlogin.go)
+  - replace: anonymous cast to `interface{ AppPartitions() }` with `processors.IProcessorWorkpiece`
+
+- [x] update: [pkg/sys/sqlquery/impl.go](../../../../pkg/sys/sqlquery/impl.go)
+  - replace: anonymous casts to `interface{ AppPartitions() }`, `interface{ AppPartition() }`, `interface{ Roles() }` with `processors.IProcessorWorkpiece`
+
+- [x] update: [pkg/sys/verifier/impl.go](../../../../pkg/sys/verifier/impl.go)
+  - replace: anonymous cast to `interface{ ResetRateLimit() }` with `processors.IProcessorWorkpiece`
+
+- [-] update: [pkg/sys/authnz/impl_enrichprincipaltoken.go](../../../../pkg/sys/authnz/impl_enrichprincipaltoken.go) — skipped: import cycle (`processors` → `sys/authnz` → `processors`)
+  - replace: anonymous cast to `interface{ GetPrincipals() }` with `processors.IProcessorWorkpiece`
+
+- [x] update: [pkg/sys/workspace/impl.go](../../../../pkg/sys/workspace/impl.go)
+  - replace: `args.Workpiece.(interface{ Context() context.Context }).Context()` with `args.State.Context()`
+
+### Sync actualizer
+
+- [x] update: [pkg/processors/actualizers/impl.go](../../../../pkg/processors/actualizers/impl.go)
+  - remove: local `syncActualizerWorkpiece` interface
+  - replace: all `syncActualizerWorkpiece` references with `processors.IProjectorWorkpiece`
+  - rename: `LogCtxForSyncProjector()` usage to `LogCtx()` (requires updating the workpiece implementation)
+
+### Query processor `LogCtx()` implementations
+
+- [x] update: [pkg/processors/query/impl.go](../../../../pkg/processors/query/impl.go)
+  - add: `func (qw *queryWork) LogCtx() context.Context` returning `qw.msg.RequestCtx()`
+
+- [x] update: [pkg/processors/query2/util.go](../../../../pkg/processors/query2/util.go)
+  - add: `func (qw *queryWork) LogCtx() context.Context` returning `qw.msg.RequestCtx()`

--- a/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/impl.md
+++ b/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/impl.md
@@ -22,7 +22,7 @@
 - [x] update: [pkg/sys/verifier/impl.go](../../../../pkg/sys/verifier/impl.go)
   - replace: anonymous cast to `interface{ ResetRateLimit() }` with `processors.IProcessorWorkpiece`
 
-- [-] update: [pkg/sys/authnz/impl_enrichprincipaltoken.go](../../../../pkg/sys/authnz/impl_enrichprincipaltoken.go) — skipped: import cycle (`processors` → `sys/authnz` → `processors`)
+- [x] update: [pkg/sys/authnz/impl_enrichprincipaltoken.go](../../../../pkg/sys/authnz/impl_enrichprincipaltoken.go)
   - replace: anonymous cast to `interface{ GetPrincipals() }` with `processors.IProcessorWorkpiece`
 
 - [x] update: [pkg/sys/workspace/impl.go](../../../../pkg/sys/workspace/impl.go)
@@ -35,10 +35,43 @@
   - replace: all `syncActualizerWorkpiece` references with `processors.IProjectorWorkpiece`
   - rename: `LogCtxForSyncProjector()` usage to `LogCtx()` (requires updating the workpiece implementation)
 
-### Query processor `LogCtx()` implementations
+### Command processor workpiece
+
+- [x] update: [pkg/processors/command/types.go](../../../../pkg/processors/command/types.go)
+  - add: compile-time assertion `var _ processors.IProcessorWorkpiece = (*cmdWorkpiece)(nil)`
+  - rename: field `logCtxForSyncProjectors` to `logCtx`
+
+- [x] update: [pkg/processors/command/impl.go](../../../../pkg/processors/command/impl.go)
+  - rename: `LogCtxForSyncProjector()` to `LogCtx()`, returning `c.logCtx`
+  - add: `GetPrincipals()`, `ResetRateLimit()`, `Roles()` methods
+
+- [x] update: [pkg/processors/command/provide.go](../../../../pkg/processors/command/provide.go)
+  - rename: `logCtxForSyncProjectors` references to `logCtx`
+
+### Query processor workpiece updates
 
 - [x] update: [pkg/processors/query/impl.go](../../../../pkg/processors/query/impl.go)
+  - add: compile-time assertion `var _ processors.IProcessorWorkpiece = (*queryWork)(nil)`
   - add: `func (qw *queryWork) LogCtx() context.Context` returning `qw.msg.RequestCtx()`
 
 - [x] update: [pkg/processors/query2/util.go](../../../../pkg/processors/query2/util.go)
+  - upgrade: compile-time assertion from `pipeline.IWorkpiece` to `processors.IProcessorWorkpiece`
+  - add: `AppPartitions()`, `AppPartition()`, `GetPrincipals()`, `Roles()` methods
   - add: `func (qw *queryWork) LogCtx() context.Context` returning `qw.msg.RequestCtx()`
+
+### Import cycle fix
+
+- [x] update: [pkg/processors/consts.go](../../../../pkg/processors/consts.go)
+  - add: `qNameCDocWorkspaceDescriptor` variable
+
+- [x] update: [pkg/processors/utils.go](../../../../pkg/processors/utils.go)
+  - replace: `authnz.QNameCDocWorkspaceDescriptor` with local `qNameCDocWorkspaceDescriptor`
+  - remove: `authnz` import
+
+### Test updates
+
+- [x] update: [pkg/processors/actualizers/impl_helpers_test.go](../../../../pkg/processors/actualizers/impl_helpers_test.go)
+  - rename: `LogCtxForSyncProjector()` to `LogCtx()`
+
+- [x] update: [pkg/sys/collection/collection_utils_test.go](../../../../pkg/sys/collection/collection_utils_test.go)
+  - rename: `LogCtxForSyncProjector()` to `LogCtx()`

--- a/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/issue.md
+++ b/uspecs/changes/archive/2604/2604031400-expose-workpiece-interfaces/issue.md
@@ -1,0 +1,27 @@
+# AIR-3446: processors: Expose workpiece interfaces and LogContext via IState/PrepareArgs
+
+- **Type:** Sub-task
+- **Status:** In Progress
+- **Assignee:** d.gribanov@dev.untill.com
+- **URL:** https://untill.atlassian.net/browse/AIR-3446
+
+## Why
+
+Workpieces that go through command and query processors have interfaces that are missing in `IState` but required for certain functions. In these cases the workpiece is cast to an anonymous interface with the required method, like here:
+
+https://github.com/voedger/voedger/blob/5860bbfcd545246903d6a74ffcd40a2162abc828/pkg/sys/verifier/impl.go#L163
+
+```go
+limitsResetter := args.Workpiece.(interface {
+    ResetRateLimit(appdef.QName, appdef.OperationKind)
+})
+```
+
+That looks like a hack. `LogContext` should also be exposed somewhere in `IState` or in `PrepareArgs` to make it possible to implement [AIR-3469](https://untill.atlassian.net/browse/AIR-3469).
+
+## What
+
+- Determine all places where the workpiece is cast to anonymous interfaces (in commands, queries, and projectors) to identify all interfaces required for functions and projectors
+- Include all determined interfaces in `IState` or `PrepareArgs`; investigate where the better placement is
+- Update technical design for logging if necessary
+

--- a/uspecs/specs/prod/apps/logging--td.md
+++ b/uspecs/specs/prod/apps/logging--td.md
@@ -213,16 +213,16 @@ The enriched context returned by `processors.LogEventAndCUDs()` (with attribs `w
 - `logEventAndCUDs` (called after PLog write) saves the enriched context to `cmdWorkpiece.logCtx`
 - During partition recovery, `LogEventAndCUDs()` is called for the re-applied event and its result is also stored in `cmdWorkpiece.logCtx`
 - Command processor sync projector handler reads `cmd.logCtx` for `sp.success` and `sp.error` logs
-- Each projector branch receives `cmd.logCtx` (via `syncActualizerWorkpiece.LogCtxForSyncProjector()`) for its per-projector logs
+- Each projector branch receives `cmd.logCtx` (via `processors.IProjectorWorkpiece.LogCtx()`) for its per-projector logs
 
 **Command processor logs** (using `cmd.logCtx`):
 
 - After all sync projectors succeed: level `Verbose`, stage `sp.success`, msg (empty)
 - Sync projector error: level `Error`, stage `sp.error`, msg `<error message>`
 
-**Each triggered sync projector** (using `LogCtxForSyncProjector()`):
+**Each triggered sync projector** (using `LogCtx()`):
 
-The event is already logged by the command processor (`cp.plog_saved`), so there is no separate `logEventAndCUDs` call per projector. The projector uses `LogCtxForSyncProjector()` directly to obtain the enriched context and extends it with `extension`=`<projector QName>`:
+The event is already logged by the command processor (`cp.plog_saved`), so there is no separate `logEventAndCUDs` call per projector. The projector uses `processors.IProjectorWorkpiece.LogCtx()` to obtain the enriched context and extends it with `extension`=`<projector QName>`:
 
 - Right before `IAppParts.Invoke()`: level `Verbose`, stage `sp.triggeredby`, msg `<triggered by qname>`, `extension`=`<projector QName>`
 - After successful `Invoke()`: level `Verbose`, stage `sp.success`, `extension`=`<projector QName>`, msg (empty)


### PR DESCRIPTION
registered_at: 2026-04-03T07:32:17Z
change_id: 2604030732-expose-workpiece-interfaces
baseline: 5860bbfcd545246903d6a74ffcd40a2162abc828
issue_url: https://untill.atlassian.net/browse/AIR-3446
archived_at: 2026-04-03T14:00:42Z

# Change request: Replace anonymous workpiece casts with named processor interfaces

## Why

Command handlers, query handlers, and projectors cast `args.Workpiece` (typed `interface{}`) to anonymous interfaces to access processor-level methods like `AppPartitions()`, `ResetRateLimit()`, and `GetPrincipals()`. These anonymous casts are not discoverable, not checked against the workpiece implementation at a single definition point, and duplicated across multiple files. `LogCtx` also needs to be exposed for structured logging in extensions (AIR-3469).

See [issue.md](issue.md) for details.

## What

Define named interfaces in `pkg/processors`:

- `IProcessorWorkpiece` for command and query handlers — provides `AppPartitions()`, `AppPartition()`, `GetPrincipals()`, `Roles()`, `ResetRateLimit()`, `LogCtx()`
- `IProjectorWorkpiece` for sync actualizer projectors — provides `AppPartition()`, `Event()`, `LogCtx()`, `PLogOffset()`

Replace anonymous casts with named interface casts at all affected call sites:

- `pkg/cluster/impl_vsqlupdate.go` — `AppPartitions()`
- `pkg/registry/impl_createlogin.go` — `AppPartitions()`
- `pkg/sys/sqlquery/impl.go` — `AppPartitions()`, `AppPartition()`, `Roles()`
- `pkg/sys/verifier/impl.go` — `ResetRateLimit()`
- `pkg/sys/authnz/impl_enrichprincipaltoken.go` — `GetPrincipals()`
- `pkg/sys/workspace/impl.go` — replace `Workpiece` cast with `args.State.Context()` (already available on `IState`)
- `pkg/processors/actualizers/impl.go` — replace `syncActualizerWorkpiece` with `IProjectorWorkpiece`
