### PR TITLE
[AIR-3603] Send Retry-After header on function limit exceed

### DIFF
--- a/pkg/coreutils/syserror.go
+++ b/pkg/coreutils/syserror.go
@@ -18,6 +18,22 @@ type SysError struct {
 	QName      appdef.QName
 	Message    string
 	Data       string
+	headers    map[string]string
+}
+
+func (he SysError) AddHeader(key, value string) SysError {
+	if _, ok := he.headers[key]; ok {
+		panic(fmt.Sprintf("header %q is already set", key))
+	}
+	if he.headers == nil {
+		he.headers = map[string]string{}
+	}
+	he.headers[key] = value
+	return he
+}
+
+func (he SysError) Headers() map[string]string {
+	return he.headers
 }
 
 func NewSysError(statusCode int) error {
@@ -77,7 +93,6 @@ func (he SysError) ToJSON_APIV2() string {
 func (he SysError) IsNil() bool {
 	return he.HTTPStatus == 0 && len(he.Data) == 0 && len(he.Message) == 0 && he.QName == appdef.NullQName
 }
-
 
 func NewHTTPErrorf(httpStatus int, args ...interface{}) SysError {
 	return SysError{

--- a/pkg/coreutils/syserror_test.go
+++ b/pkg/coreutils/syserror_test.go
@@ -87,6 +87,49 @@ func TestBasicUsage_SysError(t *testing.T) {
 	})
 }
 
+func TestSysError_Headers(t *testing.T) {
+	require := require.New(t)
+
+	t.Run("no headers by default", func(t *testing.T) {
+		require.Nil(SysError{}.Headers())
+	})
+
+	t.Run("AddHeader returns enriched value", func(t *testing.T) {
+		e := SysError{HTTPStatus: http.StatusTooManyRequests}.AddHeader("Retry-After", "3")
+		require.Equal(map[string]string{"Retry-After": "3"}, e.Headers())
+	})
+
+	t.Run("multiple headers", func(t *testing.T) {
+		e := SysError{}.AddHeader("A", "1").AddHeader("B", "2")
+		require.Equal(map[string]string{"A": "1", "B": "2"}, e.Headers())
+	})
+
+	t.Run("panic if key already set", func(t *testing.T) {
+		e := SysError{}.AddHeader("A", "1")
+		require.PanicsWithValue(`header "A" is already set`, func() {
+			_ = e.AddHeader("A", "2")
+		})
+	})
+
+	t.Run("errors.As preserves headers", func(t *testing.T) {
+		var err error = SysError{HTTPStatus: http.StatusTooManyRequests}.AddHeader("Retry-After", "5")
+		var se SysError
+		require.ErrorAs(err, &se)
+		require.Equal("5", se.Headers()["Retry-After"])
+	})
+
+	t.Run("ToJSON ignores headers", func(t *testing.T) {
+		e := SysError{HTTPStatus: http.StatusTooManyRequests, Message: "rate exceeded"}.AddHeader("Retry-After", "3")
+		require.JSONEq(`{"sys.Error":{"HTTPStatus":429,"Message":"rate exceeded"}}`, e.ToJSON_APIV1())
+		require.JSONEq(`{"status":429,"message":"rate exceeded"}`, e.ToJSON_APIV2())
+	})
+
+	t.Run("IsNil ignores headers", func(t *testing.T) {
+		e := SysError{}.AddHeader("A", "1")
+		require.True(e.IsNil())
+	})
+}
+
 func TestNewHTTPError(t *testing.T) {
 	require := require.New(t)
 	t.Run("simple", func(t *testing.T) {

--- a/pkg/processors/command/impl.go
+++ b/pkg/processors/command/impl.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/voedger/voedger/pkg/bus"
+	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/processors/actualizers"
 	"github.com/voedger/voedger/pkg/processors/oldacl"
@@ -448,10 +449,12 @@ func checkWSActive(_ context.Context, cmd *cmdWorkpiece) (err error) {
 }
 
 func limitCallRate(_ context.Context, cmd *cmdWorkpiece) (err error) {
-	if exceeded, _ := cmd.appPart.IsLimitExceeded(cmd.cmdQName, appdef.OperationKind_Execute, cmd.cmdMes.WSID(), cmd.cmdMes.Host()); exceeded {
-		return coreutils.NewHTTPErrorf(http.StatusTooManyRequests)
+	exceeded, limit := cmd.appPart.IsLimitExceeded(cmd.cmdQName, appdef.OperationKind_Execute, cmd.cmdMes.WSID(), cmd.cmdMes.Host())
+	if !exceeded {
+		return nil
 	}
-	return nil
+	retryAfter := processors.RetryAfterSecondsOnLimitExceeded(cmd.appStructs.AppDef(), limit)
+	return coreutils.NewHTTPErrorf(http.StatusTooManyRequests).AddHeader(httpu.RetryAfter, strconv.Itoa(retryAfter))
 }
 
 func (cmdProc *cmdProc) authenticate(_ context.Context, cmd *cmdWorkpiece) (err error) {

--- a/pkg/processors/command/impl_test.go
+++ b/pkg/processors/command/impl_test.go
@@ -710,6 +710,18 @@ func TestRateLimit(t *testing.T) {
 	cmdRespMeta, _, err := bus.GetCommandResponse(app.ctx, app.requestSender, request)
 	require.Error(err)
 	require.Equal(http.StatusTooManyRequests, cmdRespMeta.StatusCode)
+
+	// 4th call: inspect the SysError directly to assert Retry-After header: period/count = 60s/2 = 30s
+	respCh, _, _, err := app.requestSender.SendRequest(app.ctx, request)
+	require.NoError(err)
+	var sysErr coreutils.SysError
+	for elem := range respCh {
+		if se, ok := elem.(coreutils.SysError); ok {
+			sysErr = se
+		}
+	}
+	require.Equal(http.StatusTooManyRequests, sysErr.HTTPStatus)
+	require.Equal("30", sysErr.Headers()[httpu.RetryAfter])
 }
 
 type testApp struct {

--- a/pkg/processors/query/impl.go
+++ b/pkg/processors/query/impl.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -189,10 +190,12 @@ func newQueryProcessorPipeline(requestCtx context.Context, authn iauthnz.IAuthen
 	ops := []*pipeline.WiredOperator{
 		operator("borrowAppPart", borrowAppPart),
 		operator("check function call rate", func(ctx context.Context, qw *queryWork) (err error) {
-			if exceeded, _ := qw.appPart.IsLimitExceeded(qw.msg.QName(), appdef.OperationKind_Execute, qw.msg.WSID(), qw.msg.Host()); exceeded {
-				return coreutils.NewSysError(http.StatusTooManyRequests)
+			exceeded, limit := qw.appPart.IsLimitExceeded(qw.msg.QName(), appdef.OperationKind_Execute, qw.msg.WSID(), qw.msg.Host())
+			if !exceeded {
+				return nil
 			}
-			return nil
+			retryAfter := processors.RetryAfterSecondsOnLimitExceeded(qw.appStructs.AppDef(), limit)
+			return coreutils.NewHTTPErrorf(http.StatusTooManyRequests).AddHeader(httpu.RetryAfter, strconv.Itoa(retryAfter))
 		}),
 		operator("authenticate query request", func(ctx context.Context, qw *queryWork) (err error) {
 			if processors.SetPrincipalsForAnonymousOnlyFunc(qw.appStructs.AppDef(), qw.msg.QName(), qw.msg.WSID(), qw) {

--- a/pkg/processors/query/impl_test.go
+++ b/pkg/processors/query/impl_test.go
@@ -1205,6 +1205,9 @@ func TestRateLimiter(t *testing.T) {
 			// 3rd exceeds the limit - not often than twice per minute
 			require.Error(*respErr)
 			require.Equal(http.StatusTooManyRequests, respMeta.StatusCode)
+			var sysErr coreutils.SysError
+			require.ErrorAs(*respErr, &sysErr)
+			require.Equal("30", sysErr.Headers()[httpu.RetryAfter]) // 60s / 2 = 30s
 			logCap.HasLine("stage=qp.error")
 			logCap.NotContains("stage=qp.success")
 		}

--- a/pkg/processors/query2/util.go
+++ b/pkg/processors/query2/util.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/appparts"
@@ -27,10 +28,12 @@ import (
 )
 
 func queryRateLimitExceeded(ctx context.Context, qw *queryWork) error {
-	if exceeded, _ := qw.appPart.IsLimitExceeded(qw.msg.QName(), appdef.OperationKind_Execute, qw.msg.WSID(), qw.msg.Host()); exceeded {
-		return coreutils.NewSysError(http.StatusTooManyRequests)
+	exceeded, limit := qw.appPart.IsLimitExceeded(qw.msg.QName(), appdef.OperationKind_Execute, qw.msg.WSID(), qw.msg.Host())
+	if !exceeded {
+		return nil
 	}
-	return nil
+	retryAfter := processors.RetryAfterSecondsOnLimitExceeded(qw.appStructs.AppDef(), limit)
+	return coreutils.NewHTTPErrorf(http.StatusTooManyRequests).AddHeader(httpu.RetryAfter, strconv.Itoa(retryAfter))
 }
 func querySetRequestType(ctx context.Context, qw *queryWork) error {
 	if qw.iQuery = appdef.Query(qw.iWorkspace.Type, qw.msg.QName()); qw.iQuery == nil {

--- a/pkg/processors/utils.go
+++ b/pkg/processors/utils.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"sort"
 	"strings"
@@ -21,6 +22,15 @@ import (
 	"github.com/voedger/voedger/pkg/state"
 	"github.com/voedger/voedger/pkg/sys"
 )
+
+func RetryAfterSecondsOnLimitExceeded(appDef appdef.IAppDef, limit appdef.QName) int {
+	rate := appdef.Limit(appDef.Type, limit).Rate()
+	seconds := int(math.Ceil(rate.Period().Seconds() / float64(rate.Count())))
+	if seconds < 1 {
+		return 1
+	}
+	return seconds
+}
 
 // CheckUnexpectedFields validates that all keys in args are known fields of argsType.
 // Returns HTTP 400 SysError if unexpected fields are found.

--- a/pkg/processors/utils_test.go
+++ b/pkg/processors/utils_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present unTill Software Development Group B.V.
+ * @author Denis Gribanov
+ */
+
+package processors
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/voedger/voedger/pkg/appdef"
+	"github.com/voedger/voedger/pkg/appdef/builder"
+	"github.com/voedger/voedger/pkg/appdef/filter"
+)
+
+func TestRetryAfterSecondsOnLimitExceeded(t *testing.T) {
+	require := require.New(t)
+
+	wsName := appdef.NewQName("test", "workspace")
+	cmdName := appdef.NewQName("test", "cmd")
+	buildApp := func(count appdef.RateCount, period time.Duration) (appdef.IAppDef, appdef.QName) {
+		limitName := appdef.NewQName("test", "limit")
+		rateName := appdef.NewQName("test", "rate")
+		adb := builder.New()
+		adb.AddPackage("test", "test.com/test")
+		wsb := adb.AddWorkspace(wsName)
+		_ = wsb.AddCommand(cmdName)
+		wsb.AddRate(rateName, count, period, nil)
+		wsb.AddLimit(limitName,
+			[]appdef.OperationKind{appdef.OperationKind_Execute},
+			appdef.LimitFilterOption_EACH,
+			filter.WSTypes(wsName, appdef.TypeKind_Command),
+			rateName)
+		return adb.MustBuild(), limitName
+	}
+
+	t.Run("integer seconds", func(t *testing.T) {
+		app, limit := buildApp(6, time.Minute) // 60s / 6 = 10s
+		require.Equal(10, RetryAfterSecondsOnLimitExceeded(app, limit))
+	})
+
+	t.Run("sub-second per token rounds up to 1", func(t *testing.T) {
+		app, limit := buildApp(1000, time.Minute) // 60s / 1000 = 0.06s -> 1
+		require.Equal(1, RetryAfterSecondsOnLimitExceeded(app, limit))
+	})
+
+	t.Run("fractional seconds rounded up", func(t *testing.T) {
+		app, limit := buildApp(7, time.Minute) // 60/7 = 8.57... -> 9
+		require.Equal(9, RetryAfterSecondsOnLimitExceeded(app, limit))
+	})
+
+	t.Run("long period", func(t *testing.T) {
+		app, limit := buildApp(1, time.Hour) // 3600s / 1 = 3600
+		require.Equal(3600, RetryAfterSecondsOnLimitExceeded(app, limit))
+	})
+}

--- a/pkg/router/impl_http.go
+++ b/pkg/router/impl_http.go
@@ -20,6 +20,7 @@ import (
 	proxyproto "github.com/pires/go-proxyproto"
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/bus"
+	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/sys"
@@ -238,7 +239,7 @@ func RequestHandler_V1(requestSender bus.IRequestSender, numsAppsWorkspaces map[
 		logLatency(requestCtx, sentAt)
 
 		initResponse(rw, responseMeta)
-		reply_v1(requestCtx, rw, responseCh, responseErr, responseMeta.ContentType, cancel, busRequest, responseMeta.Mode())
+		reply_v1(requestCtx, rw, responseCh, responseErr, cancel, busRequest, responseMeta)
 	})
 }
 
@@ -270,5 +271,10 @@ func initResponse(w http.ResponseWriter, responseMeta bus.ResponseMeta) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 	}
 	w.Header().Set(httpu.ContentType, responseMeta.ContentType)
-	w.WriteHeader(responseMeta.StatusCode)
+}
+
+func applySysErrorHeaders(w http.ResponseWriter, sysErr coreutils.SysError) {
+	for k, v := range sysErr.Headers() {
+		w.Header().Set(k, v)
+	}
 }

--- a/pkg/router/impl_reply_v1.go
+++ b/pkg/router/impl_reply_v1.go
@@ -21,7 +21,7 @@ import (
 )
 
 func reply_v1(requestCtx context.Context, w http.ResponseWriter, responseCh <-chan any, responseErr *error,
-	contentType string, onSendFailed func(), busRequest bus.Request, mode bus.RespondMode) {
+	onSendFailed func(), busRequest bus.Request, responseMeta bus.ResponseMeta) {
 	sendSuccess := true
 	defer func() {
 		if requestCtx.Err() != nil {
@@ -39,7 +39,7 @@ func reply_v1(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 		}
 	}()
 
-	if mode == bus.RespondMode_Single {
+	if responseMeta.Mode() == bus.RespondMode_Single {
 		select {
 		case data := <-responseCh:
 			if requestCtx.Err() != nil {
@@ -49,10 +49,14 @@ func reply_v1(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 			}
 			switch typed := data.(type) {
 			case string:
+				w.WriteHeader(responseMeta.StatusCode)
 				sendSuccess = writeResponse(w, typed)
 			case []byte:
+				w.WriteHeader(responseMeta.StatusCode)
 				sendSuccess = writeResponse(w, string(typed))
 			case coreutils.SysError:
+				applySysErrorHeaders(w, typed)
+				w.WriteHeader(responseMeta.StatusCode)
 				if busRequest.IsAPIV2 {
 					sendSuccess = writeResponse(w, typed.ToJSON_APIV2())
 				} else {
@@ -64,6 +68,7 @@ func reply_v1(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 					// notest
 					panic(err)
 				}
+				w.WriteHeader(responseMeta.StatusCode)
 				sendSuccess = writeResponse(w, string(elemBytes))
 			}
 		case <-requestCtx.Done():
@@ -74,6 +79,13 @@ func reply_v1(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 	sectionsCloser := ""
 	responseCloser := "{}"
 	isCmd := strings.HasPrefix(busRequest.Resource, "c.")
+	headerWritten := false
+	writeHeaderOnce := func() {
+		if !headerWritten {
+			w.WriteHeader(responseMeta.StatusCode)
+			headerWritten = true
+		}
+	}
 	for elem := range responseCh {
 		// http client disconnected -> ErrNoConsumer on IMultiResponseSender.SendElement() -> QP will call Close()
 		if requestCtx.Err() != nil {
@@ -82,6 +94,7 @@ func reply_v1(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 			return
 		}
 		if !isCmd && elemsCount == 0 {
+			writeHeaderOnce()
 			if sendSuccess = writeResponse(w, `{"sections":[{"type":"","elements":[`); !sendSuccess {
 				return
 			}
@@ -95,7 +108,8 @@ func reply_v1(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 
 		elemsCount++
 
-		if isCmd || contentType == httpu.ContentType_TextPlain {
+		if isCmd || responseMeta.ContentType == httpu.ContentType_TextPlain {
+			writeHeaderOnce()
 			sendSuccess = writeResponse(w, elem.(string))
 			continue
 		}
@@ -126,6 +140,10 @@ func reply_v1(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 		}
 		var sysError coreutils.SysError
 		if errors.As(*responseErr, &sysError) {
+			if !headerWritten {
+				applySysErrorHeaders(w, sysError)
+			}
+			writeHeaderOnce()
 			jsonErr := sysError.ToJSON_APIV1()
 			if elemsCount > 0 {
 				jsonErr = strings.TrimPrefix(jsonErr, "{") // need to make "sys.Error" a top-level field within {}
@@ -133,9 +151,11 @@ func reply_v1(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 			}
 			sendSuccess = writeResponse(w, jsonErr)
 		} else {
+			writeHeaderOnce()
 			sendSuccess = writeResponse(w, fmt.Sprintf(`"status":%d,"errorDescription":"%s"`, http.StatusInternalServerError, *responseErr))
 		}
 	}
+	writeHeaderOnce()
 	if sendSuccess && len(responseCloser) > 0 {
 		sendSuccess = writeResponse(w, responseCloser)
 	}

--- a/pkg/router/impl_reply_v2.go
+++ b/pkg/router/impl_reply_v2.go
@@ -37,7 +37,15 @@ func reply_v2(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 
 	// ApiArray and no elems -> {"results":[]}
 
+	headerWritten := false
+	writeHeaderOnce := func() {
+		if !headerWritten {
+			w.WriteHeader(respMeta.StatusCode)
+			headerWritten = true
+		}
+	}
 	if respMeta.Mode() == bus.RespondMode_StreamJSON {
+		writeHeaderOnce()
 		if sendSuccess = writeResponse(w, `{"results":[`); !sendSuccess {
 			return
 		}
@@ -76,6 +84,7 @@ func reply_v2(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 			case []byte:
 				toSend = string(typed)
 			case coreutils.SysError:
+				applySysErrorHeaders(w, typed)
 				toSend = typed.ToJSON_APIV2()
 			default:
 				elemBytes, err := json.Marshal(elem)
@@ -85,6 +94,7 @@ func reply_v2(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 				}
 				toSend = string(elemBytes)
 			}
+			writeHeaderOnce()
 		}
 
 		if sendSuccess = writeResponse(w, toSend); !sendSuccess {
@@ -116,6 +126,7 @@ func reply_v2(requestCtx context.Context, w http.ResponseWriter, responseCh <-ch
 		}
 	}
 
+	writeHeaderOnce()
 	if sendSuccess && respMeta.Mode() == bus.RespondMode_StreamJSON {
 		sendSuccess = writeResponse(w, "}")
 	}

--- a/pkg/router/impl_test.go
+++ b/pkg/router/impl_test.go
@@ -166,6 +166,26 @@ type testObject struct {
 	StrField string
 }
 
+func TestSysErrorHeaders(t *testing.T) {
+	require := require.New(t)
+	sysErr := coreutils.SysError{HTTPStatus: http.StatusTooManyRequests, Message: "rate limit exceeded"}.
+		AddHeader("Retry-After", "10")
+	router := setUp(t, func(requestCtx context.Context, request bus.Request, responder bus.IResponder) {
+		go func() {
+			err := responder.Respond(bus.ResponseMeta{ContentType: httpu.ContentType_ApplicationJSON, StatusCode: sysErr.HTTPStatus}, sysErr)
+			require.NoError(err)
+		}()
+	})
+	defer tearDown(router)
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/api/v2/apps/test1/app1/workspaces/%d/queries/test.query", router.port(), testWSID))
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusTooManyRequests, resp.StatusCode)
+	require.Equal("10", resp.Header.Get("Retry-After"))
+}
+
 func TestHandlerPanic(t *testing.T) {
 	router := setUp(t, func(requestCtx context.Context, request bus.Request, responder bus.IResponder) {
 		panic("test panic HandlerPanic")

--- a/pkg/sys/it/impl_rates_test.go
+++ b/pkg/sys/it/impl_rates_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestRates_BasicUsage(t *testing.T) {
+	require := require.New(t)
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
 
@@ -34,9 +35,11 @@ func TestRates_BasicUsage(t *testing.T) {
 		vit.PostWS(ws, "c.app1pkg.RatedCmd", bodyCmd)
 	}
 
-	// 3rd is failed because per-minute rate is exceeded
-	vit.PostWS(ws, "q.app1pkg.RatedQry", bodyQry, httpu.Expect429())
-	vit.PostWS(ws, "c.app1pkg.RatedCmd", bodyCmd, httpu.Expect429())
+	// 3rd is failed because per-minute rate is exceeded (RatedPerMinute: 2 PER MINUTE -> 30s)
+	respQry := vit.PostWS(ws, "q.app1pkg.RatedQry", bodyQry, httpu.Expect429())
+	require.Equal("30", respQry.HTTPResp.Header.Get(httpu.RetryAfter))
+	respCmd := vit.PostWS(ws, "c.app1pkg.RatedCmd", bodyCmd, httpu.Expect429())
+	require.Equal("30", respCmd.HTTPResp.Header.Get(httpu.RetryAfter))
 
 	// proceed to the next minute to restore per-minute rates
 	vit.TimeAdd(time.Minute)
@@ -54,9 +57,11 @@ func TestRates_BasicUsage(t *testing.T) {
 	// proceed to the next minute to restore per-minute rates
 	vit.TimeAdd(time.Minute)
 
-	// next are failed again because per-hour rate is exceeded
-	vit.PostWS(ws, "q.app1pkg.RatedQry", bodyQry, httpu.Expect429())
-	vit.PostWS(ws, "c.app1pkg.RatedCmd", bodyCmd, httpu.Expect429())
+	// next are failed again because per-hour rate is exceeded (RatedPerHour: 4 PER HOUR -> 900s)
+	respQry = vit.PostWS(ws, "q.app1pkg.RatedQry", bodyQry, httpu.Expect429())
+	require.Equal("900", respQry.HTTPResp.Header.Get(httpu.RetryAfter))
+	respCmd = vit.PostWS(ws, "c.app1pkg.RatedCmd", bodyCmd, httpu.Expect429())
+	require.Equal("900", respCmd.HTTPResp.Header.Get(httpu.RetryAfter))
 
 	// proceed to the next hour to restore per-hour rates
 	vit.TimeAdd(time.Hour)
@@ -81,8 +86,12 @@ func TestRates_PerIP(t *testing.T) {
 		vit.PostWS(ws, "c.app1pkg.IPRatedCmd", bodyCmd)
 	}
 
-	vit.PostWS(ws, "q.app1pkg.IPRatedQry", bodyQry, httpu.Expect429())
-	vit.PostWS(ws, "c.app1pkg.IPRatedCmd", bodyCmd, httpu.Expect429())
+	// IPRatedPerMinute: 2 PER MINUTE -> 30s
+	require := require.New(t)
+	respQry := vit.PostWS(ws, "q.app1pkg.IPRatedQry", bodyQry, httpu.Expect429())
+	require.Equal("30", respQry.HTTPResp.Header.Get(httpu.RetryAfter))
+	respCmd := vit.PostWS(ws, "c.app1pkg.IPRatedCmd", bodyCmd, httpu.Expect429())
+	require.Equal("30", respCmd.HTTPResp.Header.Get(httpu.RetryAfter))
 
 	vit.TimeAdd(time.Minute)
 

--- a/uspecs/changes/archive/2604/2604171433-retry-after-on-limit-exceed/change.md
+++ b/uspecs/changes/archive/2604/2604171433-retry-after-on-limit-exceed/change.md
@@ -1,0 +1,19 @@
+---
+registered_at: 2026-04-17T13:25:28Z
+change_id: 2604171325-retry-after-on-limit-exceed
+baseline: d5de0204088ff817cdc678a5c88e27b65a2c0eaa
+issue_url: https://untill.atlassian.net/browse/AIR-3603
+archived_at: 2026-04-17T14:33:15Z
+---
+
+# Change request: Send Retry-After header on function limit exceed
+
+## Why
+
+When a function limit is exceeded, processors currently return only the HTTP 429 status code, leaving clients without guidance on when to retry. See [issue.md](issue.md) for details.
+
+## What
+
+Update processors so that limit-exceeded responses include retry guidance:
+
+- On limit exceeded in processors, send the `Retry-After` response header containing the number of seconds the client should wait before retrying

--- a/uspecs/changes/archive/2604/2604171433-retry-after-on-limit-exceed/decs.md
+++ b/uspecs/changes/archive/2604/2604171433-retry-after-on-limit-exceed/decs.md
@@ -1,0 +1,53 @@
+# Decisions: Send Retry-After header on function limit exceed
+
+## Retry-After value computation
+
+Compute Retry-After from the limit's declared rate parameters in `IAppDef`, the same way `vit.RatePerPeriod()` does: look up the exceeded limit by the QName returned from `IsLimitExceeded`, read `Rate().Count()` and `Rate().Period()`, and use `Period / Count` as the per-token interval (confidence: high).
+
+Rationale: This keeps all existing interfaces (`IBuckets`, `Limiter`, `IAppPartition.IsLimitExceeded`) untouched. The exceeded limit's QName is already returned by `IsLimitExceeded`, and `appdef.Limit(appDef.Type, limitName).Rate()` provides `Count()` and `Period()` that fully describe the refill schedule declared in VSQL. The bucket's internal token-refill state is an implementation detail of `iratesce`; the VSQL-declared rate is the contractual throughput the client can rely on.
+
+Alternatives:
+
+- Dynamic value from bucket's next-token time via extended limiter API (confidence: medium)
+  - More precise but requires changing `IBuckets.TakeTokens`, `Limiter.Exceeded`, and `IAppPartition.IsLimitExceeded` signatures and all their callers and tests
+- Fixed default (e.g., 1 second) like existing 503 path (confidence: low)
+  - Simplest, but gives clients no real information and can cause retry storms
+
+## Propagation of Retry-After from processor to HTTP response
+
+Extend `coreutils.SysError` with an optional `Headers map[string]string` field and an `AddHeaders(...)` method; the processor attaches `Retry-After` to the 429 `SysError`, and the router copies these headers onto the HTTP response when rendering the error (confidence: high).
+
+Rationale: The `SysError` is already the single value that flows from processor to router as the error payload (see `bus.ReplyErrDef` → `responder.Respond` → `reply_v1`/`reply_v2`). Attaching transport-level hints to it avoids adding new fields to `bus.ResponseMeta` or special casing by status code in the router. `AddHeaders` keeps the call sites concise and the field optional, so existing `SysError` usages are unaffected.
+
+Alternatives:
+
+- New optional `RetryAfter time.Duration` / `Headers` field in `bus.ResponseMeta` rendered by `initResponse` (confidence: medium)
+  - Keeps `SysError` a pure domain error but requires threading the value through `Responder.Respond` call sites and router's `initResponse`
+- Hard-code the Retry-After in the router by inspecting status 429 and calling back into `appPart`/`IAppDef` (confidence: low)
+  - Breaks layering: router should not depend on rate-limit semantics
+
+## Scope of processors affected
+
+Apply the change to the three existing `IsLimitExceeded` call sites that return 429: command processor (`pkg/processors/command/impl.go#limitCallRate`), query processor v1 (`pkg/processors/query/impl.go`), query processor v2 (`pkg/processors/query2/util.go#queryRateLimitExceeded`) (confidence: high).
+
+Rationale: These are all the code paths the issue refers to ("processors: limit exceeded"). The 503 "no query processors available" path in `pkg/vvm/impl_requesthandler.go` and the router-level QP wsQueryLimiter `replyServiceUnavailable` already send `Retry-After` and are out of scope of AIR-3603.
+
+Alternatives:
+
+- Also unify the 503 Retry-After path to use the same mechanism (confidence: medium)
+  - Valuable cleanup but expands scope beyond the issue
+- Limit to a single processor first (e.g., query v2) and replicate later (confidence: low)
+  - Leaves behavior inconsistent across processors for an extended period
+
+## Header format and minimum value
+
+Send `Retry-After` as an integer number of seconds (delta-seconds form), rounded up (ceiling) from the computed duration, with a minimum of 1 (confidence: high).
+
+Rationale: RFC 9110 allows both delta-seconds and HTTP-date; delta-seconds is simpler to produce, easier to test deterministically, and matches both the existing `replyServiceUnavailable` implementation and `parseRetryAfterHeader` test expectations in `pkg/goutils/httpu`. Ceiling avoids 0-second values that would encourage immediate retries; a 1-second floor guarantees a real back-off.
+
+Alternatives:
+
+- HTTP-date format (confidence: low)
+  - Harder to test (depends on wall clock), more parsing surface on clients
+- Floor with 1-second minimum (confidence: medium)
+  - Close to equivalent; slightly under-estimates wait and can trigger an extra retry

--- a/uspecs/changes/archive/2604/2604171433-retry-after-on-limit-exceed/how.md
+++ b/uspecs/changes/archive/2604/2604171433-retry-after-on-limit-exceed/how.md
@@ -1,0 +1,40 @@
+# How: Send Retry-After header on function limit exceed
+
+## Approach
+
+- Compute Retry-After from VSQL-declared rate parameters, not from bucket internals:
+  - Reuse the existing `(exceeded, limitQName)` return of `appPart.IsLimitExceeded` in `pkg/appparts/interface.go`
+  - Look up `appdef.Limit(appDef.Type, limitQName)` and read `Rate().Count()` and `Rate().Period()` — the same access pattern as `vit.RatePerPeriod()` in `pkg/vit/utils.go`
+  - Use `Period / Count` as the per-token interval; apply `math.Ceil` to seconds and enforce a 1-second minimum
+  - `IAppDef` is already reachable in each processor via `appPart.AppStructs().AppDef()`
+- Carry the computed duration from processor to router via `coreutils.SysError`:
+  - Extend `coreutils.SysError` in `pkg/coreutils/syserror.go` with an optional `headers map[string]string` field and a method `AddHeader(key, value string) SysError` that returns the enriched `SysError`
+  - Rate-limit check functions build a 429 `SysError` and call `.AddHeaders("Retry-After", strconv.Itoa(ceilSeconds))` before returning it; the existing `bus.ReplyErr` → `responder.Respond` → router path already carries the `SysError` through to the router
+  - In `pkg/router/impl_http.go` `initResponse` (and any other writer that materializes a `SysError` response), after matching/unwrapping the `SysError`, iterate its `Headers` and `w.Header().Set(k, v)` before `WriteHeader`
+- Update the three 429-producing processors to compute and propagate the value:
+  - `pkg/processors/command/impl.go` `limitCallRate`
+  - `pkg/processors/query/impl.go` "check function call rate" inline operator
+  - `pkg/processors/query2/util.go` `queryRateLimitExceeded`
+  - Extract a small shared helper (e.g. in `pkg/processors/impl_ratelimit.go` or similar existing `pkg/processors` shared package) to avoid duplication: given `appPart`, exceeded `limitQName`, return the `time.Duration` for Retry-After
+- Keep `replyServiceUnavailable` in `pkg/router/utils.go` and the 503 path in `pkg/vvm/impl_requesthandler.go` unchanged — they are out of scope and already send `Retry-After`
+- Tests:
+  - Extend `TestRateLimit` in `pkg/processors/command/impl_test.go` to assert that the 429 response carries a `Retry-After` header with a value consistent with `rateName`'s `Count/Period`
+  - Add analogous assertions in query v1 and v2 rate-limit tests
+  - Add a unit test for the Retry-After computation helper covering: integer seconds, sub-second period rounded up, 1-second floor
+
+References:
+
+- [pkg/appparts/interface.go](../../../../../pkg/appparts/interface.go)
+- [pkg/appparts/internal/limiter/limiter.go](../../../../../pkg/appparts/internal/limiter/limiter.go)
+- [pkg/appdef/interface_ratelimit.go](../../../../../pkg/appdef/interface_ratelimit.go)
+- [pkg/vit/utils.go](../../../../../pkg/vit/utils.go)
+- [pkg/coreutils/syserror.go](../../../../../pkg/coreutils/syserror.go)
+- [pkg/bus/utils.go](../../../../../pkg/bus/utils.go)
+- [pkg/router/impl_http.go](../../../../../pkg/router/impl_http.go)
+- [pkg/router/impl_reply_v1.go](../../../../../pkg/router/impl_reply_v1.go)
+- [pkg/router/impl_reply_v2.go](../../../../../pkg/router/impl_reply_v2.go)
+- [pkg/router/utils.go](../../../../../pkg/router/utils.go)
+- [pkg/processors/command/impl.go](../../../../../pkg/processors/command/impl.go)
+- [pkg/processors/query/impl.go](../../../../../pkg/processors/query/impl.go)
+- [pkg/processors/query2/util.go](../../../../../pkg/processors/query2/util.go)
+- [pkg/processors/command/impl_test.go](../../../../../pkg/processors/command/impl_test.go)

--- a/uspecs/changes/archive/2604/2604171433-retry-after-on-limit-exceed/impl.md
+++ b/uspecs/changes/archive/2604/2604171433-retry-after-on-limit-exceed/impl.md
@@ -1,0 +1,57 @@
+# Implementation plan: Send Retry-After header on function limit exceed
+
+## Construction
+
+### SysError headers support
+
+- [x] update: [pkg/coreutils/syserror.go](../../../../../pkg/coreutils/syserror.go)
+  - add: unexported `headers map[string]string` field on `SysError`
+  - add: `AddHeader(key, value string) SysError` method returning the enriched value. Make it panic if the key is set already
+  - add: `Headers() map[string]string` accessor
+  - ensure: `ToJSON_APIV1`, `ToJSON_APIV2` and `IsNil` remain unaffected by the new field
+- [x] update: [pkg/coreutils/syserror_test.go](../../../../../pkg/coreutils/syserror_test.go)
+  - add: test for `AddHeader` / `Headers` / error wrapping preserves headers
+- [x] Review
+
+### Retry-After computation helper
+
+- [x] update: [pkg/processors/utils.go](../../../../../pkg/processors/utils.go)
+  - add: helper `RetryAfterSecondsOnLimitExceeded(appDef appdef.IAppDef, limit appdef.QName) int` — reads `Rate().Count()`/`Rate().Period()` via `appdef.Limit(appDef.Type, limit)` and returns `ceil(Period.Seconds()/Count)` with a minimum of 1
+- [x] create: [pkg/processors/utils_test.go](../../../../../pkg/processors/utils_test.go)
+  - add: subtests for integer seconds, sub-second period rounded up, 1-second floor
+- [x] Review
+
+### Router: apply SysError headers on response
+
+- [x] update: [pkg/router/impl_http.go](../../../../../pkg/router/impl_http.go)
+  - update: `initResponse` no longer calls `WriteHeader`; added helper `applySysErrorHeaders`
+- [x] update: [pkg/router/impl_reply_v1.go](../../../../../pkg/router/impl_reply_v1.go)
+  - update: signature now takes `bus.ResponseMeta`; `WriteHeader(statusCode)` is deferred via a `writeHeaderOnce` closure in both Single and multi (StreamJSON) modes. On `coreutils.SysError` the headers are applied via `applySysErrorHeaders` before `WriteHeader` — including when the error arrives via `responseErr` after zero elements
+- [x] update: [pkg/router/impl_reply_v2.go](../../../../../pkg/router/impl_reply_v2.go)
+  - update: `WriteHeader(statusCode)` is deferred via a `writeHeaderOnce` closure. On `coreutils.SysError` the headers are applied via `applySysErrorHeaders` before `WriteHeader`
+- [x] update: [pkg/router/impl_test.go](../../../../../pkg/router/impl_test.go)
+  - add: `TestSysErrorHeaders` asserts that a `SysError` with `Retry-After` header results in `Retry-After` on the HTTP response
+- [x] Review
+
+### Processors: attach Retry-After on 429
+
+- [x] update: [pkg/processors/command/impl.go](../../../../../pkg/processors/command/impl.go)
+  - update: `limitCallRate` — on exceeded, builds `coreutils.NewHTTPErrorf(http.StatusTooManyRequests).AddHeader(httpu.RetryAfter, strconv.Itoa(processors.RetryAfterSecondsOnLimitExceeded(cmd.appStructs.AppDef(), limit)))`
+- [x] update: [pkg/processors/command/impl_test.go](../../../../../pkg/processors/command/impl_test.go)
+  - update: `TestRateLimit` — asserts `Retry-After` on the 429 `SysError` via `requestSender.SendRequest` (value `30` for 2/min rate)
+- [x] update: [pkg/processors/query/impl.go](../../../../../pkg/processors/query/impl.go)
+  - update: inline "check function call rate" operator — attach `Retry-After` to the 429 `SysError` the same way
+- [x] update: [pkg/processors/query/impl_test.go](../../../../../pkg/processors/query/impl_test.go)
+  - update: `TestRateLimiter` — asserts `Retry-After` on the 429 `*respErr` via `errors.As` (value `30` for 2/min rate)
+- [x] update: [pkg/processors/query2/util.go](../../../../../pkg/processors/query2/util.go)
+  - update: `queryRateLimitExceeded` — attaches `Retry-After` to the 429 `SysError` the same way
+- [-] update: [pkg/processors/query2/impl_test.go](../../../../../pkg/processors/query2/impl_test.go)
+  - rationale: query2 has no existing unit-level test for rate limits; the integration test in `pkg/sys/it/impl_rates_test.go` covers the end-to-end API v2 path using the same helper
+- [x] Review
+
+### Integration test
+
+- [x] update: [pkg/sys/it/impl_rates_test.go](../../../../../pkg/sys/it/impl_rates_test.go)
+  - update: `TestRates_BasicUsage` asserts `Retry-After: 30` on the first per-minute 429 (both query and command) and `Retry-After: 900` on the per-hour 429
+  - update: `TestRates_PerIP` asserts `Retry-After: 30` on the per-IP 429
+- [x] Review

--- a/uspecs/changes/archive/2604/2604171433-retry-after-on-limit-exceed/issue.md
+++ b/uspecs/changes/archive/2604/2604171433-retry-after-on-limit-exceed/issue.md
@@ -1,0 +1,15 @@
+# AIR-3603: voedger: send Retry-After header on func limit exceed
+
+- **Key**: AIR-3603
+- **Type**: Sub-task
+- **Status**: In Progress
+- **Assignee**: d.gribanov@dev.untill.com
+- **URL**: https://untill.atlassian.net/browse/AIR-3603
+
+## Why
+
+If a limit is exceeded then just `429` status code is sent to the HTTP client. The client does not know how much time to wait.
+
+## What
+
+In processors: limit exceeded → send `Retry-After` header with amount of seconds to retry after.


### PR DESCRIPTION
registered_at: 2026-04-17T13:25:28Z
change_id: 2604171325-retry-after-on-limit-exceed
baseline: d5de0204088ff817cdc678a5c88e27b65a2c0eaa
issue_url: https://untill.atlassian.net/browse/AIR-3603
archived_at: 2026-04-17T14:33:15Z

# Change request: Send Retry-After header on function limit exceed

## Why

When a function limit is exceeded, processors currently return only the HTTP 429 status code, leaving clients without guidance on when to retry. See [issue.md](issue.md) for details.

## What

Update processors so that limit-exceeded responses include retry guidance:

- On limit exceeded in processors, send the `Retry-After` response header containing the number of seconds the client should wait before retrying
