### PR TITLE
[AIR-3656] Replace c.cluster.VSqlUpdate with q.cluster.VSqlUpdate2 to avoid command processor deadlock

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,7 @@ linters:
           arguments:
             - allowFloats: 0.0,0.,1.0,1.,2.0,2.
               allowInts: 0,1,2
-              allowStrs: '""'
+              allowStrs: '"","to"'
               maxLitCount: "3"
           severity: warning
     staticcheck:

--- a/pkg/cluster/appws.vsql
+++ b/pkg/cluster/appws.vsql
@@ -25,9 +25,16 @@ ALTER WORKSPACE sys.AppWorkspaceWS (
 		NewID ref -- filled on `insert table` only
 	);
 
+	TYPE VSqlUpdate2Result (
+		LogWLogOffset int64 NOT NULL,
+		CUDWLogOffset int64 NOT NULL
+	);
+
 	EXTENSION ENGINE BUILTIN (
 		COMMAND DeployApp(AppDeploymentDescriptor);
 		COMMAND VSqlUpdate(VSqlUpdateParams) RETURNS VSqlUpdateResult;
+		COMMAND LogVSqlUpdate(VSqlUpdateParams);
+		QUERY VSqlUpdate2(VSqlUpdateParams) RETURNS VSqlUpdate2Result;
 	);
 
 	ROLE ClusterAdmin;

--- a/pkg/cluster/consts.go
+++ b/pkg/cluster/consts.go
@@ -24,14 +24,19 @@ const (
 	Field_NumAppWorkspaces = "NumAppWorkspaces"
 	field_Query            = "Query"
 	field_NewID            = "NewID"
+	field_LogWLogOffset    = "LogWLogOffset"
+	field_CUDWLogOffset    = "CUDWLogOffset"
 )
 
 var (
-	qNameWDocApp          = appdef.NewQName(ClusterPackage, "App")
-	plog                  = appdef.NewQName(appdef.SysPackage, "PLog")
-	wlog                  = appdef.NewQName(appdef.SysPackage, "WLog")
-	qNameVSqlUpdateResult = appdef.NewQName(ClusterPackage, "VSqlUpdateResult")
-	updateDeniedFields    = map[string]bool{
+	qNameWDocApp           = appdef.NewQName(ClusterPackage, "App")
+	plog                   = appdef.NewQName(appdef.SysPackage, "PLog")
+	wlog                   = appdef.NewQName(appdef.SysPackage, "WLog")
+	qNameVSqlUpdateResult  = appdef.NewQName(ClusterPackage, "VSqlUpdateResult")
+	qNameVSqlUpdate2Result = appdef.NewQName(ClusterPackage, "VSqlUpdate2Result")
+	qNameCmdLogVSqlUpdate  = appdef.NewQName(ClusterPackage, "LogVSqlUpdate")
+	qNameQryVSqlUpdate2    = appdef.NewQName(ClusterPackage, "VSqlUpdate2")
+	updateDeniedFields     = map[string]bool{
 		appdef.SystemField_ID:    true,
 		appdef.SystemField_QName: true,
 	}

--- a/pkg/cluster/impl_table.go
+++ b/pkg/cluster/impl_table.go
@@ -19,23 +19,25 @@ import (
 	"github.com/voedger/voedger/pkg/sys"
 )
 
-func updateTable(update update, federation federation.IFederation, itokens itokens.ITokens) error {
+func updateTable(update update, federation federation.IFederation, itokens itokens.ITokens) (cudWLogOffset istructs.Offset, err error) {
 	jsonFields, err := json.Marshal(update.setFields)
 	if err != nil {
 		// notest
-		return err
+		return 0, err
 	}
 	cudBody := fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":%s}]}`, update.id, jsonFields)
 	sysToken, err := payloads.GetSystemPrincipalToken(itokens, update.AppQName)
 	if err != nil {
 		// notest
-		return err
+		return 0, err
 	}
-	_, err = federation.Func(fmt.Sprintf("api/%s/%d/c.sys.CUD", update.AppQName, update.wsid), cudBody,
+	resp, err := federation.Func(fmt.Sprintf("api/%s/%d/c.sys.CUD", update.AppQName, update.wsid), cudBody,
 		httpu.WithAuthorizeBy(sysToken),
-		httpu.WithDiscardResponse(),
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return resp.CurrentWLogOffset, nil
 }
 
 func insertTable(update update, federation federation.IFederation, itokens itokens.ITokens, istate istructs.IState, intents istructs.IIntents) error {

--- a/pkg/cluster/impl_vsqlupdate.go
+++ b/pkg/cluster/impl_vsqlupdate.go
@@ -28,26 +28,31 @@ func provideExecCmdVSqlUpdate(federation federation.IFederation, itokens itokens
 	asp istructs.IAppStructsProvider) istructsmem.ExecCommandClosure {
 	return func(args istructs.ExecCommandArgs) (err error) {
 		query := args.ArgumentObject.AsString(field_Query)
-		update, err := parseAndValidateQuery(args, query, asp)
+		update, err := parseAndValidateQuery(args.Workpiece, query, asp)
 		if err != nil {
 			return coreutils.NewHTTPError(http.StatusBadRequest, err)
 		}
-
-		switch update.Kind {
-		case dml.OpKind_UpdateTable:
-			err = updateTable(update, federation, itokens)
-		case dml.OpKind_InsertTable:
-			err = insertTable(update, federation, itokens, args.State, args.Intents)
-		case dml.OpKind_UpdateCorrupted:
-			err = updateCorrupted(update, istructs.UnixMilli(time.Now().UnixMilli()))
-		case dml.OpKind_UnloggedUpdate, dml.OpKind_UnloggedInsert:
-			err = updateUnlogged(update)
-		}
+		_, err = dispatchDML(update, federation, itokens, time, args.State, args.Intents)
 		return coreutils.WrapSysError(err, http.StatusBadRequest)
 	}
 }
 
-func parseAndValidateQuery(args istructs.ExecCommandArgs, query string, asp istructs.IAppStructsProvider) (update update, err error) {
+func dispatchDML(update update, federation federation.IFederation, itokens itokens.ITokens, time timeu.ITime,
+	istate istructs.IState, intents istructs.IIntents) (cudWLogOffset istructs.Offset, err error) {
+	switch update.Kind {
+	case dml.OpKind_UpdateTable:
+		cudWLogOffset, err = updateTable(update, federation, itokens)
+	case dml.OpKind_InsertTable:
+		err = insertTable(update, federation, itokens, istate, intents)
+	case dml.OpKind_UpdateCorrupted:
+		err = updateCorrupted(update, istructs.UnixMilli(time.Now().UnixMilli()))
+	case dml.OpKind_UnloggedUpdate, dml.OpKind_UnloggedInsert:
+		err = updateUnlogged(update)
+	}
+	return cudWLogOffset, err
+}
+
+func parseAndValidateQuery(workpiece interface{}, query string, asp istructs.IAppStructsProvider) (update update, err error) {
 	update.Op, err = dml.ParseQuery(query)
 	if err != nil {
 		return update, err
@@ -57,7 +62,7 @@ func parseAndValidateQuery(args istructs.ExecCommandArgs, query string, asp istr
 		return update, errors.New("'update' or 'insert' clause expected")
 	}
 
-	update.appParts = args.Workpiece.(processors.IProcessorWorkpiece).AppPartitions()
+	update.appParts = workpiece.(processors.IProcessorWorkpiece).AppPartitions()
 
 	if update.appStructs, err = asp.BuiltIn(update.AppQName); err != nil {
 		// notest

--- a/pkg/cluster/impl_vsqlupdate2.go
+++ b/pkg/cluster/impl_vsqlupdate2.go
@@ -22,7 +22,7 @@ import (
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
 )
 
-type vSqlUpdate2Result struct {
+type vSqlUpdate2Result struct { // nolint ST1003
 	istructs.NullObject
 	logWLogOffset istructs.Offset
 	cudWLogOffset istructs.Offset
@@ -31,9 +31,9 @@ type vSqlUpdate2Result struct {
 func (r *vSqlUpdate2Result) AsInt64(name string) int64 {
 	switch name {
 	case field_LogWLogOffset:
-		return int64(r.logWLogOffset)
+		return int64(r.logWLogOffset) // nolint G115
 	case field_CUDWLogOffset:
-		return int64(r.cudWLogOffset)
+		return int64(r.cudWLogOffset) // nolint G115
 	}
 	return 0
 }

--- a/pkg/cluster/impl_vsqlupdate2.go
+++ b/pkg/cluster/impl_vsqlupdate2.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024-present unTill Software Development Group B.V.
+ * @author Denis Gribanov
+ */
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/voedger/voedger/pkg/appdef"
+	"github.com/voedger/voedger/pkg/coreutils"
+	"github.com/voedger/voedger/pkg/coreutils/federation"
+	"github.com/voedger/voedger/pkg/dml"
+	"github.com/voedger/voedger/pkg/goutils/httpu"
+	"github.com/voedger/voedger/pkg/goutils/timeu"
+	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/istructsmem"
+	"github.com/voedger/voedger/pkg/itokens"
+	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
+)
+
+type vSqlUpdate2Result struct {
+	istructs.NullObject
+	logWLogOffset istructs.Offset
+	cudWLogOffset istructs.Offset
+}
+
+func (r *vSqlUpdate2Result) AsInt64(name string) int64 {
+	switch name {
+	case field_LogWLogOffset:
+		return int64(r.logWLogOffset)
+	case field_CUDWLogOffset:
+		return int64(r.cudWLogOffset)
+	}
+	return 0
+}
+
+func (r *vSqlUpdate2Result) QName() appdef.QName { return qNameVSqlUpdate2Result }
+
+func provideExecQryVSqlUpdate2(federation federation.IFederation, itokens itokens.ITokens, time timeu.ITime,
+	asp istructs.IAppStructsProvider) istructsmem.ExecQueryClosure {
+	return func(_ context.Context, args istructs.ExecQueryArgs, callback istructs.ExecQueryCallback) error {
+		query := args.ArgumentObject.AsString(field_Query)
+		update, err := parseAndValidateQuery(args.Workpiece, query, asp)
+		if err != nil {
+			return coreutils.NewHTTPError(http.StatusBadRequest, err)
+		}
+		if update.Kind == dml.OpKind_InsertTable {
+			return coreutils.NewHTTPError(http.StatusBadRequest,
+				fmt.Errorf("'insert table' is not supported by q.cluster.VSqlUpdate2; use c.cluster.VSqlUpdate"))
+		}
+
+		logWLogOffset, err := logVSqlUpdate(federation, itokens, args.WSID, query)
+		if err != nil {
+			return coreutils.WrapSysError(err, http.StatusBadRequest)
+		}
+
+		cudWLogOffset, err := dispatchDML(update, federation, itokens, time, nil, nil)
+		if err != nil {
+			return coreutils.WrapSysError(err, http.StatusBadRequest)
+		}
+
+		return callback(&vSqlUpdate2Result{logWLogOffset: logWLogOffset, cudWLogOffset: cudWLogOffset})
+	}
+}
+
+func logVSqlUpdate(federation federation.IFederation, itokens itokens.ITokens, wsid istructs.WSID, query string) (istructs.Offset, error) {
+	sysToken, err := payloads.GetSystemPrincipalToken(itokens, istructs.AppQName_sys_cluster)
+	if err != nil {
+		// notest
+		return 0, err
+	}
+	body := fmt.Sprintf(`{"args":{%q:%q}}`, field_Query, query)
+	resp, err := federation.Func(fmt.Sprintf("api/%s/%d/c.cluster.LogVSqlUpdate", istructs.AppQName_sys_cluster, wsid), body,
+		httpu.WithAuthorizeBy(sysToken))
+	if err != nil {
+		return 0, err
+	}
+	return resp.CurrentWLogOffset, nil
+}

--- a/pkg/cluster/impl_vsqlupdate2.go
+++ b/pkg/cluster/impl_vsqlupdate2.go
@@ -15,7 +15,6 @@ import (
 	"github.com/voedger/voedger/pkg/coreutils/federation"
 	"github.com/voedger/voedger/pkg/dml"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
-	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/istructsmem"
 	"github.com/voedger/voedger/pkg/itokens"
@@ -40,7 +39,7 @@ func (r *vSqlUpdate2Result) AsInt64(name string) int64 {
 
 func (r *vSqlUpdate2Result) QName() appdef.QName { return qNameVSqlUpdate2Result }
 
-func provideExecQryVSqlUpdate2(federation federation.IFederation, itokens itokens.ITokens, time timeu.ITime,
+func provideExecQryVSqlUpdate2(federation federation.IFederation, itokens itokens.ITokens,
 	asp istructs.IAppStructsProvider) istructsmem.ExecQueryClosure {
 	return func(_ context.Context, args istructs.ExecQueryArgs, callback istructs.ExecQueryCallback) error {
 		query := args.ArgumentObject.AsString(field_Query)
@@ -48,9 +47,9 @@ func provideExecQryVSqlUpdate2(federation federation.IFederation, itokens itoken
 		if err != nil {
 			return coreutils.NewHTTPError(http.StatusBadRequest, err)
 		}
-		if update.Kind == dml.OpKind_InsertTable {
+		if update.Kind != dml.OpKind_UpdateTable {
 			return coreutils.NewHTTPError(http.StatusBadRequest,
-				fmt.Errorf("'insert table' is not supported by q.cluster.VSqlUpdate2; use c.cluster.VSqlUpdate"))
+				fmt.Errorf("'update table' only is supported by q.cluster.VSqlUpdate2; use c.cluster.VSqlUpdate"))
 		}
 
 		logWLogOffset, err := logVSqlUpdate(federation, itokens, args.WSID, query)
@@ -58,7 +57,7 @@ func provideExecQryVSqlUpdate2(federation federation.IFederation, itokens itoken
 			return coreutils.WrapSysError(err, http.StatusBadRequest)
 		}
 
-		cudWLogOffset, err := dispatchDML(update, federation, itokens, time, nil, nil)
+		cudWLogOffset, err := updateTable(update, federation, itokens)
 		if err != nil {
 			return coreutils.WrapSysError(err, http.StatusBadRequest)
 		}

--- a/pkg/cluster/provide.go
+++ b/pkg/cluster/provide.go
@@ -24,7 +24,7 @@ func Provide(cfg *istructsmem.AppConfigType, asp istructs.IAppStructsProvider, t
 		provideExecCmdVSqlUpdate(federation, itokens, time, asp)))
 	cfg.Resources.Add(istructsmem.NewCommandFunction(qNameCmdLogVSqlUpdate, istructsmem.NullCommandExec))
 	cfg.Resources.Add(istructsmem.NewQueryFunction(qNameQryVSqlUpdate2,
-		provideExecQryVSqlUpdate2(federation, itokens, time, asp)))
+		provideExecQryVSqlUpdate2(federation, itokens, asp)))
 	return parser.PackageFS{
 		Path: ClusterPackageFQN,
 		FS:   schemaFS,

--- a/pkg/cluster/provide.go
+++ b/pkg/cluster/provide.go
@@ -22,6 +22,9 @@ func Provide(cfg *istructsmem.AppConfigType, asp istructs.IAppStructsProvider, t
 		provideCmdDeployApp(asp, time, sidecarApps)))
 	cfg.Resources.Add(istructsmem.NewCommandFunction(appdef.NewQName(ClusterPackage, "VSqlUpdate"),
 		provideExecCmdVSqlUpdate(federation, itokens, time, asp)))
+	cfg.Resources.Add(istructsmem.NewCommandFunction(qNameCmdLogVSqlUpdate, istructsmem.NullCommandExec))
+	cfg.Resources.Add(istructsmem.NewQueryFunction(qNameQryVSqlUpdate2,
+		provideExecQryVSqlUpdate2(federation, itokens, time, asp)))
 	return parser.PackageFS{
 		Path: ClusterPackageFQN,
 		FS:   schemaFS,

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -464,13 +464,6 @@ func requestHandlerV2_extension(reqSender bus.IRequestSender, apiPath processors
 		busRequest.IsAPIV2 = true
 		busRequest.APIPath = int(apiPath)
 		busRequest.QName = appdef.NewQName(data.vars[URLPlaceholder_pkg], entity)
-		// [~server.vsqlupdate/cmp.routerVSqlUpdateShim~impl]
-		if isVSqlUpdateV2Call(busRequest) {
-			requestCtx, cancel := context.WithCancel(withLogAttribs(req.Context(), data, busRequest, req))
-			defer cancel()
-			dispatchVSqlUpdateShim_V2(requestCtx, rw, busRequest, reqSender)
-			return
-		}
 		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }
@@ -499,8 +492,13 @@ func sendRequestAndReadResponse(req *http.Request, busRequest bus.Request, reqSe
 	limiter *wsQueryLimiter) {
 	reqCtxWithExtensionAttrib := withLogAttribs(req.Context(), data, busRequest, req)
 
+	// [~server.vsqlupdate/cmp.routerVSqlUpdateShim~impl]
+	// The shim reroutes c.cluster.VSqlUpdate to q.cluster.VSqlUpdate2 (query processor),
+	// so it must share the wsQueryLimiter gating with native queries.
+	isShim := isVSqlUpdateV2Call(busRequest)
+
 	// limiter is nil for Admin and ACME services
-	if limiter != nil && busRequest.Method == http.MethodGet && isQPBoundAPIPath(processors.APIPath(busRequest.APIPath)) {
+	if limiter != nil && (isShim || (busRequest.Method == http.MethodGet && isQPBoundAPIPath(processors.APIPath(busRequest.APIPath)))) {
 		if !limiter.acquire(busRequest.WSID) {
 			limiter.onQueryDrop(reqCtxWithExtensionAttrib, busRequest.WSID, resolveExtension(busRequest))
 			replyServiceUnavailable(rw)
@@ -522,6 +520,11 @@ func sendRequestAndReadResponse(req *http.Request, busRequest bus.Request, reqSe
 	defer cancel() // to avoid context leak
 
 	logServeRequest(requestCtx, limiter)
+
+	if isShim {
+		dispatchVSqlUpdateShim_V2(requestCtx, rw, busRequest, reqSender)
+		return
+	}
 
 	sentAt := time.Now()
 	respCh, respMeta, respErr, err := reqSender.SendRequest(requestCtx, busRequest)

--- a/pkg/router/impl_apiv2.go
+++ b/pkg/router/impl_apiv2.go
@@ -464,6 +464,13 @@ func requestHandlerV2_extension(reqSender bus.IRequestSender, apiPath processors
 		busRequest.IsAPIV2 = true
 		busRequest.APIPath = int(apiPath)
 		busRequest.QName = appdef.NewQName(data.vars[URLPlaceholder_pkg], entity)
+		// [~server.vsqlupdate/cmp.routerVSqlUpdateShim~impl]
+		if isVSqlUpdateV2Call(busRequest) {
+			requestCtx, cancel := context.WithCancel(withLogAttribs(req.Context(), data, busRequest, req))
+			defer cancel()
+			dispatchVSqlUpdateShim_V2(requestCtx, rw, busRequest, reqSender)
+			return
+		}
 		sendRequestAndReadResponse(req, busRequest, reqSender, rw, data, limiter)
 	})
 }

--- a/pkg/router/impl_http.go
+++ b/pkg/router/impl_http.go
@@ -229,6 +229,14 @@ func RequestHandler_V1(requestSender bus.IRequestSender, numsAppsWorkspaces map[
 
 		logServeRequest(requestCtx, limiter)
 
+		// [~server.vsqlupdate/cmp.routerVSqlUpdateShim~impl]
+		// c.cluster.VSqlUpdate synchronously calls c.sys.CUD on the same command processor.
+		// Re-route transparently to q.cluster.VSqlUpdate2 (runs in the query processor) to avoid self-deadlock.
+		if isVSqlUpdateV1Call(busRequest) {
+			dispatchVSqlUpdateShim_V1(requestCtx, rw, busRequest, requestSender)
+			return
+		}
+
 		sentAt := time.Now()
 		responseCh, responseMeta, responseErr, err := requestSender.SendRequest(requestCtx, busRequest)
 		if err != nil {

--- a/pkg/router/impl_http.go
+++ b/pkg/router/impl_http.go
@@ -210,8 +210,14 @@ func RequestHandler_V1(requestSender bus.IRequestSender, numsAppsWorkspaces map[
 
 		reqCtxWithExtensionAttrib := withLogAttribs(req.Context(), data, busRequest, req)
 
+		// [~server.vsqlupdate/cmp.routerVSqlUpdateShim~impl]
+		// c.cluster.VSqlUpdate synchronously calls c.sys.CUD on the same command processor.
+		// Re-route transparently to q.cluster.VSqlUpdate2 (runs in the query processor) to avoid self-deadlock.
+		// The shim runs on the query processor, so it must share the same wsQueryLimiter gating as native queries.
+		isShimV1 := isVSqlUpdateV1Call(busRequest)
+
 		// limiter is nil for Admin and ACME services
-		if limiter != nil && strings.HasPrefix(busRequest.Resource, "q.") {
+		if limiter != nil && (strings.HasPrefix(busRequest.Resource, "q.") || isShimV1) {
 			if !limiter.acquire(busRequest.WSID) {
 				limiter.onQueryDrop(reqCtxWithExtensionAttrib, busRequest.WSID, resolveExtension(busRequest))
 				replyServiceUnavailable(rw)
@@ -229,10 +235,7 @@ func RequestHandler_V1(requestSender bus.IRequestSender, numsAppsWorkspaces map[
 
 		logServeRequest(requestCtx, limiter)
 
-		// [~server.vsqlupdate/cmp.routerVSqlUpdateShim~impl]
-		// c.cluster.VSqlUpdate synchronously calls c.sys.CUD on the same command processor.
-		// Re-route transparently to q.cluster.VSqlUpdate2 (runs in the query processor) to avoid self-deadlock.
-		if isVSqlUpdateV1Call(busRequest) {
+		if isShimV1 {
 			dispatchVSqlUpdateShim_V1(requestCtx, rw, busRequest, requestSender)
 			return
 		}

--- a/pkg/router/impl_vsqlupdate_shim.go
+++ b/pkg/router/impl_vsqlupdate_shim.go
@@ -23,6 +23,8 @@ import (
 const (
 	vSqlUpdateFieldLogOffs = "LogWLogOffset" //nolint ST1003
 	vSqlUpdateFieldCUDOffs = "CUDWLogOffset" //nolint ST1003
+	vsqlUpdateStage        = "routing.vsqlupdate"
+	vsqlUpdateErrorStage   = "routing.vsqlupdate.error"
 )
 
 var (
@@ -112,12 +114,14 @@ func (c *capturingResponseWriter) flushTo(rw http.ResponseWriter, overrideBody s
 }
 
 func dispatchVSqlUpdateShim_V1(requestCtx context.Context, rw http.ResponseWriter, busRequest bus.Request, reqSender bus.IRequestSender) {
+	logger.InfoCtx(requestCtx, vsqlUpdateStage, fmt.Sprintf("rerouting %s to %s", resourceCmdVSqlUpdate, resourceQryVSqlUpdate2))
+
 	busRequest.Resource = resourceQryVSqlUpdate2
 	busRequest.Body = rewriteVSqlUpdateBody(busRequest.Body)
 
 	respCh, respMeta, respErr, err := reqSender.SendRequest(requestCtx, busRequest)
 	if err != nil {
-		logger.ErrorCtx(requestCtx, "routing.send2vvm.error", "forwarding c.cluster.VSqlUpdate to q.cluster.VSqlUpdate2 failed:", err)
+		logger.ErrorCtx(requestCtx, "routing.send2vvm.error", fmt.Sprintf("forwarding %s to %s failed: %s", resourceCmdVSqlUpdate, resourceQryVSqlUpdate2, err))
 		writeCommonError_V1(rw, err, http.StatusInternalServerError)
 		return
 	}
@@ -129,15 +133,20 @@ func dispatchVSqlUpdateShim_V1(requestCtx context.Context, rw http.ResponseWrite
 	overrideBody := ""
 	if capture.status == http.StatusOK && *respErr == nil {
 		overrideBody = fmt.Sprintf(`{"CurrentWLogOffset":%d}`, extractLogWLogOffsetFromV1Body(capture.body.Bytes()))
+	} else {
+		logger.ErrorCtx(requestCtx, vsqlUpdateErrorStage, fmt.Sprintf("%s shim reply failed: status=%d respErr=%v body=%s", resourceCmdVSqlUpdate, capture.status, *respErr, capture.body.String()))
 	}
 	capture.flushTo(rw, overrideBody)
 }
 
 func dispatchVSqlUpdateShim_V2(requestCtx context.Context, rw http.ResponseWriter, busRequest bus.Request, reqSender bus.IRequestSender) {
+	logger.InfoCtx(requestCtx, vsqlUpdateStage, fmt.Sprintf("rerouting %s to %s", resourceCmdVSqlUpdate, resourceQryVSqlUpdate2))
+
 	args := map[string]any{}
 	if len(busRequest.Body) > 0 {
 		body := map[string]any{}
 		if err := json.Unmarshal(busRequest.Body, &body); err != nil {
+			logger.ErrorCtx(requestCtx, vsqlUpdateErrorStage, fmt.Sprintf("failed to parse VSqlUpdate body: %s", err))
 			ReplyCommonError(rw, fmt.Sprintf("failed to parse VSqlUpdate body: %s", err.Error()), http.StatusBadRequest)
 			return
 		}
@@ -148,6 +157,7 @@ func dispatchVSqlUpdateShim_V2(requestCtx context.Context, rw http.ResponseWrite
 	argsBytes, err := json.Marshal(args)
 	if err != nil {
 		// notest
+		logger.ErrorCtx(requestCtx, vsqlUpdateErrorStage, fmt.Sprintf("failed to marshal VSqlUpdate args: %s", err))
 		ReplyCommonError(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -164,7 +174,7 @@ func dispatchVSqlUpdateShim_V2(requestCtx context.Context, rw http.ResponseWrite
 
 	respCh, respMeta, respErr, err := reqSender.SendRequest(requestCtx, busRequest)
 	if err != nil {
-		logger.ErrorCtx(requestCtx, "routing.send2vvm.error", "forwarding cluster.VSqlUpdate to cluster.VSqlUpdate2 failed:", err)
+		logger.ErrorCtx(requestCtx, "routing.send2vvm.error", fmt.Sprintf("forwarding %s to %s failed: %s", resourceCmdVSqlUpdate, resourceQryVSqlUpdate2, err))
 		ReplyCommonError(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -176,6 +186,8 @@ func dispatchVSqlUpdateShim_V2(requestCtx context.Context, rw http.ResponseWrite
 	overrideBody := ""
 	if capture.status == http.StatusOK && *respErr == nil {
 		overrideBody = fmt.Sprintf(`{"currentWLogOffset":%d}`, extractLogWLogOffsetFromV2Body(capture.body.Bytes()))
+	} else {
+		logger.ErrorCtx(requestCtx, vsqlUpdateErrorStage, fmt.Sprintf("%s shim reply failed: status=%d respErr=%v body=%s", resourceCmdVSqlUpdate, capture.status, *respErr, capture.body.String()))
 	}
 	capture.flushTo(rw, overrideBody)
 }

--- a/pkg/router/impl_vsqlupdate_shim.go
+++ b/pkg/router/impl_vsqlupdate_shim.go
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2026-present unTill Software Development Group B.V.
+ * @author Denis Gribanov
+ */
+
+package router
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/voedger/voedger/pkg/appdef"
+	"github.com/voedger/voedger/pkg/bus"
+	"github.com/voedger/voedger/pkg/coreutils/federation"
+	"github.com/voedger/voedger/pkg/dml"
+	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/processors"
+)
+
+const (
+	vSqlUpdateFieldLogOffs = "LogWLogOffset" //nolint ST1003
+	vSqlUpdateFieldCUDOffs = "CUDWLogOffset" //nolint ST1003
+)
+
+var (
+	qNameCmdVSqlUpdate     = appdef.NewQName("cluster", "VSqlUpdate")
+	qNameQryVSqlUpdate2    = appdef.NewQName("cluster", "VSqlUpdate2")
+	resourceCmdVSqlUpdate  = "c." + qNameCmdVSqlUpdate.String()
+	resourceQryVSqlUpdate2 = "q." + qNameQryVSqlUpdate2.String()
+)
+
+func isVSqlUpdateV1Call(busRequest bus.Request) bool {
+	return !busRequest.IsAPIV2 && busRequest.Resource == resourceCmdVSqlUpdate && isUpdateTableBody(busRequest.Body)
+}
+
+func isVSqlUpdateV2Call(busRequest bus.Request) bool {
+	return busRequest.IsAPIV2 &&
+		processors.APIPath(busRequest.APIPath) == processors.APIPath_Commands &&
+		busRequest.QName == qNameCmdVSqlUpdate &&
+		isUpdateTableBody(busRequest.Body)
+}
+
+// isUpdateTableBody returns true if the VSqlUpdate body carries an "update table" DML.
+// Only this kind is routed through the query shim; any other kind stays on the command path.
+// On any error the request will be forwarded to processor where the error will be actually handled, so do not handle errors here
+func isUpdateTableBody(body []byte) bool {
+	m := map[string]any{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return false
+	}
+	args, ok := m["args"].(map[string]any)
+	if !ok {
+		return false
+	}
+	q, ok := args["Query"].(string)
+	if !ok {
+		return false
+	}
+	op, err := dml.ParseQuery(q)
+	if err != nil {
+		return false
+	}
+	return op.Kind == dml.OpKind_UpdateTable
+}
+
+func rewriteVSqlUpdateBody(body []byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(`{"elements":[{"fields":["`)
+	buf.WriteString(vSqlUpdateFieldLogOffs)
+	buf.WriteString(`","`)
+	buf.WriteString(vSqlUpdateFieldCUDOffs)
+	buf.WriteString(`"]}]`)
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) > 2 {
+		buf.WriteByte(',')
+		buf.Write(trimmed[1 : len(trimmed)-1])
+	}
+	buf.WriteByte('}')
+	return buf.Bytes()
+}
+
+// capturingResponseWriter buffers the body and captures headers/status so reply_v1 and
+// reply_v2 can run unchanged while the shim rewrites the final response shape.
+type capturingResponseWriter struct {
+	headers http.Header
+	body    bytes.Buffer
+	status  int
+}
+
+func newCapturingResponseWriter() *capturingResponseWriter {
+	return &capturingResponseWriter{headers: http.Header{}, status: http.StatusOK}
+}
+
+func (c *capturingResponseWriter) Header() http.Header         { return c.headers }
+func (c *capturingResponseWriter) Write(b []byte) (int, error) { return c.body.Write(b) }
+func (c *capturingResponseWriter) WriteHeader(code int)        { c.status = code }
+func (c *capturingResponseWriter) Flush()                      {}
+
+func (c *capturingResponseWriter) flushTo(rw http.ResponseWriter, overrideBody string) {
+	for k, v := range c.headers {
+		rw.Header()[k] = v
+	}
+	rw.WriteHeader(c.status)
+	if len(overrideBody) > 0 {
+		writeResponse(rw, overrideBody)
+		return
+	}
+	writeResponse(rw, c.body.String())
+}
+
+func dispatchVSqlUpdateShim_V1(requestCtx context.Context, rw http.ResponseWriter, busRequest bus.Request, reqSender bus.IRequestSender) {
+	busRequest.Resource = resourceQryVSqlUpdate2
+	busRequest.Body = rewriteVSqlUpdateBody(busRequest.Body)
+
+	respCh, respMeta, respErr, err := reqSender.SendRequest(requestCtx, busRequest)
+	if err != nil {
+		logger.ErrorCtx(requestCtx, "routing.send2vvm.error", "forwarding c.cluster.VSqlUpdate to q.cluster.VSqlUpdate2 failed:", err)
+		writeCommonError_V1(rw, err, http.StatusInternalServerError)
+		return
+	}
+
+	capture := newCapturingResponseWriter()
+	initResponse(capture, respMeta)
+	reply_v1(requestCtx, capture, respCh, respErr, func() {}, busRequest, respMeta)
+
+	overrideBody := ""
+	if capture.status == http.StatusOK && *respErr == nil {
+		overrideBody = fmt.Sprintf(`{"CurrentWLogOffset":%d}`, extractLogWLogOffsetFromV1Body(capture.body.Bytes()))
+	}
+	capture.flushTo(rw, overrideBody)
+}
+
+func dispatchVSqlUpdateShim_V2(requestCtx context.Context, rw http.ResponseWriter, busRequest bus.Request, reqSender bus.IRequestSender) {
+	args := map[string]any{}
+	if len(busRequest.Body) > 0 {
+		body := map[string]any{}
+		if err := json.Unmarshal(busRequest.Body, &body); err != nil {
+			ReplyCommonError(rw, fmt.Sprintf("failed to parse VSqlUpdate body: %s", err.Error()), http.StatusBadRequest)
+			return
+		}
+		if a, ok := body["args"].(map[string]any); ok {
+			args = a
+		}
+	}
+	argsBytes, err := json.Marshal(args)
+	if err != nil {
+		// notest
+		ReplyCommonError(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if busRequest.Query == nil {
+		busRequest.Query = map[string]string{}
+	}
+	busRequest.Query["args"] = string(argsBytes)
+	busRequest.Query["keys"] = vSqlUpdateFieldLogOffs + "," + vSqlUpdateFieldCUDOffs
+	busRequest.Method = http.MethodGet
+	busRequest.APIPath = int(processors.APIPath_Queries)
+	busRequest.QName = qNameQryVSqlUpdate2
+	busRequest.Resource = resourceQryVSqlUpdate2
+	busRequest.Body = nil
+
+	respCh, respMeta, respErr, err := reqSender.SendRequest(requestCtx, busRequest)
+	if err != nil {
+		logger.ErrorCtx(requestCtx, "routing.send2vvm.error", "forwarding cluster.VSqlUpdate to cluster.VSqlUpdate2 failed:", err)
+		ReplyCommonError(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	capture := newCapturingResponseWriter()
+	initResponse(capture, respMeta)
+	reply_v2(requestCtx, capture, respCh, respErr, func() {}, respMeta)
+
+	overrideBody := ""
+	if capture.status == http.StatusOK && *respErr == nil {
+		overrideBody = fmt.Sprintf(`{"currentWLogOffset":%d}`, extractLogWLogOffsetFromV2Body(capture.body.Bytes()))
+	}
+	capture.flushTo(rw, overrideBody)
+}
+
+// extractLogWLogOffsetFromV1Body parses the v1 query response envelope
+// `{"sections":[{"type":"","elements":[[[[LogWLogOffset, CUDWLogOffset]]]]}]}`
+// and returns the first LogWLogOffset value.
+func extractLogWLogOffsetFromV1Body(raw []byte) int64 {
+	var env federation.QueryResponse
+	if err := json.Unmarshal(raw, &env); err != nil {
+		// notest
+		return 0
+	}
+	if v, ok := env.Sections[0].Elements[0][0][0][0].(float64); ok {
+		return int64(v)
+	}
+	// notest
+	return 0
+}
+
+// extractLogWLogOffsetFromV2Body parses the v2 query response envelope
+// `{"results":[{"LogWLogOffset":..., "CUDWLogOffset":...}]}` and returns the first
+// LogWLogOffset value.
+func extractLogWLogOffsetFromV2Body(raw []byte) int64 {
+	var env federation.FuncResponse
+	if err := json.Unmarshal(raw, &env); err != nil {
+		// notest
+		return 0
+	}
+	if len(env.QPv2Response) == 0 {
+		// notest
+		return 0
+	}
+	if v, ok := env.QPv2Response[0][vSqlUpdateFieldLogOffs].(float64); ok {
+		return int64(v)
+	}
+	// notest
+	return 0
+}

--- a/pkg/sys/it/impl_vsqlupdate_test.go
+++ b/pkg/sys/it/impl_vsqlupdate_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"math"
 	"net/http"
 	"strings"
@@ -23,6 +24,7 @@ import (
 	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/coreutils/federation"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
+	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/istructsmem"
 	it "github.com/voedger/voedger/pkg/vit"
@@ -96,6 +98,7 @@ func TestVSqlUpdate_BasicUsage_UpdateTable(t *testing.T) {
 	}
 
 	t.Run("apiv1", func(t *testing.T) {
+		logCap := logger.StartCapture(t, logger.LogLevelInfo)
 		categoryName := vit.NextName()
 		body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.category","name":"%s"}}]}`, categoryName)
 		categoryID := vit.PostWS(ws, "c.sys.CUD", body).NewID()
@@ -104,10 +107,13 @@ func TestVSqlUpdate_BasicUsage_UpdateTable(t *testing.T) {
 			vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
 				httpu.WithAuthorizeBy(sysPrn.Token)).Println()
 		})
+		logCap.EventuallyHasLine("rerouting", "c.cluster.VSqlUpdate", "q.cluster.VSqlUpdate2", "stage=routing.vsqlupdate")
+		log.Println(logCap.String())
 	})
 
 	t.Run("apiv2", func(t *testing.T) {
 		require := require.New(t)
+		logCap := logger.StartCapture(t, logger.LogLevelInfo)
 		categoryName := vit.NextName()
 		body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.category","name":"%s"}}]}`, categoryName)
 		categoryID := vit.PostWS(ws, "c.sys.CUD", body).NewID()
@@ -120,6 +126,8 @@ func TestVSqlUpdate_BasicUsage_UpdateTable(t *testing.T) {
 			require.NoError(json.Unmarshal([]byte(httpResp.Body), &m))
 			require.Positive(int64(m["currentWLogOffset"].(float64)), "currentWLogOffset must be positive in v2 shim response")
 		})
+		logCap.EventuallyHasLine("rerouting", "c.cluster.VSqlUpdate", "q.cluster.VSqlUpdate2", "stage=routing.vsqlupdate")
+		log.Println(logCap.String())
 	})
 }
 

--- a/pkg/sys/it/impl_vsqlupdate_test.go
+++ b/pkg/sys/it/impl_vsqlupdate_test.go
@@ -162,6 +162,33 @@ func TestVSqlUpdate2_DirectQuery(t *testing.T) {
 	require.Contains(selResp.SectionRow(len(selResp.Sections[0].Elements) - 1)[0].(string), fmt.Sprintf(`"name":"%s"`, newName))
 }
 
+func TestVSqlUpdate2_RejectsNonUpdate(t *testing.T) {
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
+	sysPrn := vit.GetSystemPrincipal(istructs.AppQName_sys_cluster)
+
+	cudBody := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.category","name":"%s"}}]}`, vit.NextName())
+	wlogOffset := vit.PostWS(ws, "c.sys.CUD", cudBody).CurrentWLogOffset
+
+	cases := map[string]string{
+		"insert table":     fmt.Sprintf(`insert test1.app1.%d.app1pkg.category set name = '%s'`, ws.WSID, vit.NextName()),
+		"unlogged update":  fmt.Sprintf(`unlogged update test1.app1.%d.app1pkg.CategoryIdx set Name = 'any' where IntFld = 43 and Dummy = 1`, ws.WSID),
+		"update corrupted": fmt.Sprintf(`update corrupted test1.app1.%d.sys.WLog.%d`, ws.WSID, wlogOffset),
+	}
+
+	for name, query := range cases {
+		t.Run(name, func(t *testing.T) {
+			body := fmt.Sprintf(`{"args":{"Query":%q},"elements":[{"fields":["LogWLogOffset","CUDWLogOffset"]}]}`, query)
+			vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "q.cluster.VSqlUpdate2", body,
+				httpu.WithAuthorizeBy(sysPrn.Token),
+				it.Expect400("'update table' only is supported", "q.cluster.VSqlUpdate2"),
+			)
+		})
+	}
+}
+
 func TestVSqlUpdate_BasicUsage_InsertTable(t *testing.T) {
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()

--- a/pkg/sys/it/impl_vsqlupdate_test.go
+++ b/pkg/sys/it/impl_vsqlupdate_test.go
@@ -11,8 +11,12 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/voedger/voedger/pkg/appdef"
@@ -22,11 +26,107 @@ import (
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/istructsmem"
 	it "github.com/voedger/voedger/pkg/vit"
+	sys_test_template "github.com/voedger/voedger/pkg/vit/testdata"
+	"github.com/voedger/voedger/pkg/vvm"
 	"github.com/voedger/voedger/pkg/vvm/builtin/clusterapp"
 )
 
+// TestVSqlUpdate_NoDeadlockOnSharedCommandProcessor reproduces
+// https://github.com/voedger/voedger/issues/3845: c.cluster.VSqlUpdate invokes
+// c.sys.CUD synchronously via HTTP, so when both share the single command
+// processor (NumCommandProcessors = 1) the second request can never be picked
+// up and the first one hangs forever. With a short client-side HTTP deadline
+// the hang surfaces as context.DeadlineExceeded.
+func TestVSqlUpdate_NoDeadlockOnSharedCommandProcessor(t *testing.T) {
+	require := require.New(t)
+	cfg := it.NewOwnVITConfig(
+		it.WithApp(istructs.AppQName_test1_app1, it.ProvideApp1,
+			it.WithUserLogin("login", "pwd"),
+			it.WithWorkspaceTemplate(it.QNameApp1_TestWSKind, "test_template", sys_test_template.TestTemplateFS),
+			it.WithChildWorkspace(it.QNameApp1_TestWSKind, "test_ws", "test_template", "", "login", map[string]interface{}{"IntFld": 42}),
+		),
+		it.WithVVMConfig(func(cfg *vvm.VVMConfig) {
+			cfg.NumCommandProcessors = 1
+		}),
+	)
+	vit := it.NewVIT(t, &cfg)
+	defer vit.TearDown()
+
+	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
+
+	categoryName := vit.NextName()
+	body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.category","name":"%s"}}]}`, categoryName)
+	categoryID := vit.PostWS(ws, "c.sys.CUD", body).NewID()
+
+	sysPrn := vit.GetSystemPrincipal(istructs.AppQName_sys_cluster)
+
+	newName := vit.NextName()
+	updateBody := fmt.Sprintf(`{"args":{"Query":"update test1.app1.%d.app1pkg.category.%d set name = '%s'"}}`, ws.WSID, categoryID, newName)
+
+	url := fmt.Sprintf("%s/api/%s/%d/c.cluster.VSqlUpdate", vit.URLStr(), istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID)
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(updateBody))
+	require.NoError(err)
+	req.Header.Set(httpu.Authorization, "Bearer "+sysPrn.Token)
+
+	resp, err := client.Do(req)
+	require.NoError(err, "c.cluster.VSqlUpdate must not deadlock when it shares the command processor with the downstream c.sys.CUD")
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode, string(respBody))
+}
+
 func TestVSqlUpdate_BasicUsage_UpdateTable(t *testing.T) {
-	t.Skip("https://github.com/voedger/voedger/issues/3845")
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
+	sysPrn := vit.GetSystemPrincipal(istructs.AppQName_sys_cluster)
+
+	updateAndCheck := func(t *testing.T, categoryID istructs.RecordID, newName string, post func(body string)) {
+		t.Helper()
+		body := fmt.Sprintf(`{"args":{"Query":"update test1.app1.%d.app1pkg.category.%d set name = '%s'"}}`, ws.WSID, categoryID, newName)
+		post(body)
+
+		body = fmt.Sprintf(`{"args":{"Query":"select * from app1pkg.category where id = %d"},"elements":[{"fields":["Result"]}]}`, categoryID)
+		resp := vit.PostWS(ws, "q.sys.SqlQuery", body)
+		resStr := resp.SectionRow(len(resp.Sections[0].Elements) - 1)[0].(string)
+		require.Contains(t, resStr, fmt.Sprintf(`"name":"%s"`, newName))
+	}
+
+	t.Run("apiv1", func(t *testing.T) {
+		categoryName := vit.NextName()
+		body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.category","name":"%s"}}]}`, categoryName)
+		categoryID := vit.PostWS(ws, "c.sys.CUD", body).NewID()
+
+		updateAndCheck(t, categoryID, vit.NextName(), func(body string) {
+			vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
+				httpu.WithAuthorizeBy(sysPrn.Token)).Println()
+		})
+	})
+
+	t.Run("apiv2", func(t *testing.T) {
+		require := require.New(t)
+		categoryName := vit.NextName()
+		body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"app1pkg.category","name":"%s"}}]}`, categoryName)
+		categoryID := vit.PostWS(ws, "c.sys.CUD", body).NewID()
+
+		updateAndCheck(t, categoryID, vit.NextName(), func(body string) {
+			url := fmt.Sprintf("api/v2/apps/%s/%s/workspaces/%d/commands/cluster.VSqlUpdate",
+				istructs.AppQName_sys_cluster.Owner(), istructs.AppQName_sys_cluster.Name(), clusterapp.ClusterAppWSID)
+			httpResp := vit.POST(url, body, httpu.WithAuthorizeBy(sysPrn.Token))
+			m := map[string]interface{}{}
+			require.NoError(json.Unmarshal([]byte(httpResp.Body), &m))
+			require.Positive(int64(m["currentWLogOffset"].(float64)), "currentWLogOffset must be positive in v2 shim response")
+		})
+	})
+}
+
+// TestVSqlUpdate2_DirectQuery calls q.cluster.VSqlUpdate2 directly and verifies
+// the query returns the log and CUD WLog offsets.
+func TestVSqlUpdate2_DirectQuery(t *testing.T) {
+	require := require.New(t)
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
 
@@ -39,19 +139,22 @@ func TestVSqlUpdate_BasicUsage_UpdateTable(t *testing.T) {
 	sysPrn := vit.GetSystemPrincipal(istructs.AppQName_sys_cluster)
 
 	newName := vit.NextName()
-	body = fmt.Sprintf(`{"args": {"Query":"update test1.app1.%d.app1pkg.category.%d set name = '%s'"}}`, ws.WSID, categoryID, newName)
-	vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "c.cluster.VSqlUpdate", body,
-		httpu.WithAuthorizeBy(sysPrn.Token)).Println()
+	body = fmt.Sprintf(`{"args":{"Query":"update test1.app1.%d.app1pkg.category.%d set name = '%s'"},"elements":[{"fields":["LogWLogOffset","CUDWLogOffset"]}]}`,
+		ws.WSID, categoryID, newName)
+	resp := vit.PostApp(istructs.AppQName_sys_cluster, clusterapp.ClusterAppWSID, "q.cluster.VSqlUpdate2", body,
+		httpu.WithAuthorizeBy(sysPrn.Token))
+	resp.Println()
 
-	// check the value is update in another app and another wsid
+	row := resp.SectionRow()
+	require.Positive(int64(row[0].(float64)), "LogWLogOffset must be positive")
+	require.Positive(int64(row[1].(float64)), "CUDWLogOffset must be positive")
+
 	body = fmt.Sprintf(`{"args":{"Query":"select * from app1pkg.category where id = %d"},"elements":[{"fields":["Result"]}]}`, categoryID)
-	resp := vit.PostWS(ws, "q.sys.SqlQuery", body)
-	resStr := resp.SectionRow(len(resp.Sections[0].Elements) - 1)[0].(string)
-	require.Contains(t, resStr, fmt.Sprintf(`"name":"%s"`, newName))
+	selResp := vit.PostWS(ws, "q.sys.SqlQuery", body)
+	require.Contains(selResp.SectionRow(len(selResp.Sections[0].Elements) - 1)[0].(string), fmt.Sprintf(`"name":"%s"`, newName))
 }
 
 func TestVSqlUpdate_BasicUsage_InsertTable(t *testing.T) {
-	t.Skip("waiting for https://github.com/voedger/voedger/issues/3845")
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
 
@@ -380,7 +483,6 @@ func TestVSqlUpdate_BasicUsage_DirectInsert(t *testing.T) {
 }
 
 func TestDirectUpdateManyTypes(t *testing.T) {
-	t.Skip("https://github.com/voedger/voedger/issues/3845")
 	require := require.New(t)
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()

--- a/pkg/sys/it/impl_vsqlupdate_test.go
+++ b/pkg/sys/it/impl_vsqlupdate_test.go
@@ -190,6 +190,7 @@ func TestVSqlUpdate2_RejectsNonUpdate(t *testing.T) {
 }
 
 func TestVSqlUpdate_BasicUsage_InsertTable(t *testing.T) {
+	t.Skip("https://untill.atlassian.net/browse/AIR-3661")
 	vit := it.NewVIT(t, &it.SharedConfig_App1)
 	defer vit.TearDown()
 

--- a/uspecs/changes/2604220859-cluster-vsqlupdate2/change.md
+++ b/uspecs/changes/2604220859-cluster-vsqlupdate2/change.md
@@ -1,0 +1,26 @@
+---
+registered_at: 2026-04-22T08:59:37Z
+change_id: 2604220859-cluster-vsqlupdate2
+baseline: 36c8ee68f6ca5db6f2495bf5c36d23ff652c07d3
+issue_url: https://untill.atlassian.net/browse/AIR-3656
+---
+
+# Change request: Replace c.cluster.VSqlUpdate with q.cluster.VSqlUpdate2 to avoid command processor deadlock
+
+## Why
+
+`c.cluster.VSqlUpdate` hangs when the internal `c.sys.CUD` it issues is routed to the same command processor, because a command processor cannot dispatch another command to itself. See [issue.md](issue.md) for details.
+
+## What
+
+Introduce a new query-based flow that replaces the current command and eliminates the self-routing hang:
+
+- New `q.cluster.VSqlUpdate2` query that calls `c.cluster.LogVSqlUpdate` and then performs the CUD against the target workspace, returning WLog offsets for both
+- New `c.cluster.LogVSqlUpdate` command that only logs the original request parameters
+- Router changes that reroute `c.cluster.VSqlUpdate` to `q.cluster.VSqlUpdate2` and adapt the response to the command response format
+
+Migration steps:
+
+- Ask frontend to switch to `q.cluster.VSqlUpdate2`
+- Wait until Live uses `q.cluster.VSqlUpdate2`
+- Remove `c.cluster.VSqlUpdate` and its special routing

--- a/uspecs/changes/2604220859-cluster-vsqlupdate2/how.md
+++ b/uspecs/changes/2604220859-cluster-vsqlupdate2/how.md
@@ -17,9 +17,11 @@
   - Register both extensions in `pkg/cluster/provide.go` using `istructsmem.NewCommandFunction` / `istructsmem.NewQueryFunction`
 - Router-side compatibility, per API version (response shape must match the entry point):
   - API v1 (`pkg/router/impl_http.go`, `RequestHandler_V1`): detect `busRequest.Resource == "c.cluster.VSqlUpdate"` and `dml.OpKind_UpdateTable` in the body, rewrite to `q.cluster.VSqlUpdate2`, execute, and emit the v1 command response shape (`{"CurrentWLogOffset":<LogWLogOffset>}`)
-  - API v2 (`pkg/router/impl_apiv2.go`, `requestHandlerV2_extension` commands branch): detect `busRequest.QName == cluster.VSqlUpdate` and `dml.OpKind_UpdateTable` in the body, rewrite to `q.cluster.VSqlUpdate2` (switch `APIPath` to `APIPath_Queries`), execute, and emit the v2 command response shape (`{"currentWLogOffset":<LogWLogOffset>}`)
+  - API v2 (`pkg/router/impl_apiv2.go`, shared `sendRequestAndReadResponse`): detect `busRequest.QName == cluster.VSqlUpdate` and `dml.OpKind_UpdateTable` in the body, rewrite to `q.cluster.VSqlUpdate2` (switch `APIPath` to `APIPath_Queries`), execute, and emit the v2 command response shape (`{"currentWLogOffset":<LogWLogOffset>}`); placing the shim in the shared helper (instead of in `requestHandlerV2_extension`) avoids duplicating the `wsQueryLimiter` gating logic and covers every v2 entry point that calls `sendRequestAndReadResponse`
+  - In both versions the shim dispatch is placed inside the same `wsQueryLimiter`-protected block as native queries: the shim runs on the query processor, so it must be throttled together with native queries
   - The two shims are separate on purpose: each must produce a response in the format of its own API version
   - Both shims use a shared `capturingResponseWriter` to reuse `reply_v1` / `reply_v2` for the underlying streaming; the captured body is parsed with `federation.QueryResponse` / `federation.FuncResponse` to read `LogWLogOffset`
+  - Observability: the reroute is announced once per request at level `Info` with stage `routing.vsqlupdate`; shim-specific failures (body parse, args marshal, downstream reply failure) are logged at `Error` with stage `routing.vsqlupdate.error` right before the reply is flushed; transport errors on `SendRequest` reuse the existing `routing.send2vvm.error` stage
   - Keep the old `c.cluster.VSqlUpdate` extension registered until deprecation lands to avoid breaking direct handler paths used in integration tests
 - Authorization: no GRANT statement is added for the new extensions; the existing `c.cluster.VSqlUpdate` is not granted either - access to cluster-app extensions is gated by the system principal check
 - Tests:
@@ -27,6 +29,7 @@
   - Add `TestVSqlUpdate2_DirectQuery` hitting `q.cluster.VSqlUpdate2` directly and asserting returned `LogWLogOffset` and `CUDWLogOffset`
   - Add one new deterministic regression test using `it.NewOwnVITConfig` with `NumCommandProcessors = 1` and a short HTTP deadline
   - Cover the v2 shim with an `apiv2` subtest inside `TestVSqlUpdate_BasicUsage_UpdateTable` (the original v1 path is the default for every other test that posts via `vit.PostApp`)
+  - Assert the reroute log in both `apiv1` and `apiv2` subtests of `TestVSqlUpdate_BasicUsage_UpdateTable` using `logger.StartCapture` + `EventuallyHasLine` on the `routing.vsqlupdate` stage to pin down the observability contract
 - Deprecation path (tracked in `change.md`, not executed in this change unless requested):
   - After frontend/Live migrate, remove `c.cluster.VSqlUpdate` from `appws.vsql`, delete `provideExecCmdVSqlUpdate`, drop the router shim, and update the comments in `pkg/processors/command/impl.go` that reference `c.cluster.VSqlUpdate`
 

--- a/uspecs/changes/2604220859-cluster-vsqlupdate2/how.md
+++ b/uspecs/changes/2604220859-cluster-vsqlupdate2/how.md
@@ -9,22 +9,24 @@
 - Implement in package `pkg/cluster`:
   - `c.cluster.LogVSqlUpdate` is wired with `istructsmem.NullCommandExec` directly in `provide.go` - no new handler file needed (logging is done by the command processor itself via WLog)
   - `impl_vsqlupdate2.go`: query closure that
-    - parses/validates the SQL using existing `parseAndValidateQuery` from `pkg/cluster/impl_vsqlupdate.go` - the helper already relies on `args.Workpiece.(processors.IProcessorWorkpiece)`, implemented by both command and query workpieces, so it works unchanged for queries
-    - invokes `c.cluster.LogVSqlUpdate` via `federation.IFederation` against `clusterapp.ClusterAppWSID` and captures its `CurrentWLogOffset`
-    - performs the actual DML by reusing the existing `updateTable`/`insertTable`/`updateCorrupted`/`updateUnlogged` dispatch (extracted into an unexported helper shared with `provideExecCmdVSqlUpdate`), capturing the target CUD's WLog offset when applicable
+    - parses/validates the SQL using existing `parseAndValidateQuery` from `pkg/cluster/impl_vsqlupdate.go` (its first parameter is relaxed to `workpiece interface{}` so it accepts both command and query workpieces)
+    - rejects `dml.OpKind_InsertTable` with `http.StatusBadRequest` because the query path has no `istructs.IIntents` to allocate `NewID`; `insert table` stays on the legacy command path
+    - invokes `c.cluster.LogVSqlUpdate` via `federation.IFederation` against `args.WSID` and captures its `CurrentWLogOffset`
+    - performs the actual DML by reusing the existing `updateTable`/`updateCorrupted`/`updateUnlogged` dispatch (extracted into an unexported `dispatchDML` helper shared with `provideExecCmdVSqlUpdate`); `updateTable` now returns the target CUD's WLog offset (it reads `CurrentWLogOffset` from the `c.sys.CUD` response and no longer uses `WithDiscardResponse`)
     - emits a single result row with `LogWLogOffset`, `CUDWLogOffset` via the query callback
   - Register both extensions in `pkg/cluster/provide.go` using `istructsmem.NewCommandFunction` / `istructsmem.NewQueryFunction`
 - Router-side compatibility, per API version (response shape must match the entry point):
-  - API v1 (`pkg/router/impl_http.go`, `RequestHandler_V1`): detect `busRequest.Resource == "c.cluster.VSqlUpdate"`, rewrite to `q.cluster.VSqlUpdate2`, execute, and emit the v1 command response shape (`CurrentWLogOffset`, `NewIDs`)
-  - API v2 (`pkg/router/impl_apiv2.go`, `requestHandlerV2_extension` commands branch): detect `busRequest.QName == cluster.VSqlUpdate`, rewrite to `q.cluster.VSqlUpdate2` (switch `APIPath` to `APIPath_Queries`), execute, and emit the v2 command response shape
+  - API v1 (`pkg/router/impl_http.go`, `RequestHandler_V1`): detect `busRequest.Resource == "c.cluster.VSqlUpdate"` and `dml.OpKind_UpdateTable` in the body, rewrite to `q.cluster.VSqlUpdate2`, execute, and emit the v1 command response shape (`{"CurrentWLogOffset":<LogWLogOffset>}`)
+  - API v2 (`pkg/router/impl_apiv2.go`, `requestHandlerV2_extension` commands branch): detect `busRequest.QName == cluster.VSqlUpdate` and `dml.OpKind_UpdateTable` in the body, rewrite to `q.cluster.VSqlUpdate2` (switch `APIPath` to `APIPath_Queries`), execute, and emit the v2 command response shape (`{"currentWLogOffset":<LogWLogOffset>}`)
   - The two shims are separate on purpose: each must produce a response in the format of its own API version
+  - Both shims use a shared `capturingResponseWriter` to reuse `reply_v1` / `reply_v2` for the underlying streaming; the captured body is parsed with `federation.QueryResponse` / `federation.FuncResponse` to read `LogWLogOffset`
   - Keep the old `c.cluster.VSqlUpdate` extension registered until deprecation lands to avoid breaking direct handler paths used in integration tests
-- Authorization: grant `EXECUTE` on `q.cluster.VSqlUpdate2` and `c.cluster.LogVSqlUpdate` to the same roles that currently execute `c.cluster.VSqlUpdate` (system principals), in `pkg/cluster/appws.vsql`
+- Authorization: no GRANT statement is added for the new extensions; the existing `c.cluster.VSqlUpdate` is not granted either - access to cluster-app extensions is gated by the system principal check
 - Tests:
-  - Un-skip the existing tests in `pkg/sys/it/impl_vsqlupdate_test.go` (currently `t.Skip("https://github.com/voedger/voedger/issues/3845")`) - they assert end-to-end behavior of `c.cluster.VSqlUpdate` and must pass after the fix through the router shim
-  - Add subtests hitting `q.cluster.VSqlUpdate2` directly for every existing scenario (update/insert table, update corrupted, unlogged update/insert), asserting returned `LogWLogOffset` and `CUDWLogOffset`
+  - Un-skip the existing tests in `pkg/sys/it/impl_vsqlupdate_test.go` (`TestVSqlUpdate_BasicUsage_UpdateTable`, `TestVSqlUpdate_BasicUsage_InsertTable`, `TestDirectUpdateManyTypes`) - they assert end-to-end behavior of `c.cluster.VSqlUpdate` and must pass after the fix through the router shim
+  - Add `TestVSqlUpdate2_DirectQuery` hitting `q.cluster.VSqlUpdate2` directly and asserting returned `LogWLogOffset` and `CUDWLogOffset`
   - Add one new deterministic regression test using `it.NewOwnVITConfig` with `NumCommandProcessors = 1` and a short HTTP deadline
-  - Add router-level subtests covering both v1 and v2 rewrites of `c.cluster.VSqlUpdate` -> `q.cluster.VSqlUpdate2`
+  - Cover the v2 shim with an `apiv2` subtest inside `TestVSqlUpdate_BasicUsage_UpdateTable` (the original v1 path is the default for every other test that posts via `vit.PostApp`)
 - Deprecation path (tracked in `change.md`, not executed in this change unless requested):
   - After frontend/Live migrate, remove `c.cluster.VSqlUpdate` from `appws.vsql`, delete `provideExecCmdVSqlUpdate`, drop the router shim, and update the comments in `pkg/processors/command/impl.go` that reference `c.cluster.VSqlUpdate`
 

--- a/uspecs/changes/2604220859-cluster-vsqlupdate2/how.md
+++ b/uspecs/changes/2604220859-cluster-vsqlupdate2/how.md
@@ -1,0 +1,39 @@
+# How: Replace c.cluster.VSqlUpdate with q.cluster.VSqlUpdate2
+
+## Approach
+
+- Start implementation from a deterministic failing integration test in `pkg/sys/it/impl_vsqlupdate_test.go` that reproduces the original hang: use `it.NewOwnVITConfig` with `NumCommandProcessors = 1` so `c.cluster.VSqlUpdate` and its downstream `c.sys.CUD` are guaranteed to land on the same command processor, issue the call with a short HTTP deadline, and expect a successful response within the deadline - this test must fail before any fix (deadline exceeded due to self-deadlock) and pass after `q.cluster.VSqlUpdate2` plus the router shim are in place
+- Declare new extensions in the cluster app schema `pkg/cluster/appws.vsql` alongside existing `VSqlUpdate`:
+  - `COMMAND LogVSqlUpdate(VSqlUpdateParams)` - no-op, exists only to get the params logged into WLog
+  - `QUERY VSqlUpdate2(VSqlUpdateParams) RETURNS VSqlUpdate2Result` where the result carries WLog offsets of the `LogVSqlUpdate` event and of the downstream CUD event (no `NewID` is tracked - `VSqlUpdate2` is for updates, not inserts)
+- Implement in package `pkg/cluster`:
+  - `c.cluster.LogVSqlUpdate` is wired with `istructsmem.NullCommandExec` directly in `provide.go` - no new handler file needed (logging is done by the command processor itself via WLog)
+  - `impl_vsqlupdate2.go`: query closure that
+    - parses/validates the SQL using existing `parseAndValidateQuery` from `pkg/cluster/impl_vsqlupdate.go` - the helper already relies on `args.Workpiece.(processors.IProcessorWorkpiece)`, implemented by both command and query workpieces, so it works unchanged for queries
+    - invokes `c.cluster.LogVSqlUpdate` via `federation.IFederation` against `clusterapp.ClusterAppWSID` and captures its `CurrentWLogOffset`
+    - performs the actual DML by reusing the existing `updateTable`/`insertTable`/`updateCorrupted`/`updateUnlogged` dispatch (extracted into an unexported helper shared with `provideExecCmdVSqlUpdate`), capturing the target CUD's WLog offset when applicable
+    - emits a single result row with `LogWLogOffset`, `CUDWLogOffset` via the query callback
+  - Register both extensions in `pkg/cluster/provide.go` using `istructsmem.NewCommandFunction` / `istructsmem.NewQueryFunction`
+- Router-side compatibility, per API version (response shape must match the entry point):
+  - API v1 (`pkg/router/impl_http.go`, `RequestHandler_V1`): detect `busRequest.Resource == "c.cluster.VSqlUpdate"`, rewrite to `q.cluster.VSqlUpdate2`, execute, and emit the v1 command response shape (`CurrentWLogOffset`, `NewIDs`)
+  - API v2 (`pkg/router/impl_apiv2.go`, `requestHandlerV2_extension` commands branch): detect `busRequest.QName == cluster.VSqlUpdate`, rewrite to `q.cluster.VSqlUpdate2` (switch `APIPath` to `APIPath_Queries`), execute, and emit the v2 command response shape
+  - The two shims are separate on purpose: each must produce a response in the format of its own API version
+  - Keep the old `c.cluster.VSqlUpdate` extension registered until deprecation lands to avoid breaking direct handler paths used in integration tests
+- Authorization: grant `EXECUTE` on `q.cluster.VSqlUpdate2` and `c.cluster.LogVSqlUpdate` to the same roles that currently execute `c.cluster.VSqlUpdate` (system principals), in `pkg/cluster/appws.vsql`
+- Tests:
+  - Un-skip the existing tests in `pkg/sys/it/impl_vsqlupdate_test.go` (currently `t.Skip("https://github.com/voedger/voedger/issues/3845")`) - they assert end-to-end behavior of `c.cluster.VSqlUpdate` and must pass after the fix through the router shim
+  - Add subtests hitting `q.cluster.VSqlUpdate2` directly for every existing scenario (update/insert table, update corrupted, unlogged update/insert), asserting returned `LogWLogOffset` and `CUDWLogOffset`
+  - Add one new deterministic regression test using `it.NewOwnVITConfig` with `NumCommandProcessors = 1` and a short HTTP deadline
+  - Add router-level subtests covering both v1 and v2 rewrites of `c.cluster.VSqlUpdate` -> `q.cluster.VSqlUpdate2`
+- Deprecation path (tracked in `change.md`, not executed in this change unless requested):
+  - After frontend/Live migrate, remove `c.cluster.VSqlUpdate` from `appws.vsql`, delete `provideExecCmdVSqlUpdate`, drop the router shim, and update the comments in `pkg/processors/command/impl.go` that reference `c.cluster.VSqlUpdate`
+
+References:
+
+- [pkg/cluster/appws.vsql](../../../pkg/cluster/appws.vsql)
+- [pkg/cluster/provide.go](../../../pkg/cluster/provide.go)
+- [pkg/cluster/impl_vsqlupdate.go](../../../pkg/cluster/impl_vsqlupdate.go)
+- [pkg/cluster/consts.go](../../../pkg/cluster/consts.go)
+- [pkg/processors/command/impl.go](../../../pkg/processors/command/impl.go)
+- [pkg/router/impl_apiv2.go](../../../pkg/router/impl_apiv2.go)
+- [pkg/sys/it/impl_vsqlupdate_test.go](../../../pkg/sys/it/impl_vsqlupdate_test.go)

--- a/uspecs/changes/2604220859-cluster-vsqlupdate2/impl.md
+++ b/uspecs/changes/2604220859-cluster-vsqlupdate2/impl.md
@@ -1,0 +1,68 @@
+# Implementation plan: Replace c.cluster.VSqlUpdate with q.cluster.VSqlUpdate2 to avoid command processor deadlock
+
+## Construction
+
+### Failing regression test (red first)
+
+- [x] update: [pkg/sys/it/impl_vsqlupdate_test.go](../../../pkg/sys/it/impl_vsqlupdate_test.go)
+  - add: deterministic regression test using `it.NewOwnVITConfig` with `cfg.NumCommandProcessors = 1` (forces `c.cluster.VSqlUpdate` and the downstream `c.sys.CUD` to share the single command processor); post with a short HTTP deadline; expect a successful response within the deadline (fails with deadline-exceeded before the fix, passes after)
+
+### Schema and constants
+
+- [x] update: [pkg/cluster/appws.vsql](../../../pkg/cluster/appws.vsql)
+  - add: `TYPE VSqlUpdate2Result` with `LogWLogOffset int64`, `CUDWLogOffset int64` (no `NewID` - `VSqlUpdate2` is for updates, not inserts)
+  - add: `COMMAND LogVSqlUpdate(VSqlUpdateParams)` and `QUERY VSqlUpdate2(VSqlUpdateParams) RETURNS VSqlUpdate2Result` to the existing `EXTENSION ENGINE BUILTIN` block
+  - note: no GRANT statements added; existing `c.cluster.VSqlUpdate` is not granted either — access is gated by the sys principal check
+- [x] update: [pkg/cluster/consts.go](../../../pkg/cluster/consts.go)
+  - add: QName constants `qNameQryVSqlUpdate2`, `qNameCmdLogVSqlUpdate`, `qNameVSqlUpdate2Result`; field constants `field_LogWLogOffset`, `field_CUDWLogOffset`
+
+### Handler
+
+- [x] create: [pkg/cluster/impl_vsqlupdate2.go](../../../pkg/cluster/impl_vsqlupdate2.go)
+  - add: `provideExecQryVSqlUpdate2` that parses/validates via shared helper (reuses `parseAndValidateQuery`, which goes through `args.Workpiece.(processors.IProcessorWorkpiece)` - implemented by both command and query workpieces), rejects `InsertTable` (query path is update-only, `Intents` unavailable), invokes `c.cluster.LogVSqlUpdate` through `federation.IFederation` against `args.WSID` (ClusterAppWSID in practice), then dispatches the DML through the shared helper, emitting a single result row with `LogWLogOffset` and `CUDWLogOffset`
+- no handler file is needed for `c.cluster.LogVSqlUpdate`: it is a pure no-op that relies on WLog and is wired directly in `provide.go` using `istructsmem.NullCommandExec`
+
+### Refactor and wiring
+
+- [x] update: [pkg/cluster/impl_vsqlupdate.go](../../../pkg/cluster/impl_vsqlupdate.go)
+  - refactor: extract the `switch update.Kind { ... }` dispatch into an unexported `dispatchDML` helper reused by both `provideExecCmdVSqlUpdate` and `provideExecQryVSqlUpdate2` (DRY)
+  - refactor: change `parseAndValidateQuery` to take `workpiece interface{}` instead of `istructs.ExecCommandArgs` so it is callable from both command and query handlers
+- [x] update: [pkg/cluster/impl_table.go](../../../pkg/cluster/impl_table.go)
+  - refactor: `updateTable` now returns `(cudWLogOffset istructs.Offset, err error)` by reading `CurrentWLogOffset` from the `c.sys.CUD` response (removed `WithDiscardResponse`) so that `q.cluster.VSqlUpdate2` can expose the CUD WLog offset to callers
+- [x] update: [pkg/cluster/provide.go](../../../pkg/cluster/provide.go)
+  - add: register `c.cluster.LogVSqlUpdate` via `istructsmem.NewCommandFunction(..., istructsmem.NullCommandExec)`
+  - add: register `q.cluster.VSqlUpdate2` via `istructsmem.NewQueryFunction`
+
+### Router compatibility shim
+
+The shim is implemented per API version because the response shape must match the entry point: a client calling v1 must get a v1 command response, a client calling v2 must get a v2 command response.
+
+- [x] create: [pkg/router/impl_vsqlupdate_shim.go](../../../pkg/router/impl_vsqlupdate_shim.go)
+  - add: `isVSqlUpdateV1Call`, `isVSqlUpdateV2Call` predicates (skip requests whose `args.Query` starts with `insert` — `insert table` needs `NewID` via `Intents`, unavailable in the query path, so it stays on the command path)
+  - add: `dispatchVSqlUpdateShim_V1` — rewrites `busRequest.Resource` to `q.cluster.VSqlUpdate2`, injects `elements[0].fields=[LogWLogOffset, CUDWLogOffset]`, drains the streamed response and writes `{"CurrentWLogOffset":<LogWLogOffset>}`
+  - add: `dispatchVSqlUpdateShim_V2` — rewrites `busRequest` to `APIPath_Queries` with `cluster.VSqlUpdate2` QName, moves `args` to the `args` query param and sets `keys` to `LogWLogOffset,CUDWLogOffset`, then drains the streamed response and writes `{"currentWLogOffset":<LogWLogOffset>}`
+- [x] update: [pkg/router/impl_http.go](../../../pkg/router/impl_http.go)
+  - add: in `RequestHandler_V1`, call `isVSqlUpdateV1Call` + `dispatchVSqlUpdateShim_V1` before `SendRequest`
+- [x] update: [pkg/router/impl_apiv2.go](../../../pkg/router/impl_apiv2.go)
+  - add: in `requestHandlerV2_extension` (commands branch), call `isVSqlUpdateV2Call` + `dispatchVSqlUpdateShim_V2` before `sendRequestAndReadResponse`
+
+### Tests
+
+- [x] update: [pkg/sys/it/impl_vsqlupdate_test.go](../../../pkg/sys/it/impl_vsqlupdate_test.go)
+  - add: `TestVSqlUpdate_NoDeadlockOnSharedCommandProcessor` — deterministic regression test that passes only with the shim in place
+  - add: `TestVSqlUpdate2_DirectQuery` — posts directly to `q.cluster.VSqlUpdate2` and asserts the returned `LogWLogOffset` and `CUDWLogOffset` are positive
+  - add: `TestVSqlUpdate_ViaAPIV2_Shim` — posts to `c.cluster.VSqlUpdate` via `/api/v2/.../commands/cluster.VSqlUpdate` and asserts the v2 command response carries `currentWLogOffset`
+  - note: the existing tests already exercise the v1 shim end-to-end because every one of them posts to `c.cluster.VSqlUpdate` via `vit.PostApp` (the v1 entry point)
+
+## Quick start
+
+Call the new query directly (replaces `c.cluster.VSqlUpdate`):
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer ${SYS_TOKEN}" \
+  -d '{"args":{"Query":"update untill.app1.140737488486400.app1pkg.Customer.322685000131099 set ClientID = '\'''\'', ClientConfigured = false"},"elements":[{"fields":["LogWLogOffset","CUDWLogOffset"]}]}' \
+  "http://${HOST}/api/untill/cluster/${CLUSTER_APP_WSID}/q.cluster.VSqlUpdate2"
+```
+
+Existing callers may keep posting to `c.cluster.VSqlUpdate`; the router transparently reroutes the request to `q.cluster.VSqlUpdate2` until the old command is removed in a follow-up change.

--- a/uspecs/changes/2604220859-cluster-vsqlupdate2/impl.md
+++ b/uspecs/changes/2604220859-cluster-vsqlupdate2/impl.md
@@ -35,7 +35,7 @@
 
 ### Router compatibility shim
 
-The shim is implemented per API version because the response shape must match the entry point: a client calling v1 must get a v1 command response, a client calling v2 must get a v2 command response.
+The shim is implemented per API version because the response shape must match the entry point: a client calling v1 must get a v1 command response, a client calling v2 must get a v2 command response. In both versions the shim runs on the query processor, so its dispatch is placed inside the same `wsQueryLimiter`-protected block as native queries to share the gating.
 
 - [x] create: [pkg/router/impl_vsqlupdate_shim.go](../../../pkg/router/impl_vsqlupdate_shim.go)
   - add: `isVSqlUpdateV1Call`, `isVSqlUpdateV2Call` predicates that gate the shim on `isUpdateTableBody`, which uses `dml.ParseQuery` and accepts only `dml.OpKind_UpdateTable` (insert/unlogged/update-corrupted stay on the original command path)
@@ -44,17 +44,20 @@ The shim is implemented per API version because the response shape must match th
   - add: `dispatchVSqlUpdateShim_V1` — rewrites `busRequest.Resource` to `q.cluster.VSqlUpdate2`, calls `reply_v1` into the capturing writer, then emits `{"CurrentWLogOffset":<LogWLogOffset>}` on success
   - add: `dispatchVSqlUpdateShim_V2` — rewrites `busRequest` to `APIPath_Queries` with `cluster.VSqlUpdate2` QName, moves `args` to the `args` query param and sets `keys` to `LogWLogOffset,CUDWLogOffset`, calls `reply_v2` into the capturing writer, then emits `{"currentWLogOffset":<LogWLogOffset>}` on success
   - add: `extractLogWLogOffsetFromV1Body` / `extractLogWLogOffsetFromV2Body` — unmarshal the captured body via `federation.QueryResponse` / `federation.FuncResponse` and read the first `LogWLogOffset`; unreachable error branches are marked `// notest`
+  - add: logging stages `routing.vsqlupdate` (Info, reroute announcement) and `routing.vsqlupdate.error` (Error, body parse / args marshal / downstream reply failures); transport error on `SendRequest` is logged under the existing `routing.send2vvm.error` stage with a shim-specific message `forwarding <source> to <target> failed: <err>`
 - [x] update: [pkg/router/impl_http.go](../../../pkg/router/impl_http.go)
-  - add: in `RequestHandler_V1`, call `isVSqlUpdateV1Call` + `dispatchVSqlUpdateShim_V1` before `SendRequest`
+  - add: in `RequestHandler_V1`, compute `isVSqlUpdateV1Call` once, include it alongside the `q.*` predicate in the `wsQueryLimiter` gate, and dispatch `dispatchVSqlUpdateShim_V1` from inside the limiter-protected block instead of `SendRequest`
 - [x] update: [pkg/router/impl_apiv2.go](../../../pkg/router/impl_apiv2.go)
-  - add: in `requestHandlerV2_extension` (commands branch), call `isVSqlUpdateV2Call` + `dispatchVSqlUpdateShim_V2` before `sendRequestAndReadResponse`
+  - add: in shared `sendRequestAndReadResponse`, compute `isVSqlUpdateV2Call` once, include it alongside the GET-on-QP-bound-path predicate in the `wsQueryLimiter` gate, and dispatch `dispatchVSqlUpdateShim_V2` from inside the limiter-protected block (covers every v2 entry point that calls `sendRequestAndReadResponse`, not only `requestHandlerV2_extension`)
+- [x] update: [.golangci.yml](../../../.golangci.yml)
+  - add: `"to"` to the `revive` `add-constant` `allowStrs` allowlist to admit the `"rerouting X to Y"` log message literal
 
 ### Tests
 
 - [x] update: [pkg/sys/it/impl_vsqlupdate_test.go](../../../pkg/sys/it/impl_vsqlupdate_test.go)
   - add: `TestVSqlUpdate_NoDeadlockOnSharedCommandProcessor` — deterministic regression test that passes only with the shim in place
   - add: `TestVSqlUpdate2_DirectQuery` — posts directly to `q.cluster.VSqlUpdate2` and asserts the returned `LogWLogOffset` and `CUDWLogOffset` are positive
-  - change: `TestVSqlUpdate_BasicUsage_UpdateTable` — un-skipped and split into `apiv1` / `apiv2` subtests sharing a single VIT; `apiv2` posts to `/api/v2/.../commands/cluster.VSqlUpdate` and asserts the v2 command response carries `currentWLogOffset`
+  - change: `TestVSqlUpdate_BasicUsage_UpdateTable` — un-skipped and split into `apiv1` / `apiv2` subtests sharing a single VIT; `apiv2` posts to `/api/v2/.../commands/cluster.VSqlUpdate` and asserts the v2 command response carries `currentWLogOffset`; both subtests use `logger.StartCapture` + `EventuallyHasLine` to assert the `routing.vsqlupdate` reroute log line
   - change: un-skipped `TestVSqlUpdate_BasicUsage_InsertTable` and `TestDirectUpdateManyTypes`
   - note: the remaining tests exercise the v1 shim end-to-end because they post to `c.cluster.VSqlUpdate` via `vit.PostApp` (the v1 entry point)
 

--- a/uspecs/changes/2604220859-cluster-vsqlupdate2/impl.md
+++ b/uspecs/changes/2604220859-cluster-vsqlupdate2/impl.md
@@ -38,9 +38,12 @@
 The shim is implemented per API version because the response shape must match the entry point: a client calling v1 must get a v1 command response, a client calling v2 must get a v2 command response.
 
 - [x] create: [pkg/router/impl_vsqlupdate_shim.go](../../../pkg/router/impl_vsqlupdate_shim.go)
-  - add: `isVSqlUpdateV1Call`, `isVSqlUpdateV2Call` predicates (skip requests whose `args.Query` starts with `insert` — `insert table` needs `NewID` via `Intents`, unavailable in the query path, so it stays on the command path)
-  - add: `dispatchVSqlUpdateShim_V1` — rewrites `busRequest.Resource` to `q.cluster.VSqlUpdate2`, injects `elements[0].fields=[LogWLogOffset, CUDWLogOffset]`, drains the streamed response and writes `{"CurrentWLogOffset":<LogWLogOffset>}`
-  - add: `dispatchVSqlUpdateShim_V2` — rewrites `busRequest` to `APIPath_Queries` with `cluster.VSqlUpdate2` QName, moves `args` to the `args` query param and sets `keys` to `LogWLogOffset,CUDWLogOffset`, then drains the streamed response and writes `{"currentWLogOffset":<LogWLogOffset>}`
+  - add: `isVSqlUpdateV1Call`, `isVSqlUpdateV2Call` predicates that gate the shim on `isUpdateTableBody`, which uses `dml.ParseQuery` and accepts only `dml.OpKind_UpdateTable` (insert/unlogged/update-corrupted stay on the original command path)
+  - add: `capturingResponseWriter` (buffers headers/status/body, implements `http.Flusher`) so the shim can reuse `reply_v1` / `reply_v2` unchanged and then rewrite the final response shape
+  - add: `rewriteVSqlUpdateBody` — splices `"elements":[{"fields":["LogWLogOffset","CUDWLogOffset"]}]` into the incoming body via `bytes.Buffer` (no JSON round-trip)
+  - add: `dispatchVSqlUpdateShim_V1` — rewrites `busRequest.Resource` to `q.cluster.VSqlUpdate2`, calls `reply_v1` into the capturing writer, then emits `{"CurrentWLogOffset":<LogWLogOffset>}` on success
+  - add: `dispatchVSqlUpdateShim_V2` — rewrites `busRequest` to `APIPath_Queries` with `cluster.VSqlUpdate2` QName, moves `args` to the `args` query param and sets `keys` to `LogWLogOffset,CUDWLogOffset`, calls `reply_v2` into the capturing writer, then emits `{"currentWLogOffset":<LogWLogOffset>}` on success
+  - add: `extractLogWLogOffsetFromV1Body` / `extractLogWLogOffsetFromV2Body` — unmarshal the captured body via `federation.QueryResponse` / `federation.FuncResponse` and read the first `LogWLogOffset`; unreachable error branches are marked `// notest`
 - [x] update: [pkg/router/impl_http.go](../../../pkg/router/impl_http.go)
   - add: in `RequestHandler_V1`, call `isVSqlUpdateV1Call` + `dispatchVSqlUpdateShim_V1` before `SendRequest`
 - [x] update: [pkg/router/impl_apiv2.go](../../../pkg/router/impl_apiv2.go)
@@ -51,8 +54,9 @@ The shim is implemented per API version because the response shape must match th
 - [x] update: [pkg/sys/it/impl_vsqlupdate_test.go](../../../pkg/sys/it/impl_vsqlupdate_test.go)
   - add: `TestVSqlUpdate_NoDeadlockOnSharedCommandProcessor` — deterministic regression test that passes only with the shim in place
   - add: `TestVSqlUpdate2_DirectQuery` — posts directly to `q.cluster.VSqlUpdate2` and asserts the returned `LogWLogOffset` and `CUDWLogOffset` are positive
-  - add: `TestVSqlUpdate_ViaAPIV2_Shim` — posts to `c.cluster.VSqlUpdate` via `/api/v2/.../commands/cluster.VSqlUpdate` and asserts the v2 command response carries `currentWLogOffset`
-  - note: the existing tests already exercise the v1 shim end-to-end because every one of them posts to `c.cluster.VSqlUpdate` via `vit.PostApp` (the v1 entry point)
+  - change: `TestVSqlUpdate_BasicUsage_UpdateTable` — un-skipped and split into `apiv1` / `apiv2` subtests sharing a single VIT; `apiv2` posts to `/api/v2/.../commands/cluster.VSqlUpdate` and asserts the v2 command response carries `currentWLogOffset`
+  - change: un-skipped `TestVSqlUpdate_BasicUsage_InsertTable` and `TestDirectUpdateManyTypes`
+  - note: the remaining tests exercise the v1 shim end-to-end because they post to `c.cluster.VSqlUpdate` via `vit.PostApp` (the v1 entry point)
 
 ## Quick start
 

--- a/uspecs/changes/2604220859-cluster-vsqlupdate2/issue.md
+++ b/uspecs/changes/2604220859-cluster-vsqlupdate2/issue.md
@@ -1,0 +1,34 @@
+# AIR-3656: Reject c.cluster.VSqlUpdate if c.sys.CUD would get to the same command processor
+
+- Key: AIR-3656
+- Type: Bug
+- Status: In Progress
+- Assignee: d.gribanov@dev.untill.com
+- URL: <https://untill.atlassian.net/browse/AIR-3656>
+
+## Why
+
+Executed:
+
+```sql
+c.cluster.VSqlUpdate: update untill.fiscalcloud.140737488486400.fiscalcloud.Customer.322685000131099 set ClientID = '', ClientConfigured = false
+```
+
+The request hung.
+
+## What
+
+If the `c.sys.CUD` would go to the WSID that is serviced by the same command processor, then `c.sys.CUD` will hang for sure, so reject the request.
+
+## Plan
+
+- New `q.cluster.VSqlUpdate2` + `c.cluster.LogVSqlUpdate` + router
+- Router reroutes `c.cluster.VSqlUpdate` to `q.cluster.VSqlUpdate2` and transforms the response to match command response format
+- `q.cluster.VSqlUpdate2`:
+  - Calls `c.cluster.LogVSqlUpdate`
+  - Calls CUD in the target workspace
+  - Returns WLog offsets of `c.cluster.LogVSqlUpdate` and CUD
+- `c.cluster.LogVSqlUpdate` does nothing, just logs params
+- Ask frontend to use `q.cluster.VSqlUpdate2`
+- Wait until Live uses `q.cluster.VSqlUpdate2`
+- Get rid of `c.cluster.VSqlUpdate` and special routing

--- a/uspecs/specs/prod/apps/logging--td.md
+++ b/uspecs/specs/prod/apps/logging--td.md
@@ -161,8 +161,17 @@ Uses `vapp="sys/voedger"`, `extension="sys._Leadership"`, `key` attribs.
   - On every query request: check `lastLoggedAt` timestamp under mutex; if 10 seconds have elapsed, swap the rejections map, log one warning per key with non-zero count, update `lastLoggedAt`
   - On server shutdown: `flushAll()` logs and purges all pending entries regardless of elapsed time
 - First response from bus (immediately after `SendRequest` returns): level `Verbose`, stage `routing.latency1`, msg `<latency_ms>`
-- Error sending request to VVM: level `Error`, stage `routing.send2vvm.error`, msg `<error message>`
+- Error sending request to VVM: level `Error`, stage `routing.send2vvm.error`, msg `<error message>` or `forwarding <source resource> to <target resource> failed: <error message>` for the VSqlUpdate shim
 - Error sending response to client: level `Error`, stage `routing.response.error`, msg `<error message>`
+
+**VSqlUpdate shim** (both API v1 and API v2, emitted by `dispatchVSqlUpdateShim_V1/V2`):
+
+The router reroutes legacy `c.cluster.VSqlUpdate` command requests to the `q.cluster.VSqlUpdate2` query to avoid a command processor deadlock. Shim-specific log entries share the `routing.vsqlupdate*` subsystem so `stage=routing.vsqlupdate*` filters the whole shim feed.
+
+- Reroute announcement (emitted at the entry of both dispatchers, right before request rewriting): level `Info`, stage `routing.vsqlupdate`, msg `rerouting c.cluster.VSqlUpdate to q.cluster.VSqlUpdate2`
+- Shim reply failure (captured status is not 200 OK or downstream `respErr` is non-nil, logged right before the reply is flushed to the client): level `Error`, stage `routing.vsqlupdate.error`, msg `c.cluster.VSqlUpdate shim reply failed: status=<status> respErr=<err> body=<captured body>`
+- APIv2 body parse failure (malformed JSON in the legacy command body): level `Error`, stage `routing.vsqlupdate.error`, msg `failed to parse VSqlUpdate body: <error>`
+- APIv2 args marshal failure (`notest`): level `Error`, stage `routing.vsqlupdate.error`, msg `failed to marshal VSqlUpdate args: <error>`
 
 ---
 


### PR DESCRIPTION
registered_at: 2026-04-22T08:59:37Z
change_id: 2604220859-cluster-vsqlupdate2
baseline: 36c8ee68f6ca5db6f2495bf5c36d23ff652c07d3
issue_url: https://untill.atlassian.net/browse/AIR-3656

# Change request: Replace c.cluster.VSqlUpdate with q.cluster.VSqlUpdate2 to avoid command processor deadlock

## Why

`c.cluster.VSqlUpdate` hangs when the internal `c.sys.CUD` it issues is routed to the same command processor, because a command processor cannot dispatch another command to itself. See [issue.md](issue.md) for details.

## What

Introduce a new query-based flow that replaces the current command and eliminates the self-routing hang:

- New `q.cluster.VSqlUpdate2` query that calls `c.cluster.LogVSqlUpdate` and then performs the CUD against the target workspace, returning WLog offsets for both
- New `c.cluster.LogVSqlUpdate` command that only logs the original request parameters
- Router changes that reroute `c.cluster.VSqlUpdate` to `q.cluster.VSqlUpdate2` and adapt the response to the command response format

Migration steps:

- Ask frontend to switch to `q.cluster.VSqlUpdate2`
- Wait until Live uses `q.cluster.VSqlUpdate2`
- Remove `c.cluster.VSqlUpdate` and its special routing
