### PR TITLE
Fix stuck invite states recovery

### DIFF
--- a/pkg/sys/invite/consts.go
+++ b/pkg/sys/invite/consts.go
@@ -96,9 +96,11 @@ const (
 var (
 	inviteValidStates = map[appdef.QName]map[State]bool{
 		qNameCmdInitiateInvitationByEMail: {
-			State_Cancelled: true,
-			State_Left:      true,
-			State_Invited:   true,
+			State_Cancelled:   true,
+			State_Left:        true,
+			State_Invited:     true,
+			State_ToBeInvited: true, // recovery from stuck state (projector failed before email sent)
+			State_ToBeJoined:  true, // recovery from stuck state (projector failed during join)
 		},
 		qNameCmdInitiateJoinWorkspace: {
 			State_Invited: true,
@@ -113,7 +115,9 @@ var (
 			State_Joined: true,
 		},
 		qNameCmdCancelSentInvite: {
-			State_Invited: true,
+			State_Invited:     true,
+			State_ToBeInvited: true, // recovery from stuck state (projector failed before email sent)
+			State_ToBeJoined:  true, // recovery from stuck state (projector failed during join)
 		},
 	}
 	reInviteAllowedForState = map[State]bool{
@@ -123,5 +127,6 @@ var (
 		// https://github.com/voedger/voedger/issues/3698
 		State_ToBeInvited: true,
 		State_Invited:     true,
+		State_ToBeJoined:  true, // recovery from stuck state (projector failed during join)
 	}
 )

--- a/pkg/sys/it/impl_invite_test.go
+++ b/pkg/sys/it/impl_invite_test.go
@@ -458,3 +458,79 @@ func TestResendInvitation(t *testing.T) {
 	require.Equal(sentEmail1Data[3], sentEmail2Data[3])
 	require.Equal(sentEmail1Data[4], sentEmail2Data[4])
 }
+
+// TestRecoverFromStuckInviteStates tests that invites stuck in transitional states
+// (ToBeInvited, ToBeJoined) can be recovered via re-invite or cancel.
+// This can happen when async projectors fail (e.g., email send failed, federation call failed).
+func TestRecoverFromStuckInviteStates(t *testing.T) {
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	prn := vit.GetPrincipal(istructs.AppQName_test1_app1, it.TestEmail)
+	ws := vit.CreateWorkspace(it.SimpleWSParams("TestRecoverStuckStates_ws"), prn)
+
+	t.Run("re-invite from State_ToBeInvited", func(t *testing.T) {
+		email := fmt.Sprintf("stuck_tobeinvited_reinvite_%d@test.com", vit.NextNumber())
+		inviteID := InitiateInvitationByEMail(vit, ws, vit.Now().UnixMilli(), email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+		vit.CaptureEmail()
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+
+		// Simulate stuck state by forcing State_ToBeInvited via direct CUD
+		setInviteState(vit, ws, inviteID, invite.State_ToBeInvited)
+
+		// Re-invite should succeed from State_ToBeInvited
+		InitiateInvitationByEMail(vit, ws, vit.Now().UnixMilli(), email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+		vit.CaptureEmail()
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+	})
+
+	t.Run("cancel from State_ToBeInvited", func(t *testing.T) {
+		email := fmt.Sprintf("stuck_tobeinvited_cancel_%d@test.com", vit.NextNumber())
+		inviteID := InitiateInvitationByEMail(vit, ws, vit.Now().UnixMilli(), email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+		vit.CaptureEmail()
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+
+		// Simulate stuck state
+		setInviteState(vit, ws, inviteID, invite.State_ToBeInvited)
+
+		// Cancel should succeed from State_ToBeInvited
+		vit.PostWS(ws, "c.sys.CancelSentInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, inviteID))
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeCancelled, invite.State_Cancelled)
+	})
+
+	t.Run("re-invite from State_ToBeJoined", func(t *testing.T) {
+		email := fmt.Sprintf("stuck_tobejoined_reinvite_%d@test.com", vit.NextNumber())
+		inviteID := InitiateInvitationByEMail(vit, ws, vit.Now().UnixMilli(), email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+		vit.CaptureEmail()
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+
+		// Simulate stuck state by forcing State_ToBeJoined via direct CUD
+		setInviteState(vit, ws, inviteID, invite.State_ToBeJoined)
+
+		// Re-invite should succeed from State_ToBeJoined
+		InitiateInvitationByEMail(vit, ws, vit.Now().UnixMilli(), email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+		vit.CaptureEmail()
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+	})
+
+	t.Run("cancel from State_ToBeJoined", func(t *testing.T) {
+		email := fmt.Sprintf("stuck_tobejoined_cancel_%d@test.com", vit.NextNumber())
+		inviteID := InitiateInvitationByEMail(vit, ws, vit.Now().UnixMilli(), email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+		vit.CaptureEmail()
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+
+		// Simulate stuck state
+		setInviteState(vit, ws, inviteID, invite.State_ToBeJoined)
+
+		// Cancel should succeed from State_ToBeJoined
+		vit.PostWS(ws, "c.sys.CancelSentInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, inviteID))
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeCancelled, invite.State_Cancelled)
+	})
+}
+
+// setInviteState directly sets invite state via CUD (for testing stuck state recovery)
+func setInviteState(vit *it.VIT, ws *it.AppWorkspace, inviteID istructs.RecordID, state invite.State) {
+	vit.T.Helper()
+	body := fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"State":%d}}]}`, inviteID, state)
+	vit.PostWS(ws, "c.sys.CUD", body)
+}

--- a/uspecs/changes/archive/2604/2604240854-fix-stuck-invite-states/change.md
+++ b/uspecs/changes/archive/2604/2604240854-fix-stuck-invite-states/change.md
@@ -1,0 +1,36 @@
+---
+registered_at: 2026-04-24T08:20:45Z
+change_id: 2604240820-fix-stuck-invite-states
+baseline: f91d1438f6fbf47ffd247bb8d06e47cfdff55e6e
+archived_at: 2026-04-24T08:54:40Z
+---
+
+# Change request: Fix stuck invite states recovery
+
+## Why
+
+Invitations can get stuck in transitional states (`State_ToBeInvited`, `State_ToBeJoined`) when async projectors fail. Previously, the `ApplyJoinWorkspace` projector had an early-return bug that skipped updating invite state when an inactive Subject existed, leaving invites permanently stuck in `State_ToBeJoined`. Even after fixing the projector (change 2604221416), already-stuck invites cannot be recovered because commands `InitiateInvitationByEMail` and `CancelSentInvite` don't accept these transitional states.
+
+## What
+
+Allow recovery from stuck transitional invite states:
+
+- Add `State_ToBeInvited` and `State_ToBeJoined` to valid states for `InitiateInvitationByEMail`
+- Add `State_ToBeInvited` and `State_ToBeJoined` to valid states for `CancelSentInvite`
+- Add `State_ToBeJoined` to `reInviteAllowedForState`
+
+## How
+
+Update `inviteValidStates` and `reInviteAllowedForState` maps in `pkg/sys/invite/consts.go`.
+
+Add integration tests:
+
+- Test re-invite from `State_ToBeInvited` (email send failed scenario)
+- Test re-invite from `State_ToBeJoined` (join projector failed scenario)
+- Test cancel from `State_ToBeInvited`
+- Test cancel from `State_ToBeJoined`
+
+References:
+
+- [pkg/sys/invite/consts.go](../../../../../pkg/sys/invite/consts.go)
+- [pkg/sys/it/impl_invite_test.go](../../../../../pkg/sys/it/impl_invite_test.go)

--- a/uspecs/changes/archive/2604/2604240854-fix-stuck-invite-states/impl.md
+++ b/uspecs/changes/archive/2604/2604240854-fix-stuck-invite-states/impl.md
@@ -1,0 +1,11 @@
+# Implementation plan: Fix stuck invite states recovery
+
+## Construction
+
+- [x] update: [pkg/sys/invite/consts.go](../../../../../pkg/sys/invite/consts.go)
+  - add: `State_ToBeInvited` and `State_ToBeJoined` to `inviteValidStates[InitiateInvitationByEMail]`
+  - add: `State_ToBeInvited` and `State_ToBeJoined` to `inviteValidStates[CancelSentInvite]`
+  - add: `State_ToBeJoined` to `reInviteAllowedForState`
+- [x] update: [pkg/sys/it/impl_invite_test.go](../../../../../pkg/sys/it/impl_invite_test.go)
+  - add: `TestRecoverFromStuckInviteStates` with subtests for re-invite and cancel from stuck states
+  - add: `setInviteState` helper function for testing


### PR DESCRIPTION
registered_at: 2026-04-24T08:20:45Z
change_id: 2604240820-fix-stuck-invite-states
baseline: f91d1438f6fbf47ffd247bb8d06e47cfdff55e6e
archived_at: 2026-04-24T08:54:40Z

# Change request: Fix stuck invite states recovery

## Why

Invitations can get stuck in transitional states (`State_ToBeInvited`, `State_ToBeJoined`) when async projectors fail. Previously, the `ApplyJoinWorkspace` projector had an early-return bug that skipped updating invite state when an inactive Subject existed, leaving invites permanently stuck in `State_ToBeJoined`. Even after fixing the projector (change 2604221416), already-stuck invites cannot be recovered because commands `InitiateInvitationByEMail` and `CancelSentInvite` don't accept these transitional states.

## What

Allow recovery from stuck transitional invite states:

- Add `State_ToBeInvited` and `State_ToBeJoined` to valid states for `InitiateInvitationByEMail`
- Add `State_ToBeInvited` and `State_ToBeJoined` to valid states for `CancelSentInvite`
- Add `State_ToBeJoined` to `reInviteAllowedForState`

## How

Update `inviteValidStates` and `reInviteAllowedForState` maps in `pkg/sys/invite/consts.go`.

Add integration tests:

- Test re-invite from `State_ToBeInvited` (email send failed scenario)
- Test re-invite from `State_ToBeJoined` (join projector failed scenario)
- Test cancel from `State_ToBeInvited`
- Test cancel from `State_ToBeJoined`

References:

- [pkg/sys/invite/consts.go](../../../../../pkg/sys/invite/consts.go)
- [pkg/sys/it/impl_invite_test.go](../../../../../pkg/sys/it/impl_invite_test.go)
