### PR TITLE
[AIR-3561] sequences: mark LRU cache with Tech Debt mark, place a note in recovery flow describing how singletons are handled on recovery

### DIFF
--- a/pkg/isequencer/types.go
+++ b/pkg/isequencer/types.go
@@ -57,6 +57,8 @@ type sequencer struct {
 	actualizerCtxCancel context.CancelFunc
 	actualizerWG        *sync.WaitGroup
 
+	// TODO: LRU eviction requires re-reading from storage
+	// see https://untill.atlassian.net/browse/AIR-3506
 	cache *lruPkg.Cache[NumberKey, Number]
 
 	// Initialized by actualizer() from storage via ReadNextPLogOffset()

--- a/pkg/processors/command/impl.go
+++ b/pkg/processors/command/impl.go
@@ -297,7 +297,8 @@ func (cmdProc *cmdProc) recovery(ctx context.Context, cmd *cmdWorkpiece) (ap *ap
 		ws := ap.getWorkspace(event.Workspace())
 
 		for rec := range event.CUDs {
-			// note: Singletons are handled within UpdateOnSync: syncID<nextRecordID -> skip
+			// note: not needed to check for Singleton here
+			// because within UpdateOnSync: syncID<nextRecordID -> skip
 			if rec.IsNew() {
 				ws.idGenerator.UpdateOnSync(rec.ID())
 			}

--- a/pkg/processors/command/impl.go
+++ b/pkg/processors/command/impl.go
@@ -297,6 +297,7 @@ func (cmdProc *cmdProc) recovery(ctx context.Context, cmd *cmdWorkpiece) (ap *ap
 		ws := ap.getWorkspace(event.Workspace())
 
 		for rec := range event.CUDs {
+			// note: Singletons are handled within UpdateOnSync: syncID<nextRecordID -> skip
 			if rec.IsNew() {
 				ws.idGenerator.UpdateOnSync(rec.ID())
 			}


### PR DESCRIPTION
sequences: mark LRU cache with Tech Debt mark, place a note in recovery flow describing how singletons are handled on recovery
https://untill.atlassian.net/browse/AIR-3561