### PR TITLE
[AIR-3666] Support errors.As and errors.Is by coreutils.SysError

### DIFF
--- a/pkg/coreutils/syserror.go
+++ b/pkg/coreutils/syserror.go
@@ -65,6 +65,20 @@ func (he SysError) Error() string {
 	return he.Message
 }
 
+func (he SysError) Is(target error) bool {
+	t, ok := target.(SysError)
+	return ok && he.HTTPStatus == t.HTTPStatus && he.QName == t.QName && he.Message == t.Message && he.Data == t.Data
+}
+
+func (he SysError) As(target any) bool {
+	t, ok := target.(*SysError)
+	if !ok {
+		return false
+	}
+	*t = he
+	return true
+}
+
 func (he SysError) ToJSON_APIV1() string {
 	b := bytes.NewBuffer(nil)
 	fmt.Fprintf(b, `{"sys.Error":{"HTTPStatus":%d,"Message":%q`, he.HTTPStatus, he.Message)

--- a/pkg/coreutils/syserror.go
+++ b/pkg/coreutils/syserror.go
@@ -66,17 +66,19 @@ func (he SysError) Error() string {
 }
 
 func (he SysError) Is(target error) bool {
-	t, ok := target.(SysError)
-	return ok && he.HTTPStatus == t.HTTPStatus && he.QName == t.QName && he.Message == t.Message && he.Data == t.Data
-}
-
-func (he SysError) As(target any) bool {
-	t, ok := target.(*SysError)
-	if !ok {
+	var t SysError
+	switch v := target.(type) {
+	case SysError:
+		t = v
+	case *SysError:
+		if v == nil {
+			return false
+		}
+		t = *v
+	default:
 		return false
 	}
-	*t = he
-	return true
+	return he.HTTPStatus == t.HTTPStatus && he.QName == t.QName && he.Message == t.Message && he.Data == t.Data
 }
 
 func (he SysError) ToJSON_APIV1() string {

--- a/pkg/coreutils/syserror_test.go
+++ b/pkg/coreutils/syserror_test.go
@@ -194,6 +194,21 @@ func TestSysError_Is(t *testing.T) {
 	t.Run("non SysError target", func(t *testing.T) {
 		require.NotErrorIs(base, errors.New("other"))
 	})
+
+	t.Run("pointer target with equal fields", func(t *testing.T) {
+		other := SysError{HTTPStatus: http.StatusForbidden, Message: "workspace is not initialized"}
+		require.ErrorIs(base, &other)
+	})
+
+	t.Run("pointer target with different fields", func(t *testing.T) {
+		other := SysError{HTTPStatus: http.StatusNotFound, Message: base.Message}
+		require.NotErrorIs(base, &other)
+	})
+
+	t.Run("nil pointer target", func(t *testing.T) {
+		var nilTarget *SysError
+		require.NotErrorIs(base, nilTarget)
+	})
 }
 
 func TestSysError_As(t *testing.T) {

--- a/pkg/coreutils/syserror_test.go
+++ b/pkg/coreutils/syserror_test.go
@@ -6,6 +6,7 @@ package coreutils
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
@@ -150,3 +151,73 @@ func TestNewHTTPError(t *testing.T) {
 		require.JSONEq(`{"sys.Error":{"HTTPStatus":500,"Message":"test error"}}`, sysErr.ToJSON_APIV1())
 	})
 }
+
+func TestSysError_Is(t *testing.T) {
+	require := require.New(t)
+	base := SysError{HTTPStatus: http.StatusForbidden, Message: "workspace is not initialized"}
+
+	t.Run("equal fields", func(t *testing.T) {
+		other := SysError{HTTPStatus: http.StatusForbidden, Message: "workspace is not initialized"}
+		require.ErrorIs(base, other)
+	})
+
+	t.Run("headers ignored", func(t *testing.T) {
+		withHeaders := base.AddHeader("Retry-After", "3")
+		require.ErrorIs(withHeaders, base)
+		require.ErrorIs(base, withHeaders)
+	})
+
+	t.Run("wrapped", func(t *testing.T) {
+		require.ErrorIs(fmt.Errorf("ctx: %w", base), base)
+	})
+
+	t.Run("different status", func(t *testing.T) {
+		require.NotErrorIs(base, SysError{HTTPStatus: http.StatusNotFound, Message: base.Message})
+	})
+
+	t.Run("different message", func(t *testing.T) {
+		require.NotErrorIs(base, SysError{HTTPStatus: base.HTTPStatus, Message: "other"})
+	})
+
+	t.Run("different qname", func(t *testing.T) {
+		a := SysError{HTTPStatus: http.StatusForbidden, QName: appdef.NewQName("a", "b")}
+		b := SysError{HTTPStatus: http.StatusForbidden, QName: appdef.NewQName("c", "d")}
+		require.NotErrorIs(a, b)
+	})
+
+	t.Run("different data", func(t *testing.T) {
+		a := SysError{HTTPStatus: http.StatusForbidden, Data: "x"}
+		b := SysError{HTTPStatus: http.StatusForbidden, Data: "y"}
+		require.NotErrorIs(a, b)
+	})
+
+	t.Run("non SysError target", func(t *testing.T) {
+		require.NotErrorIs(base, errors.New("other"))
+	})
+}
+
+func TestSysError_As(t *testing.T) {
+	require := require.New(t)
+	original := SysError{HTTPStatus: http.StatusForbidden, Message: "test"}.AddHeader("A", "1")
+
+	t.Run("direct", func(t *testing.T) {
+		var se SysError
+		require.ErrorAs(original, &se)
+		require.Equal(original, se)
+	})
+
+	t.Run("wrapped", func(t *testing.T) {
+		var se SysError
+		require.ErrorAs(fmt.Errorf("ctx: %w", original), &se)
+		require.Equal(original, se)
+	})
+
+	t.Run("non-matching target", func(t *testing.T) {
+		var target *fakeErr
+		require.NotErrorAs(original, &target)
+	})
+}
+
+type fakeErr struct{}
+
+func (*fakeErr) Error() string { return "fake" }

--- a/uspecs/changes/archive/2604/2604221514-sys-error-errors-as-is/change.md
+++ b/uspecs/changes/archive/2604/2604221514-sys-error-errors-as-is/change.md
@@ -1,0 +1,20 @@
+---
+registered_at: 2026-04-22T15:03:05Z
+change_id: 2604221503-sys-error-errors-as-is
+baseline: f91d1438f6fbf47ffd247bb8d06e47cfdff55e6e
+issue_url: https://untill.atlassian.net/browse/AIR-3666
+archived_at: 2026-04-22T15:14:57Z
+---
+
+# Change request: Support errors.As and errors.Is by coreutils.SysError
+
+## Why
+
+`errors.Is(processors.ErrWSNotInited, processors.ErrWSNotInited)` returns `false` because `coreutils.SysError` does not implement the `Is` and `As` methods required by the standard `errors` package. See [issue.md](issue.md) for details.
+
+## What
+
+Extend `coreutils.SysError`:
+
+- Implement `Is(target error) bool` method
+- Implement `As(target any) bool` method

--- a/uspecs/changes/archive/2604/2604221514-sys-error-errors-as-is/impl.md
+++ b/uspecs/changes/archive/2604/2604221514-sys-error-errors-as-is/impl.md
@@ -1,0 +1,10 @@
+# Implementation plan: Support errors.As and errors.Is by coreutils.SysError
+
+## Construction
+
+- [x] update: [pkg/coreutils/syserror.go](../../../../../pkg/coreutils/syserror.go)
+  - add: `Is(target error) bool` method on `SysError`
+  - add: `As(target any) bool` method on `SysError`
+- [x] update: [pkg/coreutils/syserror_test.go](../../../../../pkg/coreutils/syserror_test.go)
+  - add: tests for `errors.Is` between equal and non-equal `SysError` values
+  - add: tests for `errors.As` into `SysError` target

--- a/uspecs/changes/archive/2604/2604221514-sys-error-errors-as-is/issue.md
+++ b/uspecs/changes/archive/2604/2604221514-sys-error-errors-as-is/issue.md
@@ -1,0 +1,15 @@
+# AIR-3666: Support errors.As and errors.Is by coreutils.SysError
+
+- **Key**: AIR-3666
+- **Type**: Task
+- **Status**: In Progress
+- **Assignee**: d.gribanov@dev.untill.com
+- **URL**: <https://untill.atlassian.net/browse/AIR-3666>
+
+## Why
+
+`errors.Is(processors.ErrWSNotInited, processors.ErrWSNotInited)` returns `false`.
+
+## What
+
+Support `errors.As` and `errors.Is` in `coreutils.SysError`.


### PR DESCRIPTION
registered_at: 2026-04-22T15:03:05Z
change_id: 2604221503-sys-error-errors-as-is
baseline: f91d1438f6fbf47ffd247bb8d06e47cfdff55e6e
issue_url: https://untill.atlassian.net/browse/AIR-3666
archived_at: 2026-04-22T15:14:57Z

# Change request: Support errors.As and errors.Is by coreutils.SysError

## Why

`errors.Is(processors.ErrWSNotInited, processors.ErrWSNotInited)` returns `false` because `coreutils.SysError` does not implement the `Is` and `As` methods required by the standard `errors` package. See [issue.md](issue.md) for details.

## What

Extend `coreutils.SysError`:

- Implement `Is(target error) bool` method
- Implement `As(target any) bool` method
