### PR TITLE
[AIR-3532] Skip singletons in ActualizeSequencesFromPLog

### DIFF
--- a/pkg/appparts/internal/seqstorage/impl.go
+++ b/pkg/appparts/internal/seqstorage/impl.go
@@ -28,7 +28,8 @@ func (ss *implISeqStorage) ActualizeSequencesFromPLog(ctx context.Context, offse
 				if !cud.IsNew() {
 					continue
 				}
-				if singleton, ok := ss.appDef.Type(cud.QName()).(appdef.ISingleton); ok && singleton.Singleton() {
+				if cud.ID() < istructs.FirstUserRecordID {
+					// skipping e.g. singletons
 					continue
 				}
 				seqQName := istructs.QNameRecordIDSequence

--- a/pkg/appparts/internal/seqstorage/impl.go
+++ b/pkg/appparts/internal/seqstorage/impl.go
@@ -28,6 +28,9 @@ func (ss *implISeqStorage) ActualizeSequencesFromPLog(ctx context.Context, offse
 				if !cud.IsNew() {
 					continue
 				}
+				if singleton, ok := ss.appDef.Type(cud.QName()).(appdef.ISingleton); ok && singleton.Singleton() {
+					continue
+				}
 				seqQName := istructs.QNameRecordIDSequence
 				addToBatch(event.Workspace(), ss.seqIDs[seqQName], cud.ID(), &batch)
 			}

--- a/pkg/appparts/internal/seqstorage/impl_test.go
+++ b/pkg/appparts/internal/seqstorage/impl_test.go
@@ -156,9 +156,9 @@ func TestSequenceActualization(t *testing.T) {
 		},
 		{
 			name: "one event with one cud",
-			plog: []testPLogEvent{{qName: testCmdQName, wsid: 1, pLogOffset: 1, wLogOffset: 2, cuds: []cud{{qName: testCDocQName, id: 1}},
+			plog: []testPLogEvent{{qName: testCmdQName, wsid: 1, pLogOffset: 1, wLogOffset: 2, cuds: []cud{{qName: testCDocQName, exactID: istructs.FirstUserRecordID}},
 				expectedBatch: []expectedSeqValue{
-					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 1},
+					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID)},
 					{wsid: 1, seqID: istructs.QNameIDWLogOffsetSequence, number: 2},
 				}}},
 		},
@@ -166,24 +166,24 @@ func TestSequenceActualization(t *testing.T) {
 			name: "3 events, 2nd has 2 cuds, other - 1 cud",
 			plog: []testPLogEvent{
 				// 1st event
-				{qName: testCmdQName, wsid: 1, pLogOffset: 1, wLogOffset: 2, cuds: []cud{{qName: testCDocQName, id: 1}},
+				{qName: testCmdQName, wsid: 1, pLogOffset: 1, wLogOffset: 2, cuds: []cud{{qName: testCDocQName, exactID: istructs.FirstUserRecordID}},
 					expectedBatch: []expectedSeqValue{
-						{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 1},
+						{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID)},
 						{wsid: 1, seqID: istructs.QNameIDWLogOffsetSequence, number: 2},
 					}},
 				// 2nd event
 				{qName: testCmdQName, wsid: 2, pLogOffset: 2, wLogOffset: 3, cuds: []cud{
-					{qName: testCDocQName, id: 2},
-					{qName: testWDocQName, id: 3},
+					{qName: testCDocQName, exactID: istructs.FirstUserRecordID + 1},
+					{qName: testWDocQName, exactID: istructs.FirstUserRecordID + 2},
 				}, expectedBatch: []expectedSeqValue{
-					{wsid: 2, seqID: istructs.QNameIDRecordIDSequence, number: 2},
-					{wsid: 2, seqID: istructs.QNameIDRecordIDSequence, number: 3},
+					{wsid: 2, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID + 1)},
+					{wsid: 2, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID + 2)},
 					{wsid: 2, seqID: istructs.QNameIDWLogOffsetSequence, number: 3},
 				}},
 				// 3rd event
-				{qName: testCmdQName, wsid: 3, pLogOffset: 3, wLogOffset: 4, cuds: []cud{{qName: testCDocQName, id: 3}},
+				{qName: testCmdQName, wsid: 3, pLogOffset: 3, wLogOffset: 4, cuds: []cud{{qName: testCDocQName, exactID: istructs.FirstUserRecordID + 3}},
 					expectedBatch: []expectedSeqValue{
-						{wsid: 3, seqID: istructs.QNameIDRecordIDSequence, number: 3},
+						{wsid: 3, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID + 3)},
 						{wsid: 3, seqID: istructs.QNameIDWLogOffsetSequence, number: 4},
 					}},
 			},
@@ -192,17 +192,17 @@ func TestSequenceActualization(t *testing.T) {
 			name: "1 event with few cdocs, wdocs and records",
 			plog: []testPLogEvent{
 				{qName: testCmdQName, wsid: 1, pLogOffset: 1, wLogOffset: 2, cuds: []cud{
-					{qName: testCDocQName, id: 1},
-					{qName: testCRecordQName, id: 2},
-					{qName: testCRecordQName, id: 3},
-					{qName: testWDocQName, id: 4},
-					{qName: testWRecordQName, id: 5},
+					{qName: testCDocQName, exactID: istructs.FirstUserRecordID},
+					{qName: testCRecordQName, exactID: istructs.FirstUserRecordID + 1},
+					{qName: testCRecordQName, exactID: istructs.FirstUserRecordID + 2},
+					{qName: testWDocQName, exactID: istructs.FirstUserRecordID + 3},
+					{qName: testWRecordQName, exactID: istructs.FirstUserRecordID + 4},
 				}, expectedBatch: []expectedSeqValue{
-					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 1},
-					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 2},
-					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 3},
-					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 4},
-					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 5},
+					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID)},
+					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID + 1)},
+					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID + 2)},
+					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID + 3)},
+					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID + 4)},
 					{wsid: 1, seqID: istructs.QNameIDWLogOffsetSequence, number: 2},
 				}},
 			},
@@ -211,19 +211,19 @@ func TestSequenceActualization(t *testing.T) {
 			name: "arg: odoc with 2 orecords + 2 new cuds + 1 update cud (should be skipped)",
 			plog: []testPLogEvent{
 				{qName: testODocQName, wsid: 1, pLogOffset: 1, wLogOffset: 2, arg: obj{
-					cud: cud{qName: testODocQName, id: 1},
+					cud: cud{qName: testODocQName, exactID: istructs.FirstUserRecordID},
 					containers: []obj{
-						{cud: cud{qName: testORecordQName, id: 2}},
-						{cud: cud{qName: testORecordQName, id: 3}},
+						{cud: cud{qName: testORecordQName, exactID: istructs.FirstUserRecordID + 1}},
+						{cud: cud{qName: testORecordQName, exactID: istructs.FirstUserRecordID + 2}},
 					},
 				}, cuds: []cud{
-					{qName: testCDocQName, id: 4},
-					{qName: testCDocQName, id: 123456789, isOld: true},
+					{qName: testCDocQName, exactID: istructs.FirstUserRecordID + 3},
+					{qName: testCDocQName, exactID: istructs.FirstUserRecordID + 4, isOld: true},
 				}, expectedBatch: []expectedSeqValue{
-					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 1},
-					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 2},
-					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 3},
-					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 4},
+					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID)},
+					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID + 1)},
+					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID + 2)},
+					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: uint64(istructs.FirstUserRecordID + 3)},
 					{wsid: 1, seqID: istructs.QNameIDWLogOffsetSequence, number: 2},
 				}},
 			},

--- a/pkg/appparts/internal/seqstorage/impl_test.go
+++ b/pkg/appparts/internal/seqstorage/impl_test.go
@@ -232,7 +232,7 @@ func TestSequenceActualization(t *testing.T) {
 			name: "singleton CUD must be skipped",
 			plog: []testPLogEvent{
 				{qName: testCmdQName, wsid: 1, pLogOffset: 1, wLogOffset: 2, cuds: []cud{
-					{qName: testSingletonCDocQName, exactID: istructs.RecordID(istructs.FirstSingletonID)},
+					{qName: testSingletonCDocQName, exactID: istructs.FirstSingletonID},
 					{qName: testCDocQName, id: 200001},
 				}, expectedBatch: []expectedSeqValue{
 					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 200001},

--- a/pkg/appparts/internal/seqstorage/impl_test.go
+++ b/pkg/appparts/internal/seqstorage/impl_test.go
@@ -23,14 +23,15 @@ import (
 )
 
 var (
-	testWSQName      = appdef.NewQName("test", "ws")
-	testCDocQName    = appdef.NewQName("test", "cdoc")
-	testCRecordQName = appdef.NewQName("test", "crecord")
-	testORecordQName = appdef.NewQName("test", "orecord")
-	testWRecordQName = appdef.NewQName("test", "wrecord")
-	testWDocQName    = appdef.NewQName("test", "wdoc")
-	testODocQName    = appdef.NewQName("test", "odoc")
-	testCmdQName     = appdef.NewQName("test", "cmd")
+	testWSQName            = appdef.NewQName("test", "ws")
+	testCDocQName          = appdef.NewQName("test", "cdoc")
+	testSingletonCDocQName = appdef.NewQName("test", "singletoncdoc")
+	testCRecordQName       = appdef.NewQName("test", "crecord")
+	testORecordQName       = appdef.NewQName("test", "orecord")
+	testWRecordQName       = appdef.NewQName("test", "wrecord")
+	testWDocQName          = appdef.NewQName("test", "wdoc")
+	testODocQName          = appdef.NewQName("test", "odoc")
+	testCmdQName           = appdef.NewQName("test", "cmd")
 )
 
 func TestReadWrite(t *testing.T) {
@@ -227,6 +228,18 @@ func TestSequenceActualization(t *testing.T) {
 				}},
 			},
 		},
+		{
+			name: "singleton CUD must be skipped",
+			plog: []testPLogEvent{
+				{qName: testCmdQName, wsid: 1, pLogOffset: 1, wLogOffset: 2, cuds: []cud{
+					{qName: testSingletonCDocQName, exactID: istructs.RecordID(istructs.FirstSingletonID)},
+					{qName: testCDocQName, id: 200001},
+				}, expectedBatch: []expectedSeqValue{
+					{wsid: 1, seqID: istructs.QNameIDRecordIDSequence, number: 200001},
+					{wsid: 1, seqID: istructs.QNameIDWLogOffsetSequence, number: 2},
+				}},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -336,6 +349,7 @@ func setupTestAppDef(t *testing.T) appdef.IAppDef {
 	ws.AddORecord(testORecordQName)
 	ws.AddWRecord(testWRecordQName)
 	ws.AddCDoc(testCDocQName).AddContainer("crecord", testCRecordQName, appdef.Occurs_Unbounded, appdef.Occurs_Unbounded)
+	ws.AddCDoc(testSingletonCDocQName).SetSingleton()
 	ws.AddODoc(testODocQName).AddContainer("orecord", testORecordQName, appdef.Occurs_Unbounded, appdef.Occurs_Unbounded)
 	ws.AddWDoc(testWDocQName).AddContainer("wrecord", testWRecordQName, appdef.Occurs_Unbounded, appdef.Occurs_Unbounded)
 	ws.AddCommand(testCmdQName)

--- a/uspecs/changes/archive/2604/2604090701-skip-singletons-actualize/change.md
+++ b/uspecs/changes/archive/2604/2604090701-skip-singletons-actualize/change.md
@@ -1,0 +1,21 @@
+---
+registered_at: 2026-04-08T19:38:46Z
+change_id: 2604081938-skip-singletons-actualize
+baseline: 2d707b6e4fd9a3b4427356077ea26a1731da85ff
+issue_url: https://untill.atlassian.net/browse/AIR-3532
+archived_at: 2026-04-09T07:01:06Z
+---
+
+# Change request: Skip singletons in ActualizeSequencesFromPLog
+
+## Why
+
+`ActualizeSequencesFromPLog()` adds all new CUD IDs to the `RecordIDSequence` batch without checking for singletons. Singleton IDs are predefined (65536–66047) and below `FirstUserRecordID` (200001). Since the batcher uses `maps.Copy` to overwrite `toBeFlushed`, a singleton-only event can lower the stored sequence value, causing subsequent `Next()` calls to return IDs in the reserved range. See [issue.md](issue.md) for details.
+
+## What
+
+Updated `ActualizeSequencesFromPLog()` to skip singleton CUDs:
+
+- Skip CUDs whose QName resolves to `ISingleton` via `appDef.Type()`
+- Add test case with singleton CUD verifying it does not appear in the batch
+- Update `sequences--arch.md` to document singleton handling during actualization

--- a/uspecs/changes/archive/2604/2604090701-skip-singletons-actualize/impl.md
+++ b/uspecs/changes/archive/2604/2604090701-skip-singletons-actualize/impl.md
@@ -1,0 +1,14 @@
+# Implementation plan: Skip singletons in ActualizeSequencesFromPLog
+
+## Technical design
+
+- [x] update: [apps/sequences--arch.md](../../../../specs/prod/apps/sequences--arch.md)
+  - add: Document that `ActualizeSequencesFromPLog` must skip singleton CUDs because they have predefined IDs (65536–66047) that would corrupt the `RecordIDSequence` state
+
+## Construction
+
+- [x] update: [pkg/appparts/internal/seqstorage/impl.go](../../../../../pkg/appparts/internal/seqstorage/impl.go)
+  - update: Skip singleton CUDs in `ActualizeSequencesFromPLog` by checking `appdef.ISingleton` type assertion on `ss.appDef.Type(cud.QName())`
+- [x] update: [pkg/appparts/internal/seqstorage/impl_test.go](../../../../../pkg/appparts/internal/seqstorage/impl_test.go)
+  - add: Singleton CDoc type (`testSingletonCDocQName`) to `setupTestAppDef`
+  - add: Test case in `TestSequenceActualization` with a singleton CUD verifying it does not appear in the batch

--- a/uspecs/changes/archive/2604/2604090701-skip-singletons-actualize/issue.md
+++ b/uspecs/changes/archive/2604/2604090701-skip-singletons-actualize/issue.md
@@ -1,0 +1,15 @@
+# AIR-3532: sequences: ActualizeSequencesFromPLog must skip singletons
+
+- **Type**: Sub-task
+- **Status**: In Progress
+- **Assignee**: d.gribanov@dev.untill.com
+
+## Why
+
+`ActualizeSequencesFromPLog()` adds all new CUD IDs to the `RecordIDSequence` batch without checking for singletons. Singleton IDs are predefined (65536–66047) and below `FirstUserRecordID` (200001). Since the batcher uses `maps.Copy` to overwrite `toBeFlushed`, a singleton-only event can lower the stored sequence value, causing subsequent `Next()` calls to return IDs in the reserved range.
+
+## What
+
+- Skip singleton CUDs in `ActualizeSequencesFromPLog()` by checking `appDef.Type(cud.QName())` for `ISingleton`
+- Add test case with singleton CUD verifying it does not appear in the batch
+- Update `sequences--arch.md` to document singleton handling during actualization

--- a/uspecs/specs/prod/apps/sequences--arch.md
+++ b/uspecs/specs/prod/apps/sequences--arch.md
@@ -345,7 +345,7 @@ PLog offset is managed per partition in `appPartition.nextPLogOffset`, not as a 
 
 ### Singleton handling in ActualizeSequencesFromPLog
 
-Singleton CUDs must be skipped when building the `RecordIDSequence` batch during actualization. Singletons have predefined IDs from the reserved range (65536–66047), which is below `FirstUserRecordID` (200001). Including them would corrupt the sequence state because the batcher stores max values per key — a singleton ID would lower the stored value, causing subsequent `Next()` calls to return IDs in the reserved range.
+Singleton CUDs must be skipped when building the `RecordIDSequence` batch during actualization. Singletons have predefined IDs from the reserved range (65536–66047), which is below `FirstUserRecordID` (200001). Including them would corrupt the sequence state because the batcher computes the max value per key only within the current batch, then overwrites any previously buffered `toBeFlushed` entry for that key. As a result, a singleton-only batch can replace a larger buffered `RecordIDSequence` value with a reserved-range singleton ID, causing subsequent `Next()` calls to return IDs in the reserved range.
 
 This mirrors the active command processing path where `regenerateIDsPlan` bypasses `generator.NextID()` for singletons and uses `cud.appCfg.singletons.ID()` instead.
 

--- a/uspecs/specs/prod/apps/sequences--arch.md
+++ b/uspecs/specs/prod/apps/sequences--arch.md
@@ -343,6 +343,12 @@ Only **2 sequences** remain:
 
 PLog offset is managed per partition in `appPartition.nextPLogOffset`, not as a separate sequence.
 
+### Singleton handling in ActualizeSequencesFromPLog
+
+Singleton CUDs must be skipped when building the `RecordIDSequence` batch during actualization. Singletons have predefined IDs from the reserved range (65536–66047), which is below `FirstUserRecordID` (200001). Including them would corrupt the sequence state because the batcher stores max values per key — a singleton ID would lower the stored value, causing subsequent `Next()` calls to return IDs in the reserved range.
+
+This mirrors the active command processing path where `regenerateIDsPlan` bypasses `generator.NextID()` for singletons and uses `cud.appCfg.singletons.ID()` instead.
+
 ## VVM storage key structure
 
 All sequence data in `IVVMSeqStorageAdapter` is scoped per application to ensure apps do not interfere with each other.


### PR DESCRIPTION
registered_at: 2026-04-08T19:38:46Z
change_id: 2604081938-skip-singletons-actualize
baseline: 2d707b6e4fd9a3b4427356077ea26a1731da85ff
issue_url: https://untill.atlassian.net/browse/AIR-3532
archived_at: 2026-04-09T07:01:06Z

# Change request: Skip singletons in ActualizeSequencesFromPLog

## Why

`ActualizeSequencesFromPLog()` adds all new CUD IDs to the `RecordIDSequence` batch without checking for singletons. Singleton IDs are predefined (65536–66047) and below `FirstUserRecordID` (200001). Since the batcher uses `maps.Copy` to overwrite `toBeFlushed`, a singleton-only event can lower the stored sequence value, causing subsequent `Next()` calls to return IDs in the reserved range. See [issue.md](issue.md) for details.

## What

Updated `ActualizeSequencesFromPLog()` to skip singleton CUDs:

- Skip CUDs whose QName resolves to `ISingleton` via `appDef.Type()`
- Add test case with singleton CUD verifying it does not appear in the batch
- Update `sequences--arch.md` to document singleton handling during actualization
