### PR TITLE
[AIR-3542] Limit concurrent query executions per workspace

### DIFF
--- a/pkg/ihttpimpl/impl.go
+++ b/pkg/ihttpimpl/impl.go
@@ -264,7 +264,7 @@ func (p *httpProcessor) registerRoutes() {
 
 func (p *httpProcessor) httpHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		routerpkg.RequestHandler_V1(p.requestSender, p.numsAppsWorkspaces)(w, r)
+		routerpkg.RequestHandler_V1(p.requestSender, p.numsAppsWorkspaces, nil)(w, r)
 	}
 }
 

--- a/pkg/router/consts.go
+++ b/pkg/router/consts.go
@@ -48,6 +48,7 @@ const (
 	URLPlaceholder_field          = "field"
 	hours24                       = 24 * time.Hour
 	DefaultRetryAfterSecondsOn503 = 1
+	DefaultMaxQueriesPerWSLimit   = 10
 	logAttrib_Origin              = "origin"
 	logAttrib_RemoteAddr          = "remoteaddr"
 	logAttrib_Projection          = "projection"

--- a/pkg/router/consts.go
+++ b/pkg/router/consts.go
@@ -30,30 +30,31 @@ const (
 	// goroutines and connections from being held open indefinitely.
 	DefaultRouterWriteTimeout = 0
 
-	URLPlaceholder_wsid           = "wsid"
-	URLPlaceholder_appOwner       = "appOwner"
-	URLPlaceholder_appName        = "appName"
-	URLPlaceholder_blobIDOrSUUID  = "blobIDOrSUUID"
-	URLPlaceholder_resourceName   = "resourceName"
-	URLPlaceholder_pkg            = "pkg"
-	URLPlaceholder_table          = "table"
-	URLPlaceholder_id             = "id"
-	URLPlaceholder_command        = "command"
-	URLPlaceholder_query          = "query"
-	URLPlaceholder_view           = "view"
-	URLPlaceholder_workspaceName  = "workspace"
-	URLPlaceholder_rolePkg        = "rolePkg"
-	URLPlaceholder_role           = "role"
-	URLPlaceholder_channelID      = "channelID"
-	URLPlaceholder_field          = "field"
-	hours24                       = 24 * time.Hour
-	DefaultRetryAfterSecondsOn503 = 1
-	DefaultMaxQueriesPerWSLimit   = 10
-	logAttrib_Origin              = "origin"
-	logAttrib_RemoteAddr          = "remoteaddr"
-	logAttrib_Projection          = "projection"
-	logAttrib_ChannelID           = "channelid"
-	n10nErrorStage                = "n10n.error"
+	URLPlaceholder_wsid              = "wsid"
+	URLPlaceholder_appOwner          = "appOwner"
+	URLPlaceholder_appName           = "appName"
+	URLPlaceholder_blobIDOrSUUID     = "blobIDOrSUUID"
+	URLPlaceholder_resourceName      = "resourceName"
+	URLPlaceholder_pkg               = "pkg"
+	URLPlaceholder_table             = "table"
+	URLPlaceholder_id                = "id"
+	URLPlaceholder_command           = "command"
+	URLPlaceholder_query             = "query"
+	URLPlaceholder_view              = "view"
+	URLPlaceholder_workspaceName     = "workspace"
+	URLPlaceholder_rolePkg           = "rolePkg"
+	URLPlaceholder_role              = "role"
+	URLPlaceholder_channelID         = "channelID"
+	URLPlaceholder_field             = "field"
+	hours24                          = 24 * time.Hour
+	DefaultRetryAfterSecondsOn503    = 1
+	DefaultMaxQueriesPerWSLimit      = 10
+	limiterSizeLogIntervalInRequests = 1000
+	logAttrib_Origin                 = "origin"
+	logAttrib_RemoteAddr             = "remoteaddr"
+	logAttrib_Projection             = "projection"
+	logAttrib_ChannelID              = "channelid"
+	n10nErrorStage                   = "n10n.error"
 )
 
 var (

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -490,7 +490,8 @@ func requestHandlerV2_table(reqSender bus.IRequestSender, apiPath processors.API
 
 func sendRequestAndReadResponse(req *http.Request, busRequest bus.Request, reqSender bus.IRequestSender, rw http.ResponseWriter, data validatedData,
 	limiter *wsQueryLimiter) {
-	if busRequest.Method == http.MethodGet && isQPBoundAPIPath(processors.APIPath(busRequest.APIPath)) {
+	// limiter is nil for Admin and ACME services
+	if limiter != nil && busRequest.Method == http.MethodGet && isQPBoundAPIPath(processors.APIPath(busRequest.APIPath)) {
 		if !limiter.acquire(busRequest.WSID) {
 			replyServiceUnavailable(rw)
 			return

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -31,71 +31,73 @@ import (
 )
 
 func (s *routerService) registerHandlersV2() {
+	l := s.queryLimiter
+
 	// create: /api/v2/apps/{owner}/{app}/workspaces/{wsid}/docs/{pkg}.{table}
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/workspaces/{%s:[0-9]+}/docs/{%s}.{%s}",
 		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_wsid, URLPlaceholder_pkg, URLPlaceholder_table),
-		corsHandler(requestHandlerV2_table(s.requestSender, processors.APIPath_Docs, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_table(s.requestSender, processors.APIPath_Docs, s.numsAppsWorkspaces, l))).
 		Methods(http.MethodOptions, http.MethodPost).Name("create")
 
 	// update, deactivate, read single doc: /api/v2/apps/{owner}/{app}/workspaces/{wsid}/docs/{pkg}.{table}/{id}
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/workspaces/{%s:[0-9]+}/docs/{%s}.{%s}/{%s:[0-9]+}",
 		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_wsid, URLPlaceholder_pkg, URLPlaceholder_table,
 		URLPlaceholder_id),
-		corsHandler(requestHandlerV2_table(s.requestSender, processors.APIPath_Docs, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_table(s.requestSender, processors.APIPath_Docs, s.numsAppsWorkspaces, l))).
 		Methods(http.MethodOptions, http.MethodPatch, http.MethodDelete, http.MethodGet).Name("update or read single")
 
 	// read collection: /api/v2/apps/{owner}/{app}/workspaces/{wsid}/cdocs/{pkg}.{table}
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/workspaces/{%s:[0-9]+}/cdocs/{%s}.{%s}",
 		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_wsid, URLPlaceholder_pkg, URLPlaceholder_table),
-		corsHandler(requestHandlerV2_table(s.requestSender, processors.APIPath_CDocs, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_table(s.requestSender, processors.APIPath_CDocs, s.numsAppsWorkspaces, l))).
 		Methods(http.MethodOptions, http.MethodGet).Name("read collection")
 
 	// execute cmd: /api/v2/apps/{owner}/{app}/workspaces/{wsid}/commands/{pkg}.{command}
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/workspaces/{%s:[0-9]+}/commands/{%s}.{%s}",
 		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_wsid, URLPlaceholder_pkg, URLPlaceholder_command),
-		corsHandler(requestHandlerV2_extension(s.requestSender, processors.APIPath_Commands, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_extension(s.requestSender, processors.APIPath_Commands, s.numsAppsWorkspaces, l))).
 		Methods(http.MethodOptions, http.MethodPost).Name("exec cmd")
 
 	// execute query: /api/v2/apps/{owner}/{app}/workspaces/{wsid}/queries/{pkg}.{query}
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/workspaces/{%s:[0-9]+}/queries/{%s}.{%s}",
 		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_wsid, URLPlaceholder_pkg, URLPlaceholder_query),
-		corsHandler(requestHandlerV2_extension(s.requestSender, processors.APIPath_Queries, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_extension(s.requestSender, processors.APIPath_Queries, s.numsAppsWorkspaces, l))).
 		Methods(http.MethodOptions, http.MethodGet).Name("exec query")
 
 	// view: /api/v2/apps/{owner}/{app}/workspaces/{wsid}/views/{pkg}.{view}
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/workspaces/{%s:[0-9]+}/views/{%s}.{%s}",
 		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_wsid, URLPlaceholder_pkg, URLPlaceholder_view),
-		corsHandler(requestHandlerV2_view(s.requestSender, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_view(s.requestSender, s.numsAppsWorkspaces, l))).
 		Methods(http.MethodOptions, http.MethodGet).Name("view")
 
 	// schemas: get workspace schema: /api/v2/apps/{owner}/{app}/schemas
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/schemas",
 		URLPlaceholder_appOwner, URLPlaceholder_appName),
-		corsHandler(requestHandlerV2_schemas(s.requestSender, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_schemas(s.requestSender, s.numsAppsWorkspaces, l))).
 		Methods(http.MethodOptions, http.MethodGet).Name("schemas")
 
 	// schemas, workspace roles: get workspace schema: /api/v2/apps/{owner}/{app}/schemas/{pkg}.{workspace}/roles
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/schemas/{%s}.{%s}/roles",
 		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_pkg, URLPlaceholder_workspaceName),
-		corsHandler(requestHandlerV2_schemas_wsRoles(s.requestSender, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_schemas_wsRoles(s.requestSender, s.numsAppsWorkspaces, l))).
 		Methods(http.MethodOptions, http.MethodGet).Name("schemas, workspace roles")
 
 	// schemas, workspace role: get workspace schema: /api/v2/apps/{owner}/{app}/schemas/{pkg}.{workspace}/roles/{pkg}.{role}
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/schemas/{%s}.{%s}/roles/{%s}.{%s}",
 		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_pkg, URLPlaceholder_workspaceName, URLPlaceholder_rolePkg, URLPlaceholder_role),
-		corsHandler(requestHandlerV2_schemas_wsRole(s.requestSender, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_schemas_wsRole(s.requestSender, s.numsAppsWorkspaces, l))).
 		Methods(http.MethodOptions, http.MethodGet).Name("schemas, workspace role")
 
 	// auth/login: /api/v2/apps/{owner}/{app}/auth/login
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/auth/login",
 		URLPlaceholder_appOwner, URLPlaceholder_appName),
-		corsHandler(requestHandlerV2_auth_login(s.requestSender, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_auth_login(s.requestSender, s.numsAppsWorkspaces, l))).
 		Methods(http.MethodOptions, http.MethodPost).Name("auth login")
 
 	// auth/login: /api/v2/apps/{owner}/{app}/auth/login
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/auth/refresh",
 		URLPlaceholder_appOwner, URLPlaceholder_appName),
-		corsHandler(requestHandlerV2_auth_refresh(s.requestSender, s.numsAppsWorkspaces))).
+		corsHandler(requestHandlerV2_auth_refresh(s.requestSender, s.numsAppsWorkspaces, l))).
 		Methods(http.MethodOptions, http.MethodPost).Name("auth refresh")
 
 	// create user /api/v2/apps/{owner}/{app}/users
@@ -150,40 +152,42 @@ func (s *routerService) registerHandlersV2() {
 	// [~server.n10n/cmp.routerCreateChannelHandler~impl]
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/notifications",
 		URLPlaceholder_appOwner, URLPlaceholder_appName),
-		corsHandler(requestHandlerV2_notifications_subscribeAndWatch(s.numsAppsWorkspaces, s.requestSender))).
+		corsHandler(requestHandlerV2_notifications_subscribeAndWatch(s.numsAppsWorkspaces, s.requestSender, l))).
 		Methods(http.MethodOptions, http.MethodPost).Name("notifications subscribe + watch")
 
 	// notifications unsubscribe /api/v2/apps/{owner}/{app}/notifications/{channelId}/workspaces/{wsid}/subscriptions/{entity}
 	// [~server.n10n/cmp.routerUnsubscribeHandler~impl]
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/notifications/{%s}/workspaces/{%s}/subscriptions/{%s}",
 		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_channelID, URLPlaceholder_wsid, URLPlaceholder_view),
-		corsHandler(requestHandlerV2_notifications(s.numsAppsWorkspaces, s.requestSender))).
+		corsHandler(requestHandlerV2_notifications(s.numsAppsWorkspaces, s.requestSender, l))).
 		Methods(http.MethodOptions, http.MethodDelete).Name("notifications unsubscribe")
 
 	// notifications subscribe to an extra view /api/v2/apps/{owner}/{app}/notifications/{channelId}/workspaces/{wsid}/subscriptions/{entity}
 	// [~server.n10n/cmp.routerAddSubscriptionHandler~impl]
 	s.router.HandleFunc(fmt.Sprintf("/api/v2/apps/{%s}/{%s}/notifications/{%s}/workspaces/{%s}/subscriptions/{%s}",
 		URLPlaceholder_appOwner, URLPlaceholder_appName, URLPlaceholder_channelID, URLPlaceholder_wsid, URLPlaceholder_view),
-		corsHandler(requestHandlerV2_notifications(s.numsAppsWorkspaces, s.requestSender))).
+		corsHandler(requestHandlerV2_notifications(s.numsAppsWorkspaces, s.requestSender, l))).
 		Methods(http.MethodOptions, http.MethodPut).Name("notifications subscribe to an extra view")
 }
 
-func requestHandlerV2_schemas(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
+func requestHandlerV2_schemas(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces,
+	limiter *wsQueryLimiter) http.HandlerFunc {
 	return withValidateForFuncs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(data, req)
 		busRequest.IsAPIV2 = true
 		busRequest.APIPath = int(processors.APIPaths_Schema)
-		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data)
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }
 
-func requestHandlerV2_schemas_wsRoles(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
+func requestHandlerV2_schemas_wsRoles(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces,
+	limiter *wsQueryLimiter) http.HandlerFunc {
 	return withValidateForFuncs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(data, req)
 		busRequest.IsAPIV2 = true
 		busRequest.APIPath = int(processors.APIPath_Schemas_WorkspaceRoles)
 		busRequest.WorkspaceQName = appdef.NewQName(data.vars[URLPlaceholder_pkg], data.vars[URLPlaceholder_workspaceName])
-		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data)
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }
 
@@ -276,7 +280,8 @@ func requestHandlerV2_create_user(numsAppsWorkspaces map[appdef.AppQName]istruct
 	})
 }
 
-func requestHandlerV2_notifications_subscribeAndWatch(numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces, reqSender bus.IRequestSender) http.HandlerFunc {
+func requestHandlerV2_notifications_subscribeAndWatch(numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces, reqSender bus.IRequestSender,
+	limiter *wsQueryLimiter) http.HandlerFunc {
 	return withValidateForN10N(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		_, ok := rw.(http.Flusher)
 		if !ok {
@@ -287,12 +292,13 @@ func requestHandlerV2_notifications_subscribeAndWatch(numsAppsWorkspaces map[app
 		busRequest := createBusRequest(data, req)
 		busRequest.IsAPIV2 = true
 		busRequest.IsN10N = true
-		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data)
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }
 
 // handles both unsubscribe and subscribe to an extra view
-func requestHandlerV2_notifications(numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces, reqSender bus.IRequestSender) http.HandlerFunc {
+func requestHandlerV2_notifications(numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces, reqSender bus.IRequestSender,
+	limiter *wsQueryLimiter) http.HandlerFunc {
 	return withValidateForN10N(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		var err error
 		busRequest := createBusRequest(data, req)
@@ -306,7 +312,7 @@ func requestHandlerV2_notifications(numsAppsWorkspaces map[appdef.AppQName]istru
 			return
 		}
 
-		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data)
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }
 
@@ -334,18 +340,20 @@ func requestHandlerV2_create_device(numsAppsWorkspaces map[appdef.AppQName]istru
 }
 
 // [~server.authnz/cmp.routerRefreshHandler~impl]
-func requestHandlerV2_auth_refresh(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
+func requestHandlerV2_auth_refresh(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces,
+	limiter *wsQueryLimiter) http.HandlerFunc {
 	return withValidateForFuncs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(data, req)
 		busRequest.IsAPIV2 = true
 		busRequest.APIPath = int(processors.APIPath_Auth_Refresh)
 		busRequest.Method = http.MethodGet
-		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data)
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }
 
 // [~server.authnz/cmp.routerLoginPathHandler~impl]
-func requestHandlerV2_auth_login(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
+func requestHandlerV2_auth_login(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces,
+	limiter *wsQueryLimiter) http.HandlerFunc {
 	return withValidateForFuncs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(data, req)
 		busRequest.IsAPIV2 = true
@@ -354,7 +362,7 @@ func requestHandlerV2_auth_login(reqSender bus.IRequestSender, numsAppsWorkspace
 		queryParams := map[string]string{}
 		queryParams["args"] = string(busRequest.Body)
 		busRequest.Query = queryParams
-		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data)
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }
 
@@ -419,28 +427,31 @@ func requestHandlerV2_blobs_create(blobRequestHandler blobprocessor.IRequestHand
 	})
 }
 
-func requestHandlerV2_schemas_wsRole(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
+func requestHandlerV2_schemas_wsRole(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces,
+	limiter *wsQueryLimiter) http.HandlerFunc {
 	return withValidateForFuncs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(data, req)
 		busRequest.IsAPIV2 = true
 		busRequest.APIPath = int(processors.APIPath_Schemas_WorkspaceRole)
 		busRequest.WorkspaceQName = appdef.NewQName(data.vars[URLPlaceholder_pkg], data.vars[URLPlaceholder_workspaceName])
 		busRequest.QName = appdef.NewQName(data.vars[URLPlaceholder_rolePkg], data.vars[URLPlaceholder_role])
-		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data)
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }
 
-func requestHandlerV2_view(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
+func requestHandlerV2_view(reqSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces,
+	limiter *wsQueryLimiter) http.HandlerFunc {
 	return withValidateForFuncs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(data, req)
 		busRequest.IsAPIV2 = true
 		busRequest.APIPath = int(processors.APIPath_Views)
 		busRequest.QName = appdef.NewQName(data.vars[URLPlaceholder_pkg], data.vars[URLPlaceholder_view])
-		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data)
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }
 
-func requestHandlerV2_extension(reqSender bus.IRequestSender, apiPath processors.APIPath, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
+func requestHandlerV2_extension(reqSender bus.IRequestSender, apiPath processors.APIPath, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces,
+	limiter *wsQueryLimiter) http.HandlerFunc {
 	return withValidateForFuncs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		entity := ""
 		switch apiPath {
@@ -453,11 +464,12 @@ func requestHandlerV2_extension(reqSender bus.IRequestSender, apiPath processors
 		busRequest.IsAPIV2 = true
 		busRequest.APIPath = int(apiPath)
 		busRequest.QName = appdef.NewQName(data.vars[URLPlaceholder_pkg], entity)
-		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data)
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }
 
-func requestHandlerV2_table(reqSender bus.IRequestSender, apiPath processors.APIPath, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
+func requestHandlerV2_table(reqSender bus.IRequestSender, apiPath processors.APIPath, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces,
+	limiter *wsQueryLimiter) http.HandlerFunc {
 	return withValidateForFuncs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(data, req)
 		if recordIDStr, hasDocID := data.vars[URLPlaceholder_id]; hasDocID {
@@ -472,11 +484,20 @@ func requestHandlerV2_table(reqSender bus.IRequestSender, apiPath processors.API
 		busRequest.IsAPIV2 = true
 		busRequest.APIPath = int(apiPath)
 		busRequest.QName = appdef.NewQName(data.vars[URLPlaceholder_pkg], data.vars[URLPlaceholder_table])
-		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data)
+		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }
 
-func sendRequestAndReadResponse(req *http.Request, busRequest bus.Request, reqSender bus.IRequestSender, rw http.ResponseWriter, data validatedData) {
+func sendRequestAndReadResponse(req *http.Request, busRequest bus.Request, reqSender bus.IRequestSender, rw http.ResponseWriter, data validatedData,
+	limiter *wsQueryLimiter) {
+	if isQPBoundAPIPath(processors.APIPath(busRequest.APIPath)) {
+		if !limiter.acquire(istructs.WSID(busRequest.WSID)) {
+			replyServiceUnavailable(rw)
+			return
+		}
+		defer limiter.release(istructs.WSID(busRequest.WSID))
+	}
+
 	reqCtxWithExtensionAttrib := withLogAttribs(req.Context(), data, busRequest, req)
 
 	// req's BaseContext is router service's context. See service.Start()

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -490,7 +490,7 @@ func requestHandlerV2_table(reqSender bus.IRequestSender, apiPath processors.API
 
 func sendRequestAndReadResponse(req *http.Request, busRequest bus.Request, reqSender bus.IRequestSender, rw http.ResponseWriter, data validatedData,
 	limiter *wsQueryLimiter) {
-	if isQPBoundAPIPath(processors.APIPath(busRequest.APIPath)) {
+	if busRequest.Method == http.MethodGet && isQPBoundAPIPath(processors.APIPath(busRequest.APIPath)) {
 		if !limiter.acquire(busRequest.WSID) {
 			replyServiceUnavailable(rw)
 			return
@@ -512,7 +512,7 @@ func sendRequestAndReadResponse(req *http.Request, busRequest bus.Request, reqSe
 	requestCtx, cancel := context.WithCancel(reqCtxWithExtensionAttrib)
 	defer cancel() // to avoid context leak
 
-	logServeRequest(requestCtx)
+	logServeRequest(requestCtx, limiter)
 
 	sentAt := time.Now()
 	respCh, respMeta, respErr, err := reqSender.SendRequest(requestCtx, busRequest)

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -491,11 +491,11 @@ func requestHandlerV2_table(reqSender bus.IRequestSender, apiPath processors.API
 func sendRequestAndReadResponse(req *http.Request, busRequest bus.Request, reqSender bus.IRequestSender, rw http.ResponseWriter, data validatedData,
 	limiter *wsQueryLimiter) {
 	if isQPBoundAPIPath(processors.APIPath(busRequest.APIPath)) {
-		if !limiter.acquire(istructs.WSID(busRequest.WSID)) {
+		if !limiter.acquire(busRequest.WSID) {
 			replyServiceUnavailable(rw)
 			return
 		}
-		defer limiter.release(istructs.WSID(busRequest.WSID))
+		defer limiter.release(busRequest.WSID)
 	}
 
 	reqCtxWithExtensionAttrib := withLogAttribs(req.Context(), data, busRequest, req)

--- a/pkg/router/impl_blob.go
+++ b/pkg/router/impl_blob.go
@@ -21,7 +21,7 @@ import (
 func (s *routerService) blobHTTPRequestHandler_Write(numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
 	return withValidateForBLOBs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		reqCtxWithAttribs := withLogAttribs(req.Context(), data, bus.Request{Resource: "sys._Blob_Write"}, req)
-		logServeRequest(reqCtxWithAttribs)
+		logServeRequest(reqCtxWithAttribs, s.queryLimiter)
 		if !s.blobRequestHandler.HandleWrite(data.appQName, data.wsid, data.header, reqCtxWithAttribs, req.URL.Query(),
 			newBLOBOKResponseIniter(rw, http.StatusOK), req.Body, func(sysErr coreutils.SysError) {
 				writeCommonError_V1(rw, sysErr, sysErr.HTTPStatus)
@@ -35,7 +35,7 @@ func (s *routerService) blobHTTPRequestHandler_Write(numsAppsWorkspaces map[appd
 func (s *routerService) blobHTTPRequestHandler_Read(numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
 	return withValidateForBLOBs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		reqCtxWithAttribs := withLogAttribs(req.Context(), data, bus.Request{Resource: "sys._Blob_Read"}, req)
-		logServeRequest(reqCtxWithAttribs)
+		logServeRequest(reqCtxWithAttribs, s.queryLimiter)
 		vars := mux.Vars(req)
 		existingBLOBIDOrSUID := vars[URLPlaceholder_blobIDOrSUUID]
 		if !s.blobRequestHandler.HandleRead(data.appQName, data.wsid, data.header, reqCtxWithAttribs,

--- a/pkg/router/impl_http.go
+++ b/pkg/router/impl_http.go
@@ -190,7 +190,7 @@ func (s *routerService) registerHandlersV1() {
 			Name("blob read")
 	}
 	s.router.HandleFunc(fmt.Sprintf("/api/{%s}/{%s}/{%s:[0-9]+}/{%s:[a-zA-Z0-9_/.]+}", URLPlaceholder_appOwner, URLPlaceholder_appName,
-		URLPlaceholder_wsid, URLPlaceholder_resourceName), corsHandler(RequestHandler_V1(s.requestSender, s.numsAppsWorkspaces))).
+		URLPlaceholder_wsid, URLPlaceholder_resourceName), corsHandler(RequestHandler_V1(s.requestSender, s.numsAppsWorkspaces, s.queryLimiter))).
 		Methods("POST", "PATCH", "OPTIONS").Name("api")
 
 	s.router.Handle("/n10n/channel", corsHandler(s.subscribeAndWatchHandler())).Methods("GET")
@@ -199,9 +199,18 @@ func (s *routerService) registerHandlersV1() {
 	s.router.Handle("/n10n/update/{offset:[0-9]{1,10}}", corsHandler(s.updateHandler()))
 }
 
-func RequestHandler_V1(requestSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces) http.HandlerFunc {
+func RequestHandler_V1(requestSender bus.IRequestSender, numsAppsWorkspaces map[appdef.AppQName]istructs.NumAppWorkspaces,
+	limiter *wsQueryLimiter) http.HandlerFunc {
 	return withValidateForFuncs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(data, req)
+
+		if limiter != nil && len(busRequest.Resource) > 0 && busRequest.Resource[:1] == "q" {
+			if !limiter.acquire(busRequest.WSID) {
+				replyServiceUnavailable(rw)
+				return
+			}
+			defer limiter.release(busRequest.WSID)
+		}
 
 		reqCtxWithExtensionAttrib := withLogAttribs(req.Context(), data, busRequest, req)
 

--- a/pkg/router/impl_http.go
+++ b/pkg/router/impl_http.go
@@ -204,6 +204,7 @@ func RequestHandler_V1(requestSender bus.IRequestSender, numsAppsWorkspaces map[
 	return withValidateForFuncs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(data, req)
 
+		// limiter is nil for Admin and ACME services
 		if limiter != nil && strings.HasPrefix(busRequest.Resource, "q.") {
 			if !limiter.acquire(busRequest.WSID) {
 				replyServiceUnavailable(rw)

--- a/pkg/router/impl_http.go
+++ b/pkg/router/impl_http.go
@@ -204,7 +204,7 @@ func RequestHandler_V1(requestSender bus.IRequestSender, numsAppsWorkspaces map[
 	return withValidateForFuncs(numsAppsWorkspaces, func(req *http.Request, rw http.ResponseWriter, data validatedData) {
 		busRequest := createBusRequest(data, req)
 
-		if limiter != nil && len(busRequest.Resource) > 0 && busRequest.Resource[:1] == "q" {
+		if limiter != nil && strings.HasPrefix(busRequest.Resource, "q.") {
 			if !limiter.acquire(busRequest.WSID) {
 				replyServiceUnavailable(rw)
 				return
@@ -221,7 +221,7 @@ func RequestHandler_V1(requestSender bus.IRequestSender, numsAppsWorkspaces map[
 		requestCtx, cancel := context.WithCancel(reqCtxWithExtensionAttrib)
 		defer cancel() // to avoid context leak
 
-		logServeRequest(requestCtx)
+		logServeRequest(requestCtx, limiter)
 
 		sentAt := time.Now()
 		responseCh, responseMeta, responseErr, err := requestSender.SendRequest(requestCtx, busRequest)

--- a/pkg/router/impl_limiter.go
+++ b/pkg/router/impl_limiter.go
@@ -6,17 +6,11 @@
 package router
 
 import (
-	"sync"
 	"sync/atomic"
 
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/processors"
 )
-
-type wsQueryLimiter struct {
-	counters  sync.Map // istructs.WSID -> *atomic.Int32
-	maxQPerWS int
-}
 
 func (l *wsQueryLimiter) acquire(wsid istructs.WSID) bool {
 	if l.maxQPerWS <= 0 {
@@ -41,6 +35,15 @@ func (l *wsQueryLimiter) release(wsid istructs.WSID) {
 		return
 	}
 	val.(*atomic.Int32).Add(-1)
+}
+
+func (l *wsQueryLimiter) size() int {
+	n := 0
+	l.counters.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
 }
 
 func isQPBoundAPIPath(apiPath processors.APIPath) bool {

--- a/pkg/router/impl_limiter.go
+++ b/pkg/router/impl_limiter.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026-present unTill Software Development Group B.V.
+ * @author Denis Gribanov
+ */
+
+package router
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/processors"
+)
+
+type wsQueryLimiter struct {
+	counters  sync.Map // istructs.WSID -> *atomic.Int32
+	maxQPerWS int
+}
+
+func (l *wsQueryLimiter) acquire(wsid istructs.WSID) bool {
+	if l.maxQPerWS <= 0 {
+		return true
+	}
+	val, _ := l.counters.LoadOrStore(wsid, &atomic.Int32{})
+	counter := val.(*atomic.Int32)
+	for {
+		current := counter.Load()
+		if int(current) >= l.maxQPerWS {
+			return false
+		}
+		if counter.CompareAndSwap(current, current+1) {
+			return true
+		}
+	}
+}
+
+func (l *wsQueryLimiter) release(wsid istructs.WSID) {
+	val, ok := l.counters.Load(wsid)
+	if !ok {
+		return
+	}
+	val.(*atomic.Int32).Add(-1)
+}
+
+func isQPBoundAPIPath(apiPath processors.APIPath) bool {
+	switch apiPath {
+	case processors.APIPath_Queries, processors.APIPath_Views, processors.APIPath_Docs, processors.APIPath_CDocs:
+		return true
+	}
+	return false
+}

--- a/pkg/router/impl_limiter.go
+++ b/pkg/router/impl_limiter.go
@@ -16,7 +16,10 @@ func (l *wsQueryLimiter) acquire(wsid istructs.WSID) bool {
 	if l.maxQPerWS <= 0 {
 		return true
 	}
-	val, _ := l.counters.LoadOrStore(wsid, &atomic.Int32{})
+	val, ok := l.counters.Load(wsid)
+	if !ok {
+		val, _ = l.counters.LoadOrStore(wsid, &atomic.Int32{})
+	}
 	counter := val.(*atomic.Int32)
 	for {
 		current := counter.Load()

--- a/pkg/router/provide.go
+++ b/pkg/router/provide.go
@@ -91,6 +91,7 @@ func getRouterService(name string, listenAddress string, rp RouterParams, broker
 		iTokens:            iTokens,
 		federation:         federation,
 		appTokensFactory:   appTokensFactory,
+		queryLimiter:       &wsQueryLimiter{maxQPerWS: rp.MaxQueriesPerWS},
 	}
 }
 

--- a/pkg/router/types.go
+++ b/pkg/router/types.go
@@ -43,6 +43,7 @@ type RouterParams struct {
 	Routes               map[string]string // /grafana=http://10.0.0.3:3000 : https://alpha.dev.untill.ru/grafana/foo -> http://10.0.0.3:3000/grafana/foo
 	RoutesRewrite        map[string]string // /grafana-rewrite=http://10.0.0.3:3000/rewritten : https://alpha.dev.untill.ru/grafana-rewrite/foo -> http://10.0.0.3:3000/rewritten/foo
 	RouteDomains         map[string]string // resellerportal.dev.untill.ru=http://resellerportal : https://resellerportal.dev.untill.ru/foo -> http://resellerportal/foo
+	MaxQueriesPerWS      int
 }
 
 type httpServer struct {
@@ -69,6 +70,7 @@ type routerService struct {
 	iTokens            itokens.ITokens
 	federation         federation.IFederation
 	appTokensFactory   payloads.IAppTokensFactory
+	queryLimiter       *wsQueryLimiter
 }
 
 type httpsService struct {

--- a/pkg/router/types.go
+++ b/pkg/router/types.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sync"
 	"sync/atomic"
 
 	"github.com/gorilla/mux"
@@ -114,3 +115,8 @@ type validatedData struct {
 }
 
 type validatorFunc func(validateData validatedData, req *http.Request) (validatedData, error)
+
+type wsQueryLimiter struct {
+	counters  sync.Map // istructs.WSID -> *atomic.Int32
+	maxQPerWS int
+}

--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -173,7 +173,7 @@ func logLatency(ctx context.Context, sentAt time.Time) {
 func logServeRequest(ctx context.Context, limiter *wsQueryLimiter) {
 	if logger.IsVerbose() {
 		logger.LogCtx(ctx, 1, logger.LogLevelVerbose, "routing.accepted", "")
-		if reqID.Load()%limiterSizeLogIntervalInRequests == 0 {
+		if limiter != nil && reqID.Load()%limiterSizeLogIntervalInRequests == 0 {
 			logger.LogCtx(ctx, 1, logger.LogLevelVerbose, "routing.qpLimiterSize", limiter.size())
 		}
 	}

--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -170,9 +170,12 @@ func logLatency(ctx context.Context, sentAt time.Time) {
 	}
 }
 
-func logServeRequest(ctx context.Context) {
+func logServeRequest(ctx context.Context, limiter *wsQueryLimiter) {
 	if logger.IsVerbose() {
 		logger.LogCtx(ctx, 1, logger.LogLevelVerbose, "routing.accepted", "")
+		if reqID.Load()%limiterSizeLogIntervalInRequests == 0 {
+			logger.LogCtx(ctx, 1, logger.LogLevelVerbose, "routing.qpLimiterSize", limiter.size())
+		}
 	}
 }
 

--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -85,8 +85,8 @@ func (f *annoyingErrorsFilter) Write(p []byte) (n int, err error) {
 }
 
 func replyServiceUnavailable(rw http.ResponseWriter) {
+	rw.Header().Set("Retry-After", strconv.Itoa(DefaultRetryAfterSecondsOn503))
 	rw.WriteHeader(http.StatusServiceUnavailable)
-	rw.Header().Add("Retry-After", strconv.Itoa(DefaultRetryAfterSecondsOn503))
 }
 
 func replyErr(rw http.ResponseWriter, err error) {

--- a/pkg/sys/it/impl_rates_test.go
+++ b/pkg/sys/it/impl_rates_test.go
@@ -5,11 +5,17 @@
 package sys_it
 
 import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/router"
 	it "github.com/voedger/voedger/pkg/vit"
 )
 
@@ -86,4 +92,80 @@ func TestRates_PerIP(t *testing.T) {
 
 	vit.PostWS(ws, "q.app1pkg.IPRatedQry", bodyQry, httpu.Expect429())
 	vit.PostWS(ws, "c.app1pkg.IPRatedCmd", bodyCmd, httpu.Expect429())
+}
+
+func TestQueryLimiter_BasicUsage(t *testing.T) {
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
+	sys := vit.GetSystemPrincipal(istructs.AppQName_test1_app1)
+	limit := vit.VVMConfig.RouterMaxQueriesPerWS
+
+	t.Run("queries rejected with 503 when per-workspace limit reached", func(t *testing.T) {
+		t.Run("qpv1", func(t *testing.T) {
+			wg, okToFinish := fillQuerySlots(t, vit, ws, limit)
+			defer releaseQuerySlots(wg, okToFinish, limit)
+
+			body := `{"args": {"Input": "world"},"elements": [{"fields": ["Res"]}]}`
+			vit.PostWS(ws, "q.app1pkg.MockQry", body, httpu.Expect503(), httpu.WithAuthorizeBy(sys.Token), httpu.WithNoRetryPolicy())
+		})
+
+		t.Run("qpv2", func(t *testing.T) {
+			wg, okToFinish := fillQuerySlots(t, vit, ws, limit)
+			defer releaseQuerySlots(wg, okToFinish, limit)
+
+			resp := vit.GET(fmt.Sprintf(`api/v2/apps/test1/app1/workspaces/%d/queries/sys.Echo?args=%s`, ws.WSID, url.QueryEscape(`{"Text":"Hello"}`)),
+				httpu.WithAuthorizeBy(sys.Token), httpu.Expect503(), httpu.WithNoRetryPolicy())
+			require.Equal(t, http.StatusServiceUnavailable, resp.HTTPResp.StatusCode)
+			require.Equal(t, fmt.Sprintf("%d", router.DefaultRetryAfterSecondsOn503), resp.HTTPResp.Header.Get("Retry-After"))
+		})
+	})
+
+	t.Run("commands not affected by query limiter", func(t *testing.T) {
+		wg, okToFinish := fillQuerySlots(t, vit, ws, limit)
+		defer releaseQuerySlots(wg, okToFinish, limit)
+
+		cmdBody := `{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.air_table_plan","name":"test"}}]}`
+		vit.PostWS(ws, "c.sys.CUD", cmdBody)
+	})
+
+	t.Run("different workspaces independently limited", func(t *testing.T) {
+		wg, okToFinish := fillQuerySlots(t, vit, ws, limit-1)
+		defer releaseQuerySlots(wg, okToFinish, limit-1)
+
+		ws3 := vit.WS(istructs.AppQName_test1_app1, "test_ws3")
+		body := `{"args": {"Text": "world"},"elements":[{"fields":["Res"]}]}`
+		resp := vit.PostWS(ws3, "q.sys.Echo", body)
+		require.Equal(t, http.StatusOK, resp.HTTPResp.StatusCode)
+	})
+}
+
+func fillQuerySlots(t *testing.T, vit *it.VIT, ws *it.AppWorkspace, count int) (wg *sync.WaitGroup, okToFinish chan struct{}) {
+	t.Helper()
+	funcStarted := make(chan struct{})
+	okToFinish = make(chan struct{})
+	it.MockQryExec = func(_ string, _ istructs.ExecQueryArgs, _ istructs.ExecQueryCallback) error {
+		funcStarted <- struct{}{}
+		<-okToFinish
+		return nil
+	}
+	sys := vit.GetSystemPrincipal(istructs.AppQName_test1_app1)
+	body := `{"args": {"Input": "world"},"elements": [{"fields": ["Res"]}]}`
+	wg = &sync.WaitGroup{}
+	for range count {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			vit.PostWS(ws, "q.app1pkg.MockQry", body, httpu.WithAuthorizeBy(sys.Token))
+		}()
+		<-funcStarted
+	}
+	return wg, okToFinish
+}
+
+func releaseQuerySlots(wg *sync.WaitGroup, okToFinish chan struct{}, count int) {
+	for range count {
+		okToFinish <- struct{}{}
+	}
+	wg.Wait()
 }

--- a/pkg/vvm/impl_cfg.go
+++ b/pkg/vvm/impl_cfg.go
@@ -36,6 +36,7 @@ func NewVVMDefaultConfig() VVMConfig {
 		RouterWriteTimeout:     router.DefaultRouterWriteTimeout, // same
 		RouterReadTimeout:      router.DefaultRouterWriteTimeout, // same
 		RouterConnectionsLimit: router.DefaultConnectionsLimit,
+		RouterMaxQueriesPerWS:  router.DefaultMaxQueriesPerWSLimit,
 		BLOBMaxSize:            DefaultBLOBMaxSize,
 		Time:                   timeu.NewITime(),
 		Name:                   processors.VVMName(hostname),

--- a/pkg/vvm/provide.go
+++ b/pkg/vvm/provide.go
@@ -573,6 +573,7 @@ func provideRouterParams(cfg *VVMConfig, port VVMPortType) router.RouterParams {
 		Routes:               cfg.Routes,
 		RoutesRewrite:        cfg.RoutesRewrite,
 		RouteDomains:         cfg.RouteDomains,
+		MaxQueriesPerWS:      cfg.RouterMaxQueriesPerWS,
 	}
 	return res
 }

--- a/pkg/vvm/types.go
+++ b/pkg/vvm/types.go
@@ -141,6 +141,7 @@ type VVMConfig struct {
 	RouterWriteTimeout               int
 	RouterReadTimeout                int
 	RouterConnectionsLimit           int
+	RouterMaxQueriesPerWS            int
 	RouterUseProxyProtocol           bool
 	RouterHTTP01ChallengeHosts       []string
 	RouteDefault                     string

--- a/pkg/vvm/wire_gen.go
+++ b/pkg/vvm/wire_gen.go
@@ -642,6 +642,7 @@ func provideRouterParams(cfg *VVMConfig, port VVMPortType) router.RouterParams {
 		Routes:               cfg.Routes,
 		RoutesRewrite:        cfg.RoutesRewrite,
 		RouteDomains:         cfg.RouteDomains,
+		MaxQueriesPerWS:      cfg.RouterMaxQueriesPerWS,
 	}
 	return res
 }

--- a/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/change.md
+++ b/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/change.md
@@ -1,0 +1,25 @@
+---
+registered_at: 2026-04-10T13:24:52Z
+change_id: 2604101324-limit-query-per-ws
+baseline: 2d707b6e4fd9a3b4427356077ea26a1731da85ff
+issue_url: https://untill.atlassian.net/browse/AIR-3542
+archived_at: 2026-04-10T14:50:46Z
+---
+
+# Change request: Limit concurrent query executions per workspace
+
+## Why
+
+During a production outage (AIR-3536), 93 goroutines simultaneously processed webhook requests for a single workspace, starving all other workspaces and blocking query processors entirely. A per-workspace concurrency limit is needed to prevent this resource exhaustion.
+
+See [issue.md](issue.md) for details.
+
+## What
+
+Implement a per-workspace concurrent query execution limiter in the router layer (`pkg/router`):
+
+- Add a concurrent-safe per-WSID counter map in the router
+- Before sending a query request, check the counter for the target WSID; return HTTP 503 if at or above the limit
+- Increment the counter before processing and decrement after `reply_v1`/`reply_v2` returns (via defer)
+- Apply the limit to query requests only (QP-bound APIPath in V2, resource prefix `q.` in V1)
+- Make the limit configurable via `RouterMaxQueriesPerWS` in `VVMConfig` (default 10)

--- a/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/decs.md
+++ b/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/decs.md
@@ -1,0 +1,71 @@
+# Decisions: Limit concurrent query executions per workspace
+
+## Detecting query requests in API v2
+
+Use `busRequest.APIPath` (the `processors.APIPath` enum) instead of the HTTP method to identify query requests (confidence: high).
+
+Rationale: In API v2, the HTTP GET method is used by 9 different endpoint types — not just queries. The `APIPath` field is set per handler and precisely identifies what kind of request it is. The relevant values that go through the query processor are:
+
+- `APIPath_Queries` — explicit query execution (`/queries/{pkg}.{query}`)
+- `APIPath_Views` — view reads (`/views/{pkg}.{view}`)
+- `APIPath_Docs` — single doc read (`/docs/{pkg}.{table}/{id}`, GET)
+- `APIPath_CDocs` — collection read (`/cdocs/{pkg}.{table}`, GET)
+- `APIPaths_Schema`, `APIPath_Schemas_WorkspaceRoles`, `APIPath_Schemas_WorkspaceRole` — schema reads
+- Blob reads and notifications also use GET but have separate handlers
+
+The VVM request handler (`impl_requesthandler.go:74`) currently uses `request.Method == http.MethodGet` to route to the query processor, meaning **all** GET requests go to the QP. The limiter should match the same scope — whatever the QP processes.
+
+Alternatives:
+
+- Check HTTP method == GET (confidence: medium)
+  - Simple but semantically imprecise; would limit schema reads and blob reads equally, which may not be desired. However, since the VVM itself routes all GET to QP, this actually matches the real bottleneck scope
+- Check URL path segment for `/queries/` (confidence: low)
+  - Too narrow; misses views, doc reads, and schema reads which also consume QP slots and contributed to the outage
+
+## Scope of the limiter: only `/queries/` or all QP requests
+
+Limit all requests routed to the query processor, not just `/queries/` (confidence: high).
+
+Rationale: The outage was caused by UPStandardWebhook requests saturating QP capacity for one workspace. Any GET request in V2 (queries, views, doc reads, schema reads) goes through the QP and can cause the same starvation. Limiting only `/queries/` would leave the door open for the same problem via other QP-bound paths.
+
+Alternatives:
+
+- Limit only `/queries/` endpoints (confidence: medium)
+  - More surgical, but leaves views and doc reads uncapped per workspace
+- Separate limits per APIPath type (confidence: low)
+  - Over-engineered for the current problem; can be introduced later if needed
+
+## Where to place the limiter check in the code
+
+Place the check inside `sendRequestAndReadResponse` with a condition on `busRequest.APIPath` via `isQPBoundAPIPath()` (confidence: high).
+
+Rationale: Centralizes the logic in one place — fewer code changes and less risk of missing a handler. The `busRequest.APIPath` is already set by each handler before calling `sendRequestAndReadResponse`, so the check is precise. Commands pass through too but are skipped by the `isQPBoundAPIPath` guard.
+
+Alternatives:
+
+- Place the check inside each specific handler function (confidence: medium)
+  - More explicit per-handler, but duplicates logic across many handlers and is error-prone when new handlers are added
+- Place the check in VVM request handler (confidence: low)
+  - Too late; the request has already been sent through the bus, the router cannot return 503 easily
+
+## Schema and blob reads: should they count toward the per-workspace limit
+
+Schema reads should NOT count (confidence: high). Blob reads should NOT count (confidence: high).
+
+Rationale: Schema endpoints (`/schemas`) don't take a WSID — they operate at the app level, so there's no workspace to limit against. Blob reads have their own separate handler (`blobRequestHandler`) and don't go through `sendRequestAndReadResponse` the same way. Both are lightweight and weren't part of the outage scenario.
+
+Alternatives:
+
+- Include all GET endpoints uniformly (confidence: low)
+  - Schema endpoints lack WSID, making per-workspace limiting impossible without redesign
+
+## Notification subscribe-and-watch: should it count toward the limit
+
+Notifications should NOT count toward the per-workspace query limit (confidence: high).
+
+Rationale: The subscribe-and-watch endpoint is long-lived (SSE/WebSocket style) and has `IsN10N = true` set. It uses a completely different processing path. Including it would quickly exhaust the limit and block normal queries.
+
+Alternatives:
+
+- Include notifications with a separate higher limit (confidence: low)
+  - Adds complexity for no clear benefit; notifications weren't part of the outage

--- a/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/how.md
+++ b/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/how.md
@@ -1,0 +1,28 @@
+# How: Limit concurrent query executions per workspace
+
+## Approach
+
+- Add a `wsQueryLimiter` type in `pkg/router` with a `sync.Map` keyed by `istructs.WSID`, values are `*atomic.Int32` counters, and `maxQPerWS int` field encapsulating the limit
+- Expose two methods: `acquire(wsid) bool` (increment-if-below-limit, return false if at limit or if `maxQPerWS <= 0`) and `release(wsid)` (decrement)
+- Add `MaxQueriesPerWS int` field to `RouterParams` in `pkg/router/types.go`, defaulting to 10 via `DefaultMaxQueriesPerWSLimit` constant in `pkg/router/consts.go`
+  - use it in http\https service only, not in admin or ACME services
+- Store the limiter instance as a `*wsQueryLimiter` pointer field on `routerService` in `pkg/router/types.go`
+- Wire the limit value through `provideRouterParams` in `pkg/vvm/provide.go` from `VVMConfig`
+- Add parameter `RouterMaxQueriesPerWS` to `VVMConfig` in `pkg/vvm/types.go`, following the existing `RouterWriteTimeout`/`RouterReadTimeout`/`RouterConnectionsLimit` pattern
+
+- **V2 detection**: use `busRequest.APIPath` to identify QP-bound requests. The limiter applies to handlers where `APIPath` is `APIPath_Queries`, `APIPath_Views`, `APIPath_Docs`, or `APIPath_CDocs` — these are the paths routed to the query processor by `impl_requesthandler.go`. Schema reads are excluded (no WSID). Blobs and notifications use separate handlers
+- **V2 placement**: inject the limiter call inside `sendRequestAndReadResponse` in `pkg/router/impl_apiv2.go`, checking `busRequest.APIPath` via `isQPBoundAPIPath()` helper. This centralizes the logic in one place rather than modifying every handler
+- **V1 detection**: in `RequestHandler_V1` in `pkg/router/impl_http.go`, check `limiter != nil && busRequest.Resource[:1] == "q"` before calling `SendRequest`. `nil` limiter check supports `ihttpimpl` caller which passes `nil` (no limiting for internal HTTP processor)
+- On limit exceeded, return HTTP 503 with `Retry-After: <DefaultRetryAfterSecondsOn503>` header via `replyServiceUnavailable()` (fixed: header must be set before `WriteHeader`)
+- Decrement via `defer limiter.release(wsid)` immediately after successful `acquire`, before `SendRequest` call — `reply_v1`/`reply_v2` blocking guarantees the QP slot is held until response is fully consumed
+
+References:
+
+- [pkg/router/impl_apiv2.go](../../../../pkg/router/impl_apiv2.go)
+- [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+- [pkg/router/types.go](../../../../pkg/router/types.go)
+- [pkg/router/consts.go](../../../../pkg/router/consts.go)
+- [pkg/vvm/provide.go](../../../../pkg/vvm/provide.go)
+- [pkg/vvm/types.go](../../../../pkg/vvm/types.go)
+- [pkg/vvm/impl_requesthandler.go](../../../../pkg/vvm/impl_requesthandler.go)
+- [pkg/processors/consts.go](../../../../pkg/processors/consts.go)

--- a/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/how.md
+++ b/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/how.md
@@ -3,7 +3,7 @@
 ## Approach
 
 - Add a `wsQueryLimiter` type in `pkg/router` with a `sync.Map` keyed by `istructs.WSID`, values are `*atomic.Int32` counters, and `maxQPerWS int` field encapsulating the limit
-- Expose two methods: `acquire(wsid) bool` (increment-if-below-limit, return false if at limit or if `maxQPerWS <= 0`) and `release(wsid)` (decrement)
+- Expose two methods: `acquire(wsid) bool` (increment-if-below-limit, return false if at limit; if `maxQPerWS <= 0`, treat it as unlimited and return true) and `release(wsid)` (decrement)
 - Add `MaxQueriesPerWS int` field to `RouterParams` in `pkg/router/types.go`, defaulting to 10 via `DefaultMaxQueriesPerWSLimit` constant in `pkg/router/consts.go`
   - use it in http\https service only, not in admin or ACME services
 - Store the limiter instance as a `*wsQueryLimiter` pointer field on `routerService` in `pkg/router/types.go`

--- a/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/impl.md
+++ b/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/impl.md
@@ -1,0 +1,56 @@
+# Implementation plan: Limit concurrent query executions per workspace
+
+## Construction
+
+### Core limiter
+
+- [x] create: [pkg/router/impl_limiter.go](../../../../pkg/router/impl_limiter.go)
+  - add: `wsQueryLimiter` type with `sync.Map` keyed by `istructs.WSID`, `*atomic.Int32` values, and `maxQPerWS int` field
+  - add: `acquire(wsid) bool` method — atomically increment if below `maxQPerWS`, return true if `maxQPerWS <= 0`
+  - add: `release(wsid)` method — atomically decrement counter
+  - add: `isQPBoundAPIPath(apiPath) bool` helper for V2 detection
+
+### Configuration
+
+- [x] update: [pkg/router/consts.go](../../../../pkg/router/consts.go)
+  - add: `DefaultMaxQueriesPerWSLimit` constant with value 10
+- [x] update: [pkg/router/types.go](../../../../pkg/router/types.go)
+  - add: `MaxQueriesPerWS int` field to `RouterParams`
+  - add: `queryLimiter *wsQueryLimiter` field to `routerService`
+- [x] update: [pkg/vvm/types.go](../../../../pkg/vvm/types.go)
+  - add: `RouterMaxQueriesPerWS int` field to `VVMConfig`
+- [x] update: [pkg/vvm/impl_cfg.go](../../../../pkg/vvm/impl_cfg.go)
+  - add: default value `RouterMaxQueriesPerWS: router.DefaultMaxQueriesPerWSLimit` in `NewVVMDefaultConfig()`
+- [x] update: [pkg/vvm/provide.go](../../../../pkg/vvm/provide.go)
+  - add: `MaxQueriesPerWS: cfg.RouterMaxQueriesPerWS` in `provideRouterParams()`
+- [x] update: [pkg/vvm/wire_gen.go](../../../../pkg/vvm/wire_gen.go)
+  - add: `MaxQueriesPerWS: cfg.RouterMaxQueriesPerWS` in `provideRouterParams()`
+- [x] update: [pkg/router/provide.go](../../../../pkg/router/provide.go)
+  - add: `queryLimiter: &wsQueryLimiter{maxQPerWS: rp.MaxQueriesPerWS}` in `getRouterService()`
+
+### V2 limiter integration
+
+- [x] update: [pkg/router/impl_apiv2.go](../../../../pkg/router/impl_apiv2.go)
+  - update: `sendRequestAndReadResponse()` — accept `limiter *wsQueryLimiter`; before `SendRequest`, check `isQPBoundAPIPath(busRequest.APIPath)` and if so, call `limiter.acquire(busRequest.WSID)`; on failure call `replyServiceUnavailable(rw)` and return; on success defer `limiter.release(busRequest.WSID)`
+  - update: all `requestHandlerV2_*` factory functions — accept `limiter *wsQueryLimiter` and pass to `sendRequestAndReadResponse`
+
+### V1 limiter integration
+
+- [x] update: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+  - update: `RequestHandler_V1()` — accept `limiter *wsQueryLimiter`; before `SendRequest`, check `limiter != nil && busRequest.Resource[:1] == "q"` and if so, call `limiter.acquire(busRequest.WSID)`; on failure call `replyServiceUnavailable(rw)` and return; on success defer `limiter.release(busRequest.WSID)`
+- [x] update: [pkg/ihttpimpl/impl.go](../../../../pkg/ihttpimpl/impl.go)
+  - update: pass `nil` for limiter in `RequestHandler_V1` call (no limiting for internal HTTP processor)
+
+### Bug fix
+
+- [x] update: [pkg/router/utils.go](../../../../pkg/router/utils.go)
+  - fix: `replyServiceUnavailable()` — set `Retry-After` header before `WriteHeader` (Go ignores headers set after `WriteHeader`)
+
+### Tests
+
+- [x] update: [pkg/sys/it/impl_rates_test.go](../../../../pkg/sys/it/impl_rates_test.go)
+  - add: `TestQueryLimiter_BasicUsage` integration test using shared VIT config with `vit.VVMConfig.RouterMaxQueriesPerWS`
+  - add: subtest: queries rejected with 503 when per-workspace limit reached (V1 and V2)
+  - add: subtest: commands not affected by the limiter
+  - add: subtest: different workspaces independently limited
+  - add: helpers `fillQuerySlots`/`releaseQuerySlots` using `MockQryExec`

--- a/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/issue.md
+++ b/uspecs/changes/archive/2604/2604101450-limit-query-per-ws/issue.md
@@ -1,0 +1,35 @@
+# AIR-3542: voedger: Limit concurrent query executions per workspace to 10 (by default)
+
+- **Type:** Sub-task
+- **Status:** In Progress
+- **Assignee:** d.gribanov@dev.untill.com
+
+## Problem
+
+During the AIR-3536 outage, 93 goroutines were simultaneously processing UPStandardWebhook requests for a single workspace, starving all other workspaces and blocking query processors entirely.
+
+## Architecture
+
+Implement the limiter in the router layer (`pkg/router`), not inside the query processor or VVM request handler. Why it can work:
+
+- `bus.IResponseWriter.Write()` blocks until the router reads each item from the channel (buffer = 1, one-by-one handshake)
+- The query processor calls `rowsProcessor.Close()` only after all rows are confirmed consumed by the router, then calls `respWriter.Close(err)` which closes the channel
+- The router detects channel close via `for elem := range responseCh` exiting
+
+Therefore: when `reply_v1` / `reply_v2` returns, the processor slot is provably free. Decrementing the per-WSID counter at that exact point reflects actual processor occupancy, not HTTP session duration.
+
+## Implementation
+
+- Add a concurrent-safe per-WSID counter map in the router (`pkg/router`)
+- In `sendRequestAndReadResponse` (V2) and `RequestHandler_V1` (V1), before calling `SendRequest`: check the counter for the request WSID. If it is at or above the limit, return HTTP 503 immediately
+- Increment the counter, call `SendRequest`, call `reply_v1` / `reply_v2`, then decrement (defer)
+- Apply the limit to query requests only (GET in V2, resource prefix `q.` in V1). Commands have a separate protection mechanism (one channel per partition)
+- The limit value is configurable via `RouterMaxQueriesPerWS` in `VVMConfig` (default 10), consistent with existing `RouterWriteTimeout`/`RouterReadTimeout`/`RouterConnectionsLimit` naming
+
+## Testing
+
+Reasonable tests are needed.
+
+## Scope
+
+voedger repository, `pkg/router`.

--- a/uspecs/specs/prod/apps/logging--td.md
+++ b/uspecs/specs/prod/apps/logging--td.md
@@ -151,6 +151,7 @@ Uses `vapp="sys/voedger"`, `extension="sys._Leadership"`, `key` attribs.
   - `origin`: HTTP Origin header value
   - `headers`: all request headers formatted as a single string for production debugging of real IP propagation
 - Request received: level `Verbose`, stage `routing.accepted`, msg (empty)
+- Every `limiterSizeLogIntervalInRequests` requests: level `Verbose`, stage `routing.qpLimiterSize`, msg `<number of workspaces tracked by the per-WS query limiter>`
 - First response from bus (immediately after `SendRequest` returns): level `Verbose`, stage `routing.latency1`, msg `<latency_ms>`
 - Error sending request to VVM: level `Error`, stage `routing.send2vvm.error`, msg `<error message>`
 - Error sending response to client: level `Error`, stage `routing.response.error`, msg `<error message>`


### PR DESCRIPTION
registered_at: 2026-04-10T13:24:52Z
change_id: 2604101324-limit-query-per-ws
baseline: 2d707b6e4fd9a3b4427356077ea26a1731da85ff
issue_url: https://untill.atlassian.net/browse/AIR-3542
archived_at: 2026-04-10T14:50:46Z

# Change request: Limit concurrent query executions per workspace

## Why

During a production outage (AIR-3536), 93 goroutines simultaneously processed webhook requests for a single workspace, starving all other workspaces and blocking query processors entirely. A per-workspace concurrency limit is needed to prevent this resource exhaustion.

See [issue.md](issue.md) for details.

## What

Implement a per-workspace concurrent query execution limiter in the router layer (`pkg/router`):

- Add a concurrent-safe per-WSID counter map in the router
- Before sending a query request, check the counter for the target WSID; return HTTP 503 if at or above the limit
- Increment the counter before processing and decrement after `reply_v1`/`reply_v2` returns (via defer)
- Apply the limit to query requests only (QP-bound APIPath in V2, resource prefix `q.` in V1)
- Make the limit configurable via `RouterMaxQueriesPerWS` in `VVMConfig` (default 10)
