### PR TITLE
[AIR-3510] Use proxy protocol to get the real request IP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
+	github.com/pires/go-proxyproto v0.11.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/untillpro/gojay v1.2.17-0.20250325110036-70ad3373aa24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/pires/go-proxyproto v0.11.0 h1:gUQpS85X/VJMdUsYyEgyn59uLJvGqPhJV5YvG68wXH4=
+github.com/pires/go-proxyproto v0.11.0/go.mod h1:ZKAAyp3cgy5Y5Mo4n9AlScrkCZwUy0g3Jf+slqQVcuU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/router/consts.go
+++ b/pkg/router/consts.go
@@ -49,6 +49,7 @@ const (
 	hours24                       = 24 * time.Hour
 	DefaultRetryAfterSecondsOn503 = 1
 	logAttrib_Origin              = "origin"
+	logAttrib_Headers             = "headers"
 	logAttrib_Projection          = "projection"
 	logAttrib_ChannelID           = "channelid"
 	n10nErrorStage                = "n10n.error"

--- a/pkg/router/impl_http.go
+++ b/pkg/router/impl_http.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	proxyproto "github.com/pires/go-proxyproto"
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/bus"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
@@ -82,6 +83,10 @@ func (s *httpServer) prepareBasicServer(handler http.Handler) (err error) {
 	}
 
 	s.listeningPort.Store(uint32(s.listener.Addr().(*net.TCPAddr).Port)) // nolint G115
+
+	if s.UseProxyProtocol {
+		s.listener = &proxyproto.Listener{Listener: s.listener}
+	}
 
 	if s.ConnectionsLimit > 0 {
 		s.listener = netutil.LimitListener(s.listener, s.ConnectionsLimit)

--- a/pkg/router/types.go
+++ b/pkg/router/types.go
@@ -31,6 +31,7 @@ type HTTPServerParams struct {
 	WriteTimeout     int
 	ReadTimeout      int
 	ConnectionsLimit int
+	UseProxyProtocol bool
 }
 
 type RouterParams struct {

--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -16,7 +16,9 @@ import (
 	"net/http"
 	"net/url"
 	"runtime/debug"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/voedger/voedger/pkg/appdef"
@@ -159,8 +161,27 @@ func withLogAttribs(ctx context.Context, data validatedData, busRequest bus.Requ
 		logger.LogAttr_VApp:      data.appQName,
 		logger.LogAttr_Extension: extension,
 		logAttrib_Origin:         req.Header.Get(httpu.Origin),
+		logAttrib_Headers:        formatHeaders(req.Header),
 	})
 	return enrichedCtx
+}
+
+func formatHeaders(h http.Header) string {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(';')
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(strings.Join(h[k], ","))
+	}
+	return b.String()
 }
 
 func logLatency(ctx context.Context, sentAt time.Time) {

--- a/pkg/sys/it/impl_cud_test.go
+++ b/pkg/sys/it/impl_cud_test.go
@@ -24,6 +24,8 @@ func TestBasicUsage_CUD(t *testing.T) {
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
 
+	logger.SetLogLevel(logger.LogLevelVerbose)
+
 	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
 
 	t.Run("create", func(t *testing.T) {

--- a/pkg/sys/it/impl_cud_test.go
+++ b/pkg/sys/it/impl_cud_test.go
@@ -24,8 +24,6 @@ func TestBasicUsage_CUD(t *testing.T) {
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
 
-	logger.SetLogLevel(logger.LogLevelVerbose)
-
 	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
 
 	t.Run("create", func(t *testing.T) {

--- a/pkg/vvm/provide.go
+++ b/pkg/vvm/provide.go
@@ -566,6 +566,7 @@ func provideRouterParams(cfg *VVMConfig, port VVMPortType) router.RouterParams {
 			WriteTimeout:     cfg.RouterWriteTimeout,
 			ReadTimeout:      cfg.RouterReadTimeout,
 			ConnectionsLimit: cfg.RouterConnectionsLimit,
+			UseProxyProtocol: cfg.RouterUseProxyProtocol,
 		},
 		HTTP01ChallengeHosts: cfg.RouterHTTP01ChallengeHosts,
 		RouteDefault:         cfg.RouteDefault,

--- a/pkg/vvm/types.go
+++ b/pkg/vvm/types.go
@@ -141,6 +141,7 @@ type VVMConfig struct {
 	RouterWriteTimeout               int
 	RouterReadTimeout                int
 	RouterConnectionsLimit           int
+	RouterUseProxyProtocol           bool
 	RouterHTTP01ChallengeHosts       []string
 	RouteDefault                     string
 	Routes                           map[string]string

--- a/pkg/vvm/wire_gen.go
+++ b/pkg/vvm/wire_gen.go
@@ -635,6 +635,7 @@ func provideRouterParams(cfg *VVMConfig, port VVMPortType) router.RouterParams {
 			WriteTimeout:     cfg.RouterWriteTimeout,
 			ReadTimeout:      cfg.RouterReadTimeout,
 			ConnectionsLimit: cfg.RouterConnectionsLimit,
+			UseProxyProtocol: cfg.RouterUseProxyProtocol,
 		},
 		HTTP01ChallengeHosts: cfg.RouterHTTP01ChallengeHosts,
 		RouteDefault:         cfg.RouteDefault,

--- a/uspecs/changes/archive/2604/2604031446-proxy-protocol-real-ip/change.md
+++ b/uspecs/changes/archive/2604/2604031446-proxy-protocol-real-ip/change.md
@@ -1,0 +1,22 @@
+---
+registered_at: 2026-04-03T14:07:52Z
+change_id: 2604031407-proxy-protocol-real-ip
+baseline: 5860bbfcd545246903d6a74ffcd40a2162abc828
+issue_url: https://untill.atlassian.net/browse/AIR-3510
+archived_at: 2026-04-03T14:46:19Z
+---
+
+# Change request: Use proxy protocol to get the real request IP
+
+## Why
+
+We are behind Hetzner's load balancer, so the real IP of the request is not available. `http.Request.Host` returns `10.0.0.2`, and `X-Forwarded-For` / `X-Real-IP` headers are empty.
+
+See [issue.md](issue.md) for details.
+
+## What
+
+Use proxy protocol in the router to obtain the real client IP address from the load balancer:
+
+- Enable proxy protocol support in the router to parse the PROXY protocol header
+- Extract the real client IP from the proxy protocol header and make it available in request handling

--- a/uspecs/changes/archive/2604/2604031446-proxy-protocol-real-ip/how.md
+++ b/uspecs/changes/archive/2604/2604031446-proxy-protocol-real-ip/how.md
@@ -1,0 +1,17 @@
+# How: Use proxy protocol to get the real request IP
+
+## Approach
+
+- Use `github.com/pires/go-proxyproto` library to wrap the `net.Listener` in `pkg/router/impl_http.go` (`httpServer.prepareBasicServer`). After `net.Listen("tcp", ...)` returns, wrap the listener with `proxyproto.Listener` so that `net.Conn.RemoteAddr()` automatically returns the real client IP from the PROXY protocol header
+- Add a `UseProxyProtocol` flag to `HTTPServerParams` in `pkg/router/types.go` so the wrapping is opt-in (only enable when behind a proxy-protocol-capable LB)
+- No downstream changes needed: `remoteIP(req.RemoteAddr)` in `pkg/router/utils.go` (`createBusRequest`) already extracts the host from `RemoteAddr`, which will now contain the real client IP
+- The same wrapping applies to the HTTPS listener path since `httpsService` reuses the same `prepareBasicServer` method
+- Consider whether `pkg/ihttpimpl/impl.go` (the alternative HTTP processor) also needs the same wrapping
+- Append all request headers to the router log context under a `headers` attribute in `withLogAttribs` in `pkg/router/utils.go` to verify real IP propagation in production
+
+References:
+
+- [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+- [pkg/router/types.go](../../../../pkg/router/types.go)
+- [pkg/router/utils.go](../../../../pkg/router/utils.go)
+- [pkg/ihttpimpl/impl.go](../../../../pkg/ihttpimpl/impl.go)

--- a/uspecs/changes/archive/2604/2604031446-proxy-protocol-real-ip/impl.md
+++ b/uspecs/changes/archive/2604/2604031446-proxy-protocol-real-ip/impl.md
@@ -1,0 +1,33 @@
+# Implementation plan: Use proxy protocol to get the real request IP
+
+## Provisioning and configuration
+
+- [x] update: [go.mod](../../../../go.mod): Add go-proxyproto library
+  - `go get github.com/pires/go-proxyproto@v0.11.0`
+
+## Technical design
+
+- [x] update: [prod/apps/logging--td.md](../../../../specs/prod/apps/logging--td.md)
+  - update: Router section — add `headers` attribute (all request headers as a formatted string) to `withLogAttribs` context attributes for production debugging of real IP propagation
+
+## Construction
+
+### Router changes
+
+- [x] update: [pkg/router/types.go](../../../../pkg/router/types.go)
+  - add: `UseProxyProtocol bool` field to `HTTPServerParams`
+- [x] update: [pkg/router/consts.go](../../../../pkg/router/consts.go)
+  - add: `logAttrib_Headers` constant for the `headers` log attribute key
+- [x] update: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+  - update: `prepareBasicServer` — wrap listener with `proxyproto.Listener` when `UseProxyProtocol` is true (after `net.Listen`, before `LimitListener`)
+- [x] update: [pkg/router/utils.go](../../../../pkg/router/utils.go)
+  - add: `formatHeaders` helper that formats `http.Header` as a single string
+  - update: `withLogAttribs` — add `logAttrib_Headers: formatHeaders(req.Header)` to context attributes
+
+### VVM wiring
+
+- [x] update: [pkg/vvm/types.go](../../../../pkg/vvm/types.go)
+  - add: `RouterUseProxyProtocol bool` field to `VVMConfig`
+- [x] update: [pkg/vvm/provide.go](../../../../pkg/vvm/provide.go)
+  - update: `provideRouterParams` — pass `cfg.RouterUseProxyProtocol` to `HTTPServerParams.UseProxyProtocol`
+- [x] Review

--- a/uspecs/changes/archive/2604/2604031446-proxy-protocol-real-ip/issue.md
+++ b/uspecs/changes/archive/2604/2604031446-proxy-protocol-real-ip/issue.md
@@ -1,0 +1,14 @@
+# AIR-3510: voedger: try proxy protocol to get the real request IP
+
+- **Type:** Sub-task
+- **Status:** In Progress
+- **Assignee:** d.gribanov@dev.untill.com
+
+## Why
+
+We're behind Hetzner's load balancer so we do not have the real IP of the request. `http.Request.Host` is `10.0.0.2`, no `X-Forwarded-For`, `X-Real-IP` headers are empty.
+
+## What
+
+Use proxy protocol in router.
+

--- a/uspecs/specs/prod/apps/logging--td.md
+++ b/uspecs/specs/prod/apps/logging--td.md
@@ -149,6 +149,7 @@ Uses `vapp="sys/voedger"`, `extension="sys._Leadership"`, `key` attribs.
   - `wsid`: Workspace ID from validated data
   - `extension`: Resource name (API v1) or QName/API path (API v2)
   - `origin`: HTTP Origin header value
+  - `headers`: all request headers formatted as a single string for production debugging of real IP propagation
 - Request received: level `Verbose`, stage `routing.accepted`, msg (empty)
 - First response from bus (immediately after `SendRequest` returns): level `Verbose`, stage `routing.latency1`, msg `<latency_ms>`
 - Error sending request to VVM: level `Error`, stage `routing.send2vvm.error`, msg `<error message>`
@@ -594,6 +595,7 @@ func withLogAttribs(ctx context.Context, data validatedData,
         logger.LogAttr_VApp:      data.appQName,
         logger.LogAttr_Extension: extension,
         logAttrib_Origin:         req.Header.Get(httpu.Origin),
+        logAttrib_Headers:        formatHeaders(req.Header),
     })
 }
 ```


### PR DESCRIPTION
registered_at: 2026-04-03T14:07:52Z
change_id: 2604031407-proxy-protocol-real-ip
baseline: 5860bbfcd545246903d6a74ffcd40a2162abc828
issue_url: https://untill.atlassian.net/browse/AIR-3510
archived_at: 2026-04-03T14:46:19Z

# Change request: Use proxy protocol to get the real request IP

## Why

We are behind Hetzner's load balancer, so the real IP of the request is not available. `http.Request.Host` returns `10.0.0.2`, and `X-Forwarded-For` / `X-Real-IP` headers are empty.

See [issue.md](issue.md) for details.

## What

Use proxy protocol in the router to obtain the real client IP address from the load balancer:

- Enable proxy protocol support in the router to parse the PROXY protocol header
- Extract the real client IP from the proxy protocol header and make it available in request handling
