### PR TITLE
[AIR-3692] voedger: exclude paths from golangci-lint

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,6 +32,7 @@ with:
   short_test: "true" # Run short tests only
   go_race: "false" # Enable race detector
   install_tinygo: "true" # Install TinyGo
+  lint_exclude: "cmd/vpm/testdata pkg/iextengine/wazero/_testdata pkg/sys/it/testdata" # Paths skipped by the linter
 secrets:
   reporeading_token: ${{ secrets.REPOREADING_TOKEN }}
 ```
@@ -58,6 +59,7 @@ with:
   running_workflow: "CI pkg-cmd PR" # Cancel duplicates
   go_race: "false"
   install_tinygo: "true"
+  lint_exclude: "cmd/vpm/testdata pkg/iextengine/wazero/_testdata pkg/sys/it/testdata" # Paths skipped by the linter
 secrets:
   reporeading_token: ${{ secrets.REPOREADING_TOKEN }}
 ```
@@ -115,6 +117,7 @@ Scripts called from `https://raw.githubusercontent.com/untillpro/ci-action/main/
 
 1. Calls `untillpro/ci-action/.github/workflows/ci.yml@main`
    - short_test: true, go_race: false, install_tinygo: true
+   - lint_exclude: `cmd/vpm/testdata`, `pkg/iextengine/wazero/_testdata`, `pkg/sys/it/testdata`
 2. Calls `cd-voedger.yml` to build Docker image
 
 ### PR (ci_pr.yml)
@@ -125,6 +128,7 @@ Scripts called from `https://raw.githubusercontent.com/untillpro/ci-action/main/
 
 1. Calls `untillpro/ci-action/.github/workflows/ci.yml@main`
    - go_race: true, short_test: false (full tests)
+   - lint_exclude: `cmd/vpm/testdata`, `pkg/iextengine/wazero/_testdata`, `pkg/sys/it/testdata`
 2. On failure: Creates issue via `create_issue.yml`
 3. Calls `cd-voedger.yml` to build Docker image
 

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -13,6 +13,7 @@ jobs:
       go_race: "true"
       short_test: "false"
       install_tinygo: "true"
+      lint_exclude: "cmd/vpm/testdata pkg/iextengine/wazero/_testdata pkg/sys/it/testdata"
     secrets:
       reporeading_token: ${{ secrets.REPOREADING_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       short_test: "true"
       go_race: "false"
       install_tinygo: "true"
+      lint_exclude: "cmd/vpm/testdata pkg/iextengine/wazero/_testdata pkg/sys/it/testdata"
     secrets:
       reporeading_token: ${{ secrets.REPOREADING_TOKEN }}
 

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -14,5 +14,6 @@ jobs:
       running_workflow: "CI pkg-cmd PR"
       go_race: "false"
       install_tinygo: "true"
+      lint_exclude: "cmd/vpm/testdata pkg/iextengine/wazero/_testdata pkg/sys/it/testdata"
     secrets:
       reporeading_token: ${{ secrets.REPOREADING_TOKEN }}


### PR DESCRIPTION
voedger: exclude paths from golangci-lint 
https://untill.atlassian.net/browse/AIR-3692