### PR TITLE
[AIR-3664] Fix user cannot be reinvited after removal

### DIFF
--- a/pkg/sys/invite/impl_applyjoinworkspace.go
+++ b/pkg/sys/invite/impl_applyjoinworkspace.go
@@ -17,7 +17,6 @@ import (
 	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
 	"github.com/voedger/voedger/pkg/sys"
 	"github.com/voedger/voedger/pkg/sys/authnz"
-	"github.com/voedger/voedger/pkg/sys/collection"
 )
 
 func asyncProjectorApplyJoinWorkspace(time timeu.ITime, federation federation.IFederation, tokens itokens.ITokens) istructs.Projector {
@@ -40,29 +39,20 @@ func applyJoinWorkspace(time timeu.ITime, federation federation.IFederation, tok
 			return
 		}
 
-		login := svCDocInvite.AsString(Field_Login)
-		subjectExistsByActualLogin := false
-		existingSubjectID, err := SubjectExistsByLogin(login, s) // for backward compatibility
-		subjectExistsByLogin := existingSubjectID > 0
-		if err == nil && !subjectExistsByLogin {
-			login = svCDocInvite.AsString(field_ActualLogin)
-			existingSubjectID, err = SubjectExistsByLogin(login, s)
-			subjectExistsByActualLogin = existingSubjectID > 0
-		}
+		// Check if Subject exists for this user
+		// ActualLogin = user's login from auth token (set by InitiateJoinWorkspace)
+		// Note: Currently ActualLogin always equals Login because InitiateJoinWorkspace validates they match (earlier it wasn't required)
+		login := svCDocInvite.AsString(field_ActualLogin)
+		existingSubjectID, isActive, err := SubjectExistsByLogin(login, s)
 		if err != nil {
 			// notest
 			return err
 		}
 
-		if subjectExistsByLogin || subjectExistsByActualLogin {
-			// cdoc.sys.Subject exists by login -> skip
+		if isActive {
+			// Active Subject already exists -> skip
 			// see https://github.com/voedger/voedger/issues/1107
-			// && svCDocInvite.AsInt32(Field_State) == State_Joined -> insert cdoc.sys.Subject with an existing login -> unique violation -> the projector stuck
-			fieldName := "cdoc.sys.Invite.Login"
-			if subjectExistsByActualLogin {
-				fieldName = "cdoc.sys.Invite.ActualLogin"
-			}
-			logger.Info(fmt.Sprintf(`skip aproj.sys.ApplyJoinWorkspace because cdoc.sys.SubjectID.%d exists already by %s "%s"`, existingSubjectID, fieldName, login))
+			logger.Info(fmt.Sprintf(`skip aproj.sys.ApplyJoinWorkspace: active Subject %d already exists for login "%s"`, existingSubjectID, login))
 			return nil
 		}
 
@@ -93,40 +83,25 @@ func applyJoinWorkspace(time timeu.ITime, federation federation.IFederation, tok
 			return
 		}
 
-		// Find cdoc.sys.Subject by cdoc.air.Invite
-		skbViewCollection, err := s.KeyBuilder(sys.Storage_View, collection.QNameCollectionView)
-		if err != nil {
-			return
-		}
-		skbViewCollection.PutInt32(collection.Field_PartKey, collection.PartitionKeyCollection)
-		skbViewCollection.PutQName(collection.Field_DocQName, QNameCDocSubject)
-
-		var svCDocSubject istructs.IStateValue
-		if svCDocInvite.AsRecordID(field_SubjectID) != istructs.NullRecordID {
-			err = s.Read(skbViewCollection, func(key istructs.IKey, value istructs.IStateValue) (err error) {
-				if svCDocSubject != nil {
-					return nil
-				}
-				if svCDocInvite.AsRecordID(field_SubjectID) == value.AsRecordID(appdef.SystemField_ID) {
-					svCDocSubject = value
-				}
-				return nil
-			})
-			if err != nil {
-				return
-			}
-		}
-
 		var body string
 		// Store cdoc.sys.Subject
-		if svCDocSubject == nil {
-			// svCDocInvite.AsString(Field_Login) is actually c.sys.InitiateInvitationByEMail.Email
+		if existingSubjectID == istructs.NullRecordID {
+			// Create new Subject
 			body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"sys.Subject","Login":"%s","Roles":"%s","SubjectKind":%d,"ProfileWSID":%d}}]}`,
 				svCDocInvite.AsString(field_ActualLogin), svCDocInvite.AsString(Field_Roles), svCDocInvite.AsInt32(authnz.Field_SubjectKind),
 				svCDocInvite.AsInt64(Field_InviteeProfileWSID))
 		} else {
-			body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"Roles":"%s"}}]}`,
-				svCDocSubject.AsRecordID(appdef.SystemField_ID), svCDocInvite.AsString(Field_Roles))
+			// Reactivate existing Subject - first activate, then update Roles (can't update both in one call)
+			body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"sys.IsActive":true}}]}`, existingSubjectID)
+			_, err = federation.Func(
+				fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
+				body,
+				httpu.WithAuthorizeBy(token),
+				httpu.WithDiscardResponse())
+			if err != nil {
+				return
+			}
+			body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"Roles":"%s"}}]}`, existingSubjectID, svCDocInvite.AsString(Field_Roles))
 		}
 		resp, err := federation.Func(
 			fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
@@ -136,9 +111,8 @@ func applyJoinWorkspace(time timeu.ITime, federation federation.IFederation, tok
 			return
 		}
 
-		//Store cdoc.sys.Invite
-		//TODO why Login update???
-		if svCDocSubject == nil {
+		// Store cdoc.sys.Invite
+		if existingSubjectID == istructs.NullRecordID {
 			body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"State":%d,"SubjectID":%d,"Updated":%d}}]}`,
 				svCDocInvite.AsRecordID(appdef.SystemField_ID), State_Joined, resp.NewID(), time.Now().UnixMilli())
 		} else {

--- a/pkg/sys/invite/impl_applyjoinworkspace.go
+++ b/pkg/sys/invite/impl_applyjoinworkspace.go
@@ -10,7 +10,6 @@ import (
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils/federation"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
-	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/itokens"
@@ -49,12 +48,10 @@ func applyJoinWorkspace(time timeu.ITime, federation federation.IFederation, tok
 			return err
 		}
 
-		if isActive {
-			// Active Subject already exists -> skip
-			// see https://github.com/voedger/voedger/issues/1107
-			logger.Info(fmt.Sprintf(`skip aproj.sys.ApplyJoinWorkspace: active Subject %d already exists for login "%s"`, existingSubjectID, login))
-			return nil
-		}
+		// No early skip here - all operations below are idempotent, ensuring completion on projector retries:
+		// - CreateJoinedWorkspace: checks if exists, updates if so (see impl_createjoinedworkspace.go)
+		// - Subject create/reactivate: handled by existingSubjectID check
+		// - Invite update: idempotent state transition
 
 		skbCDocWorkspaceDescriptor, err := s.KeyBuilder(sys.Storage_Record, appdef.QNameCDocWorkspaceDescriptor)
 		if err != nil {
@@ -85,13 +82,14 @@ func applyJoinWorkspace(time timeu.ITime, federation federation.IFederation, tok
 
 		var body string
 		// Store cdoc.sys.Subject
-		if existingSubjectID == istructs.NullRecordID {
+		switch {
+		case existingSubjectID == istructs.NullRecordID:
 			// Create new Subject
 			body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"sys.Subject","Login":"%s","Roles":"%s","SubjectKind":%d,"ProfileWSID":%d}}]}`,
 				svCDocInvite.AsString(field_ActualLogin), svCDocInvite.AsString(Field_Roles), svCDocInvite.AsInt32(authnz.Field_SubjectKind),
 				svCDocInvite.AsInt64(Field_InviteeProfileWSID))
-		} else {
-			// Reactivate existing Subject - first activate, then update Roles (can't update both in one call)
+		case !isActive:
+			// Reactivate inactive Subject - first activate, then update Roles (can't update both in one call)
 			body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"sys.IsActive":true}}]}`, existingSubjectID)
 			_, err = federation.Func(
 				fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
@@ -101,6 +99,9 @@ func applyJoinWorkspace(time timeu.ITime, federation federation.IFederation, tok
 			if err != nil {
 				return
 			}
+			fallthrough
+		default:
+			// Subject already active (retry scenario) - just update Roles
 			body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"Roles":"%s"}}]}`, existingSubjectID, svCDocInvite.AsString(Field_Roles))
 		}
 		resp, err := federation.Func(

--- a/pkg/sys/invite/impl_initiateinvitationbyemail.go
+++ b/pkg/sys/invite/impl_initiateinvitationbyemail.go
@@ -34,7 +34,7 @@ func execCmdInitiateInvitationByEMail(tm timeu.ITime) func(args istructs.ExecCom
 		cmdInitiateInvitation_ArgEmail := args.ArgumentObject.AsString(field_Email)
 		// do not check if the login from token exists in subjects, see https://github.com/voedger/voedger/issues/3698
 		// because login is Inviter here, not Invitee
-		existingSubjectID, err := SubjectExistsByLogin(cmdInitiateInvitation_ArgEmail, args.State)
+		_, subjectIsActive, err := SubjectExistsByLogin(cmdInitiateInvitation_ArgEmail, args.State)
 		if err != nil {
 			return
 		}
@@ -66,7 +66,7 @@ func execCmdInitiateInvitationByEMail(tm timeu.ITime) func(args istructs.ExecCom
 			}
 
 			inviteState := State(svCDocInvite.AsInt32(Field_State))
-			if existingSubjectID > 0 && !reInviteAllowedForState[inviteState] {
+			if subjectIsActive && !reInviteAllowedForState[inviteState] {
 				return coreutils.NewHTTPError(http.StatusBadRequest, fmt.Errorf(`%w %s`, ErrReInviteNotAllowedForState, inviteState))
 			}
 

--- a/pkg/sys/invite/utils.go
+++ b/pkg/sys/invite/utils.go
@@ -97,15 +97,29 @@ func LoginFromToken(st istructs.IState) (loginFromToken string, err error) {
 	return svPrincipal.AsString(sys.Storage_RequestSubject_Field_Name), nil
 }
 
-func SubjectExistsByLogin(login string, state istructs.IState) (existingSubjectID istructs.RecordID, err error) {
+// SubjectExistsByLogin returns SubjectID and isActive status for a Subject with the given login.
+// Returns (0, false, nil) if no Subject exists for this login.
+func SubjectExistsByLogin(login string, state istructs.IState) (subjectID istructs.RecordID, isActive bool, err error) {
 	skbViewSubjectsIdx, err := GetSubjectIdxViewKeyBuilder(login, state)
 	if err != nil {
 		// notest
-		return 0, err
+		return 0, false, err
 	}
 	val, ok, err := state.CanExist(skbViewSubjectsIdx)
-	if ok {
-		existingSubjectID = val.AsRecordID("SubjectID")
+	if err != nil || !ok {
+		return 0, false, err
 	}
-	return existingSubjectID, err
+	subjectID = val.AsRecordID(Field_SubjectID)
+
+	skbSubject, err := state.KeyBuilder(sys.Storage_Record, QNameCDocSubject)
+	if err != nil {
+		// notest
+		return 0, false, err
+	}
+	skbSubject.PutRecordID(sys.Storage_Record_Field_ID, subjectID)
+	svSubject, ok, err := state.CanExist(skbSubject)
+	if err != nil || !ok {
+		return 0, false, err
+	}
+	return subjectID, svSubject.AsBool(appdef.SystemField_IsActive), nil
 }

--- a/pkg/sys/it/impl_invite_test.go
+++ b/pkg/sys/it/impl_invite_test.go
@@ -376,6 +376,54 @@ func TestWrongEmail(t *testing.T) {
 	}
 }
 
+func TestReinviteAfterCancelAcceptedInvite(t *testing.T) {
+	require := require.New(t)
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	// Setup: create workspace and user
+	wsName := "TestReinviteAfterCancel_ws"
+	wsParams := it.SimpleWSParams(wsName)
+	expireDatetime := vit.Now().UnixMilli()
+
+	email := fmt.Sprintf("reinvite_after_cancel_%d@test.com", vit.NextNumber())
+	login := vit.SignUp(email, "1", istructs.AppQName_test1_app1)
+	loginPrn := vit.SignIn(login)
+	ownerPrn := vit.GetPrincipal(istructs.AppQName_test1_app1, it.TestEmail)
+	ws := vit.CreateWorkspace(wsParams, ownerPrn)
+
+	// Step 1: Invite and join
+	inviteID := InitiateInvitationByEMail(vit, ws, expireDatetime, email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+	sentEmail := vit.CaptureEmail()
+	verificationCode := sentEmail.Body[:6]
+	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+
+	InitiateJoinWorkspace(vit, ws, inviteID, loginPrn, verificationCode)
+	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeJoined, invite.State_Joined)
+
+	// Step 2: Cancel accepted invite (admin removes user)
+	vit.PostWS(ws, "c.sys.InitiateCancelAcceptedInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, inviteID))
+	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeCancelled, invite.State_Cancelled)
+
+	// Step 3: Reinvite the same email
+	InitiateInvitationByEMail(vit, ws, expireDatetime, email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+	sentEmail2 := vit.CaptureEmail()
+	verificationCode2 := sentEmail2.Body[:6]
+	WaitForInviteState(vit, ws, inviteID, invite.State_Cancelled, invite.State_Invited)
+
+	// Step 4: User accepts invitation again - this should succeed
+	InitiateJoinWorkspace(vit, ws, inviteID, loginPrn, verificationCode2)
+	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeJoined, invite.State_Joined)
+
+	// Verify: Subject should be active again
+	cDocSubject := vit.PostWS(ws, "q.sys.Collection", fmt.Sprintf(`
+		{"args":{"Schema":"sys.Subject"},
+		"elements":[{"fields":["Login","sys.IsActive"]}],
+		"filters":[{"expr":"eq","args":{"field":"Login","value":"%s"}}]}`, email)).SectionRow(0)
+	require.Equal(email, cDocSubject[0])
+	require.True(cDocSubject[1].(bool))
+}
+
 func TestResendInvitation(t *testing.T) {
 	require := require.New(t)
 	vit := it.NewVIT(t, &it.SharedConfig_App1)

--- a/pkg/sys/sys.vsql
+++ b/pkg/sys/sys.vsql
@@ -80,6 +80,7 @@ ABSTRACT WORKSPACE Workspace (
 
 	TABLE Invite INHERITS sys.CDoc (
 		SubjectKind int32,
+		-- Login: email address the invitation was sent to (set by InitiateInvitationByEMail)
 		Login varchar NOT NULL,
 		Email varchar NOT NULL,
 		Roles varchar(1024),
@@ -90,6 +91,9 @@ ABSTRACT WORKSPACE Workspace (
 		Updated int64 NOT NULL,
 		SubjectID ref,
 		InviteeProfileWSID int64,
+		-- ActualLogin: invitee's login from auth token (set by InitiateJoinWorkspace when user accepts)
+		-- Currently always equals Login because InitiateJoinWorkspace validates they match
+		-- Used for cdoc.sys.Subject.Login field
 		ActualLogin varchar,
 		UNIQUEFIELD Email
 	) WITH Tags=(WorkspaceOwnerTableTag);

--- a/uspecs/changes/archive/2604/2604221416-fix-reinvite-after-removal/change.md
+++ b/uspecs/changes/archive/2604/2604221416-fix-reinvite-after-removal/change.md
@@ -31,14 +31,17 @@ This happens because:
 Refactor `SubjectExistsByLogin()` to return both SubjectID and isActive status:
 
 - Return `(subjectID, isActive, err)` instead of just `(subjectID, err)`
-- Callers can decide: skip if active, reactivate if inactive, create if not found
-- `ApplyJoinWorkspace` uses `existingSubjectID` directly for reactivation (no separate lookup needed)
+- Remove early skip in `ApplyJoinWorkspace` - all operations are idempotent, ensuring completion on projector retries
+- Handle three cases: create new Subject, reactivate inactive Subject, or just update Roles (retry scenario)
 
 ## How
 
 - Write failing integration test first (`TestReinviteAfterCancelAcceptedInvite`)
 - Refactor `SubjectExistsByLogin()` to return `(subjectID, isActive, err)`
-- Update `ApplyJoinWorkspace` to use `isActive` for skip check, `existingSubjectID` for reactivation
+- Update `ApplyJoinWorkspace`:
+  - Remove early skip (was causing issues on projector retries)
+  - Use switch statement: create new / reactivate inactive / update roles only
+  - All operations are idempotent (CreateJoinedWorkspace, Subject update, Invite update)
 - Update `InitiateInvitationByEMail` to use `subjectIsActive` instead of `existingSubjectID > 0`
 - Add comments explaining `Login` vs `ActualLogin` fields in vsql and projector
 

--- a/uspecs/changes/archive/2604/2604221416-fix-reinvite-after-removal/change.md
+++ b/uspecs/changes/archive/2604/2604221416-fix-reinvite-after-removal/change.md
@@ -1,0 +1,51 @@
+---
+registered_at: 2026-04-22T09:14:48Z
+change_id: 2604220914-fix-reinvite-after-removal
+baseline: cde799cbe15807fbd753b5c4a00c53efc1b8d4af
+issue_url: https://untill.atlassian.net/browse/AIR-3664
+archived_at: 2026-04-22T14:16:32Z
+---
+
+# Change request: Fix user cannot be reinvited after removal
+
+## Why
+
+When a joined user is removed from a workspace (via cancel accepted invite), the `view.sys.SubjectsIdx` still contains the old Subject entry. On reinvitation, `SubjectExistsByLogin()` finds this entry and `ApplyJoinWorkspace` skips creating the Subject, leaving the invite stuck.
+
+The protection message appears:
+```text
+skip aproj.sys.ApplyJoinWorkspace because cdoc.sys.SubjectID.{id} exists already by cdoc.sys.Invite.Login "{email}"
+```
+
+This happens because:
+
+- User joins workspace -> `cdoc.sys.Subject` created, `view.sys.SubjectsIdx` populated with login -> SubjectID mapping
+- Admin removes user -> `cdoc.sys.Subject.sys.IsActive` set to `false`, but `view.sys.SubjectsIdx` entry remains
+- Admin reinvites same email -> new invite created, user clicks link
+- `ap.sys.ApplyJoinWorkspace` checks `SubjectExistsByLogin()` which queries `view.sys.SubjectsIdx`
+- View returns old (now inactive) SubjectID -> projector skips Subject creation to prevent unique constraint violation
+- Invite never transitions to `State_Joined`, user stuck
+
+## What
+
+Refactor `SubjectExistsByLogin()` to return both SubjectID and isActive status:
+
+- Return `(subjectID, isActive, err)` instead of just `(subjectID, err)`
+- Callers can decide: skip if active, reactivate if inactive, create if not found
+- `ApplyJoinWorkspace` uses `existingSubjectID` directly for reactivation (no separate lookup needed)
+
+## How
+
+- Write failing integration test first (`TestReinviteAfterCancelAcceptedInvite`)
+- Refactor `SubjectExistsByLogin()` to return `(subjectID, isActive, err)`
+- Update `ApplyJoinWorkspace` to use `isActive` for skip check, `existingSubjectID` for reactivation
+- Update `InitiateInvitationByEMail` to use `subjectIsActive` instead of `existingSubjectID > 0`
+- Add comments explaining `Login` vs `ActualLogin` fields in vsql and projector
+
+References:
+
+- [pkg/sys/it/impl_invite_test.go](../../../../../pkg/sys/it/impl_invite_test.go)
+- [pkg/sys/invite/utils.go](../../../../../pkg/sys/invite/utils.go)
+- [pkg/sys/invite/impl_applyjoinworkspace.go](../../../../../pkg/sys/invite/impl_applyjoinworkspace.go)
+- [pkg/sys/invite/impl_initiateinvitationbyemail.go](../../../../../pkg/sys/invite/impl_initiateinvitationbyemail.go)
+- [pkg/sys/sys.vsql](../../../../../pkg/sys/sys.vsql)

--- a/uspecs/changes/archive/2604/2604221416-fix-reinvite-after-removal/impl.md
+++ b/uspecs/changes/archive/2604/2604221416-fix-reinvite-after-removal/impl.md
@@ -1,0 +1,26 @@
+# Implementation plan: Fix user cannot be reinvited after removal
+
+## Construction
+
+### Tests
+
+- [x] update: [pkg/sys/it/impl_invite_test.go](../../../../../pkg/sys/it/impl_invite_test.go)
+  - add: `TestReinviteAfterCancelAcceptedInvite` - test that reproduces the bug scenario
+- [x] run tests to verify the new test fails before fix is applied
+- [x] review
+
+### Fix
+
+- [x] update: [pkg/sys/invite/utils.go](../../../../../pkg/sys/invite/utils.go)
+  - refactor: `SubjectExistsByLogin()` returns `(subjectID, isActive, err)` instead of just `(subjectID, err)`
+- [x] update: [pkg/sys/invite/impl_applyjoinworkspace.go](../../../../../pkg/sys/invite/impl_applyjoinworkspace.go)
+  - fix: use `isActive` to decide skip, use `existingSubjectID` for reactivation
+  - fix: reactivate existing Subject by splitting update into two CUD calls (IsActive first, then Roles)
+  - refactor: removed separate lookup by `Invite.SubjectID` (no longer needed)
+  - refactor: removed unused `collection` import
+  - add: comments explaining `Login` vs `ActualLogin` fields
+- [x] update: [pkg/sys/invite/impl_initiateinvitationbyemail.go](../../../../../pkg/sys/invite/impl_initiateinvitationbyemail.go)
+  - fix: use `subjectIsActive` instead of `existingSubjectID > 0`
+- [x] update: [pkg/sys/sys.vsql](../../../../../pkg/sys/sys.vsql)
+  - add: comments explaining `Login` and `ActualLogin` fields in Invite table
+- [x] run tests to verify that now test passes after fix is applied


### PR DESCRIPTION
registered_at: 2026-04-22T09:14:48Z
change_id: 2604220914-fix-reinvite-after-removal
baseline: cde799cbe15807fbd753b5c4a00c53efc1b8d4af
issue_url: https://untill.atlassian.net/browse/AIR-3664
archived_at: 2026-04-22T14:16:32Z

# Change request: Fix user cannot be reinvited after removal

## Why

When a joined user is removed from a workspace (via cancel accepted invite), the `view.sys.SubjectsIdx` still contains the old Subject entry. On reinvitation, `SubjectExistsByLogin()` finds this entry and `ApplyJoinWorkspace` skips creating the Subject, leaving the invite stuck.

The protection message appears:
```text
skip aproj.sys.ApplyJoinWorkspace because cdoc.sys.SubjectID.{id} exists already by cdoc.sys.Invite.Login "{email}"
```

This happens because:

- User joins workspace -> `cdoc.sys.Subject` created, `view.sys.SubjectsIdx` populated with login -> SubjectID mapping
- Admin removes user -> `cdoc.sys.Subject.sys.IsActive` set to `false`, but `view.sys.SubjectsIdx` entry remains
- Admin reinvites same email -> new invite created, user clicks link
- `ap.sys.ApplyJoinWorkspace` checks `SubjectExistsByLogin()` which queries `view.sys.SubjectsIdx`
- View returns old (now inactive) SubjectID -> projector skips Subject creation to prevent unique constraint violation
- Invite never transitions to `State_Joined`, user stuck

## What

Refactor `SubjectExistsByLogin()` to return both SubjectID and isActive status:

- Return `(subjectID, isActive, err)` instead of just `(subjectID, err)`
- Callers can decide: skip if active, reactivate if inactive, create if not found
- `ApplyJoinWorkspace` uses `existingSubjectID` directly for reactivation (no separate lookup needed)

## How

- Write failing integration test first (`TestReinviteAfterCancelAcceptedInvite`)
- Refactor `SubjectExistsByLogin()` to return `(subjectID, isActive, err)`
- Update `ApplyJoinWorkspace` to use `isActive` for skip check, `existingSubjectID` for reactivation
- Update `InitiateInvitationByEMail` to use `subjectIsActive` instead of `existingSubjectID > 0`


---
(truncated -- see change.md for full details)
