### PR TITLE
[AIR-3704] Refactor invite flow - single projector and roles validation

### DIFF
--- a/pkg/iauthnz/utils.go
+++ b/pkg/iauthnz/utils.go
@@ -8,11 +8,10 @@ package iauthnz
 import (
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/istructs"
-	"slices"
 )
 
 func IsSystemRole(role appdef.QName) bool {
-	return slices.Contains(SysRoles, role)
+	return role.Pkg() == appdef.SysPackage
 }
 
 // returns NullQName if missing

--- a/pkg/iauthnz/utils_test.go
+++ b/pkg/iauthnz/utils_test.go
@@ -18,7 +18,11 @@ func TestIsSystemRole(t *testing.T) {
 	require.True(IsSystemRole(QNameRoleSystem))
 	require.True(IsSystemRole(QNameRoleWorkspaceAdmin))
 	require.True(IsSystemRole(QNameRoleWorkspaceDevice))
-	require.False(IsSystemRole(appdef.NewQName(appdef.SysPackage, "test")))
+	require.True(IsSystemRole(appdef.NewQName(appdef.SysPackage, "test")))
+	require.True(IsSystemRole(QNameRoleEveryone))
+	require.True(IsSystemRole(QNameRoleAnonymous))
+	require.True(IsSystemRole(QNameRoleAuthenticatedUser))
+	require.False(IsSystemRole(appdef.NewQName("test", "role")))
 }
 
 func TestRolesInheritance(t *testing.T) {

--- a/pkg/iauthnzimpl/impl_test.go
+++ b/pkg/iauthnzimpl/impl_test.go
@@ -176,7 +176,7 @@ func TestAuthenticate(t *testing.T) {
 	userToken, err := appTokens.IssueToken(time.Minute, &pp)
 	require.NoError(err)
 
-	testRole := appdef.NewQName(appdef.SysPackage, "test")
+	testRole := appdef.NewQName("test", "role")
 	apiKeyToken, err := IssueAPIToken(appTokens, time.Hour, []appdef.QName{
 		testRole,
 	}, 2, pp)
@@ -191,7 +191,7 @@ func TestAuthenticate(t *testing.T) {
 	deviceToken, err := appTokens.IssueToken(time.Minute, &pp)
 	require.NoError(err)
 
-	notIncludedRole := appdef.NewQName(appdef.SysPackage, "non-inluded")
+	notIncludedRole := appdef.NewQName("test", "non-included")
 	pp = payloads.PrincipalPayload{
 		Login:       login,
 		SubjectKind: istructs.SubjectKind_User,
@@ -445,7 +445,7 @@ func TestErrors(t *testing.T) {
 	})
 
 	t.Run("personal access token for NullWSID", func(t *testing.T) {
-		token, err := IssueAPIToken(appTokens, time.Hour, []appdef.QName{appdef.NewQName(appdef.SysPackage, "test")}, istructs.NullWSID, payloads.PrincipalPayload{})
+		token, err := IssueAPIToken(appTokens, time.Hour, []appdef.QName{appdef.NewQName("test", "role")}, istructs.NullWSID, payloads.PrincipalPayload{})
 		require.ErrorIs(err, ErrPersonalAccessTokenOnNullWSID)
 		require.Empty(token)
 	})

--- a/pkg/sys/invite/consts.go
+++ b/pkg/sys/invite/consts.go
@@ -32,6 +32,7 @@ var (
 	qNameAPApplyJoinWorkspace            = appdef.NewQName(appdef.SysPackage, "ApplyJoinWorkspace")
 	qNameAPApplyLeaveWorkspace           = appdef.NewQName(appdef.SysPackage, "ApplyLeaveWorkspace")
 	qNameAPApplyUpdateInviteRoles        = appdef.NewQName(appdef.SysPackage, "ApplyUpdateInviteRoles")
+	qNameAPApplyInviteEvents             = appdef.NewQName(appdef.SysPackage, "ApplyInviteEvents")
 	QNameCDocJoinedWorkspace             = appdef.NewQName(appdef.SysPackage, "JoinedWorkspace")
 	QNameCDocSubject                     = appdef.NewQName(appdef.SysPackage, "Subject")
 	QNameViewSubjectsIdx                 = appdef.NewQName(appdef.SysPackage, "ViewSubjectsIdx")
@@ -96,37 +97,47 @@ const (
 var (
 	inviteValidStates = map[appdef.QName]map[State]bool{
 		qNameCmdInitiateInvitationByEMail: {
-			State_Cancelled:   true,
-			State_Left:        true,
-			State_Invited:     true,
-			State_ToBeInvited: true, // recovery from stuck state (projector failed before email sent)
-			State_ToBeJoined:  true, // recovery from stuck state (projector failed during join)
+			State_Cancelled:     true,
+			State_Left:          true,
+			State_Invited:       true,
+			State_ToBeInvited:   true,
+			State_ToBeJoined:    true, // dead: was Invited, join never completed
+			State_ToBeCancelled: true, // dead: was Joined, cancel never completed
+			State_ToBeLeft:      true, // dead: was Joined, leave never completed
+			State_ToUpdateRoles: true, // dead: was Joined, role update never completed
 		},
 		qNameCmdInitiateJoinWorkspace: {
-			State_Invited: true,
+			State_Invited:    true,
+			State_ToBeJoined: true, // dead: retry stuck join
 		},
 		qNameCmdInitiateUpdateInviteRoles: {
-			State_Joined: true,
+			State_Joined:        true,
+			State_ToUpdateRoles: true, // dead: retry stuck update
 		},
 		qNameCmdInitiateCancelAcceptedInvite: {
-			State_Joined: true,
+			State_Joined:        true,
+			State_ToBeCancelled: true, // dead: retry stuck cancel
+			State_ToUpdateRoles: true, // dead: was Joined
 		},
 		qNameCmdInitiateLeaveWorkspace: {
-			State_Joined: true,
+			State_Joined:        true,
+			State_ToBeLeft:      true, // dead: retry stuck leave
+			State_ToUpdateRoles: true, // dead: was Joined
 		},
 		qNameCmdCancelSentInvite: {
 			State_Invited:     true,
-			State_ToBeInvited: true, // recovery from stuck state (projector failed before email sent)
-			State_ToBeJoined:  true, // recovery from stuck state (projector failed during join)
+			State_ToBeInvited: true,
+			State_ToBeJoined:  true, // dead: cancel during stuck join
 		},
 	}
 	reInviteAllowedForState = map[State]bool{
-		State_Cancelled: true,
-		State_Left:      true,
-
-		// https://github.com/voedger/voedger/issues/3698
-		State_ToBeInvited: true,
-		State_Invited:     true,
-		State_ToBeJoined:  true, // recovery from stuck state (projector failed during join)
+		State_Cancelled:     true,
+		State_Left:          true,
+		State_ToBeInvited:   true,
+		State_Invited:       true,
+		State_ToBeJoined:    true, // dead: join never completed
+		State_ToBeCancelled: true, // dead: cancel never completed
+		State_ToBeLeft:      true, // dead: leave never completed
+		State_ToUpdateRoles: true, // dead: role update never completed
 	}
 )

--- a/pkg/sys/invite/consts.go
+++ b/pkg/sys/invite/consts.go
@@ -97,47 +97,54 @@ const (
 var (
 	inviteValidStates = map[appdef.QName]map[State]bool{
 		qNameCmdInitiateInvitationByEMail: {
-			State_Cancelled:     true,
-			State_Left:          true,
-			State_Invited:       true,
-			State_ToBeInvited:   true,
-			State_ToBeJoined:    true, // dead: was Invited, join never completed
-			State_ToBeCancelled: true, // dead: was Joined, cancel never completed
-			State_ToBeLeft:      true, // dead: was Joined, leave never completed
-			State_ToUpdateRoles: true, // dead: was Joined, role update never completed
+			State_Cancelled:   true,
+			State_Left:        true,
+			State_Invited:     true,
+			State_ToBeInvited: true,
+			// legacy ToBe* states: allow re-invite on stuck records from old data
+			State_ToBeJoined:    true,
+			State_ToBeCancelled: true,
+			State_ToBeLeft:      true,
+			State_ToUpdateRoles: true,
 		},
 		qNameCmdInitiateJoinWorkspace: {
-			State_Invited:    true,
-			State_ToBeJoined: true, // dead: retry stuck join
+			State_Invited: true,
+			// legacy: retry join on stuck record from old data
+			State_ToBeJoined: true,
 		},
 		qNameCmdInitiateUpdateInviteRoles: {
-			State_Joined:        true,
-			State_ToUpdateRoles: true, // dead: retry stuck update
+			State_Joined: true,
+			// legacy: retry role update on stuck record from old data
+			State_ToUpdateRoles: true,
 		},
 		qNameCmdInitiateCancelAcceptedInvite: {
-			State_Joined:        true,
-			State_ToBeCancelled: true, // dead: retry stuck cancel
-			State_ToUpdateRoles: true, // dead: was Joined
+			State_Joined: true,
+			// legacy ToBe*/ToUpdateRoles states: cancel stuck records from old data
+			State_ToBeCancelled: true,
+			State_ToUpdateRoles: true,
 		},
 		qNameCmdInitiateLeaveWorkspace: {
-			State_Joined:        true,
-			State_ToBeLeft:      true, // dead: retry stuck leave
-			State_ToUpdateRoles: true, // dead: was Joined
+			State_Joined: true,
+			// legacy ToBe*/ToUpdateRoles states: leave stuck records from old data
+			State_ToBeLeft:      true,
+			State_ToUpdateRoles: true,
 		},
 		qNameCmdCancelSentInvite: {
 			State_Invited:     true,
 			State_ToBeInvited: true,
-			State_ToBeJoined:  true, // dead: cancel during stuck join
+			// legacy: cancel stuck record from old data
+			State_ToBeJoined: true,
 		},
 	}
 	reInviteAllowedForState = map[State]bool{
-		State_Cancelled:     true,
-		State_Left:          true,
-		State_ToBeInvited:   true,
-		State_Invited:       true,
-		State_ToBeJoined:    true, // dead: join never completed
-		State_ToBeCancelled: true, // dead: cancel never completed
-		State_ToBeLeft:      true, // dead: leave never completed
-		State_ToUpdateRoles: true, // dead: role update never completed
+		State_Cancelled:   true,
+		State_Left:        true,
+		State_ToBeInvited: true,
+		State_Invited:     true,
+		// legacy ToBe* states: allow re-invite on stuck records from old data
+		State_ToBeJoined:    true,
+		State_ToBeCancelled: true,
+		State_ToBeLeft:      true,
+		State_ToUpdateRoles: true,
 	}
 )

--- a/pkg/sys/invite/errors.go
+++ b/pkg/sys/invite/errors.go
@@ -17,4 +17,10 @@ var (
 
 	// [~server.invites.invite/err.State~impl]
 	ErrReInviteNotAllowedForState = errors.New("re-invite not allowed for state")
+
+	ErrRoleInvalid   = errors.New("invalid role")
+	ErrRolesEmpty    = errors.New("roles must not be empty")
+	ErrSystemRole    = errors.New("system roles cannot be assigned via invite")
+	ErrRoleNotFound  = errors.New("role not found in workspace")
+	ErrRoleDuplicate = errors.New("duplicate role")
 )

--- a/pkg/sys/invite/impl_applycancelacceptedinvite.go
+++ b/pkg/sys/invite/impl_applycancelacceptedinvite.go
@@ -5,82 +5,13 @@
 package invite
 
 import (
-	"fmt"
-
-	"github.com/voedger/voedger/pkg/appdef"
-	"github.com/voedger/voedger/pkg/coreutils/federation"
-	"github.com/voedger/voedger/pkg/goutils/httpu"
-	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istructs"
-	"github.com/voedger/voedger/pkg/itokens"
-	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
-	"github.com/voedger/voedger/pkg/sys"
 )
 
-func asyncProjectorApplyCancelAcceptedInvite(time timeu.ITime, federation federation.IFederation, tokens itokens.ITokens) istructs.Projector {
+// Deprecated: superseded by asyncProjectorApplyInviteEvents. Kept for backward compatibility only.
+func asyncProjectorApplyCancelAcceptedInvite() istructs.Projector {
 	return istructs.Projector{
 		Name: qNameAPApplyCancelAcceptedInvite,
-		Func: applyCancelAcceptedInvite(time, federation, tokens),
-	}
-}
-
-// AFTER EXEC c.sys.InitiateCancelAcceptedInvite
-func applyCancelAcceptedInvite(time timeu.ITime, federation federation.IFederation, tokens itokens.ITokens) func(event istructs.IPLogEvent, state istructs.IState, intents istructs.IIntents) (err error) {
-	return func(event istructs.IPLogEvent, s istructs.IState, intents istructs.IIntents) (err error) {
-		skbCDocInvite, err := s.KeyBuilder(sys.Storage_Record, QNameCDocInvite)
-		if err != nil {
-			return
-		}
-		skbCDocInvite.PutRecordID(sys.Storage_Record_Field_ID, event.ArgumentObject().AsRecordID(field_InviteID))
-		svCDocInvite, err := s.MustExist(skbCDocInvite)
-		if err != nil {
-			return
-		}
-
-		skbCDocSubject, err := s.KeyBuilder(sys.Storage_Record, QNameCDocSubject)
-		if err != nil {
-			return
-		}
-		skbCDocSubject.PutRecordID(sys.Storage_Record_Field_ID, svCDocInvite.AsRecordID(field_SubjectID))
-		svCDocSubject, err := s.MustExist(skbCDocSubject)
-		if err != nil {
-			return
-		}
-
-		appQName := s.App()
-
-		token, err := payloads.GetSystemPrincipalToken(tokens, appQName)
-		if err != nil {
-			return
-		}
-
-		// Update subject
-		_, err = federation.Func(
-			fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
-			fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"sys.IsActive":false}}]}`, svCDocSubject.AsRecordID(appdef.SystemField_ID)),
-			httpu.WithAuthorizeBy(token),
-			httpu.WithDiscardResponse())
-		if err != nil {
-			return
-		}
-
-		// Deactivate joined workspace
-		_, err = federation.Func(
-			fmt.Sprintf("api/%s/%d/c.sys.DeactivateJoinedWorkspace", appQName, svCDocInvite.AsInt64(Field_InviteeProfileWSID)),
-			fmt.Sprintf(`{"args":{"InvitingWorkspaceWSID":%d}}`, event.Workspace()),
-			httpu.WithAuthorizeBy(token),
-			httpu.WithDiscardResponse())
-		if err != nil {
-			return
-		}
-
-		// Update invite
-		_, err = federation.Func(
-			fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
-			fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"State":%d,"Updated":%d}}]}`, event.ArgumentObject().AsRecordID(field_InviteID), State_Cancelled, time.Now().UnixMilli()),
-			httpu.WithAuthorizeBy(token),
-			httpu.WithDiscardResponse())
-
-		return err
+		Func: deprecatedNullProjector,
 	}
 }

--- a/pkg/sys/invite/impl_applyinvitation.go
+++ b/pkg/sys/invite/impl_applyinvitation.go
@@ -5,104 +5,18 @@
 package invite
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/voedger/voedger/pkg/appdef"
-	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/federation"
-	"github.com/voedger/voedger/pkg/goutils/httpu"
-	"github.com/voedger/voedger/pkg/goutils/strconvu"
-	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istructs"
-	"github.com/voedger/voedger/pkg/itokens"
-	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
-	"github.com/voedger/voedger/pkg/state"
-	"github.com/voedger/voedger/pkg/sys"
-	"github.com/voedger/voedger/pkg/sys/authnz"
-	"github.com/voedger/voedger/pkg/sys/smtp"
 )
 
-func asyncProjectorApplyInvitation(time timeu.ITime, federation federation.IFederation, tokens itokens.ITokens, smtpCfg smtp.Cfg) istructs.Projector {
-	return istructs.Projector{
-		Name: qNameAPApplyInvitation,
-		Func: applyInvitationProjector(time, federation, tokens, smtpCfg),
-	}
+// Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.
+func deprecatedNullProjector(_ istructs.IPLogEvent, _ istructs.IState, _ istructs.IIntents) error {
+	return nil
 }
 
-// AFTER EXECUTE ON (InitiateInvitationByEMail)
-// [~server.invites.invite/ap.sys.Workspace.ApplyInvitation~impl]
-func applyInvitationProjector(time timeu.ITime, federation federation.IFederation, tokens itokens.ITokens, smtpCfg smtp.Cfg) func(event istructs.IPLogEvent, state istructs.IState, intents istructs.IIntents) (err error) {
-	return func(event istructs.IPLogEvent, s istructs.IState, intents istructs.IIntents) (err error) {
-		skbViewInviteIndex, err := s.KeyBuilder(sys.Storage_View, qNameViewInviteIndex)
-		if err != nil {
-			return
-		}
-		skbViewInviteIndex.PutInt32(field_Dummy, value_Dummy_One)
-		skbViewInviteIndex.PutString(Field_Login, event.ArgumentObject().AsString(Field_Email))
-		svViewInviteIndex, err := s.MustExist(skbViewInviteIndex)
-		if err != nil {
-			return
-		}
-
-		verificationCode := coreutils.EmailVerificationCode()
-		emailTemplate := coreutils.TruncateEmailTemplate(event.ArgumentObject().AsString(field_EmailTemplate))
-
-		skbCDocWorkspaceDescriptor, err := s.KeyBuilder(sys.Storage_Record, appdef.QNameCDocWorkspaceDescriptor)
-		if err != nil {
-			return
-		}
-		skbCDocWorkspaceDescriptor.PutQName(sys.Storage_Record_Field_Singleton, appdef.QNameCDocWorkspaceDescriptor)
-		svCDocWorkspaceDescriptor, err := s.MustExist(skbCDocWorkspaceDescriptor)
-		if err != nil {
-			return
-		}
-
-		replacer := strings.NewReplacer(
-			EmailTemplatePlaceholder_VerificationCode, verificationCode,
-			EmailTemplatePlaceholder_InviteID, strconvu.UintToString(svViewInviteIndex.AsRecordID(field_InviteID)),
-			EmailTemplatePlaceholder_WSID, strconvu.UintToString(event.Workspace()),
-			EmailTemplatePlaceholder_WSName, svCDocWorkspaceDescriptor.AsString(authnz.Field_WSName),
-			EmailTemplatePlaceholder_Email, event.ArgumentObject().AsString(Field_Email),
-		)
-
-		// Send invitation email
-		skbSendMail, err := s.KeyBuilder(sys.Storage_SendMail, appdef.NullQName)
-		if err != nil {
-			return
-		}
-		skbSendMail.PutString(sys.Storage_SendMail_Field_Subject, event.ArgumentObject().AsString(field_EmailSubject))
-		skbSendMail.PutString(sys.Storage_SendMail_Field_To, event.ArgumentObject().AsString(Field_Email))
-		skbSendMail.PutString(sys.Storage_SendMail_Field_Body, replacer.Replace(emailTemplate))
-		skbSendMail.PutString(sys.Storage_SendMail_Field_From, smtpCfg.GetFrom())
-		skbSendMail.PutString(sys.Storage_SendMail_Field_Host, smtpCfg.Host)
-		skbSendMail.PutInt32(sys.Storage_SendMail_Field_Port, smtpCfg.Port)
-		skbSendMail.PutString(sys.Storage_SendMail_Field_Username, smtpCfg.Username)
-
-		pwd, err := state.ReadSecret(s, smtpCfg.PwdSecret)
-		if err != nil {
-			return err
-		}
-		skbSendMail.PutString(sys.Storage_SendMail_Field_Password, pwd)
-
-		// Send invitation Email
-		_, err = intents.NewValue(skbSendMail)
-		if err != nil {
-			return
-		}
-
-		// Update cdoc.Invite State=Invited
-		appQName := s.App()
-		authToken, err := payloads.GetSystemPrincipalToken(tokens, appQName)
-		if err != nil {
-			return
-		}
-		_, err = federation.Func(
-			fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
-			fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"State":%d,"VerificationCode":"%s","Updated":%d}}]}`, svViewInviteIndex.AsRecordID(field_InviteID), State_Invited, verificationCode, time.Now().UnixMilli()),
-			httpu.WithAuthorizeBy(authToken),
-			httpu.WithDiscardResponse())
-
-		return err
+// Deprecated: superseded by asyncProjectorApplyInviteEvents. Kept for backward compatibility only.
+func asyncProjectorApplyInvitation() istructs.Projector {
+	return istructs.Projector{
+		Name: qNameAPApplyInvitation,
+		Func: deprecatedNullProjector,
 	}
 }

--- a/pkg/sys/invite/impl_applyinviteevents.go
+++ b/pkg/sys/invite/impl_applyinviteevents.go
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2026-present unTill Software Development Group B.V.
+ * @author Maxim Geraskin
+ */
+
+package invite
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/voedger/voedger/pkg/appdef"
+	"github.com/voedger/voedger/pkg/coreutils"
+	"github.com/voedger/voedger/pkg/coreutils/federation"
+	"github.com/voedger/voedger/pkg/goutils/httpu"
+	"github.com/voedger/voedger/pkg/goutils/strconvu"
+	"github.com/voedger/voedger/pkg/goutils/timeu"
+	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/itokens"
+	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
+	"github.com/voedger/voedger/pkg/state"
+	"github.com/voedger/voedger/pkg/sys"
+	"github.com/voedger/voedger/pkg/sys/authnz"
+	"github.com/voedger/voedger/pkg/sys/smtp"
+)
+
+var projectorValidStates = map[appdef.QName]map[State]bool{
+	qNameCmdInitiateInvitationByEMail:    {State_ToBeInvited: true},
+	qNameCmdInitiateJoinWorkspace:        {State_Invited: true, State_ToBeJoined: true},
+	qNameCmdInitiateUpdateInviteRoles:    {State_Joined: true, State_ToUpdateRoles: true},
+	qNameCmdInitiateCancelAcceptedInvite: {State_Joined: true, State_ToBeCancelled: true, State_ToUpdateRoles: true},
+	qNameCmdInitiateLeaveWorkspace:       {State_Joined: true, State_ToBeLeft: true, State_ToUpdateRoles: true},
+	qNameCmdCancelSentInvite:             {State_ToBeInvited: true, State_Invited: true, State_ToBeJoined: true},
+}
+
+func asyncProjectorApplyInviteEvents(time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens, smtpCfg smtp.Cfg) istructs.Projector {
+	return istructs.Projector{
+		Name: qNameAPApplyInviteEvents,
+		Func: applyInviteEvents(time, fed, tokens, smtpCfg),
+	}
+}
+
+func applyInviteEvents(time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens, smtpCfg smtp.Cfg) func(event istructs.IPLogEvent, state istructs.IState, intents istructs.IIntents) (err error) {
+	return func(event istructs.IPLogEvent, s istructs.IState, intents istructs.IIntents) (err error) {
+		cmd := event.QName()
+		inviteID, err := inviteIDFromEvent(cmd, event, s)
+		if err != nil {
+			return err
+		}
+		if inviteID == istructs.NullRecordID {
+			return nil
+		}
+		svCDocInvite, err := loadInviteByID(s, inviteID)
+		if err != nil {
+			return err
+		}
+		if !projectorValidStates[cmd][State(svCDocInvite.AsInt32(Field_State))] {
+			return nil
+		}
+		switch cmd {
+		case qNameCmdInitiateInvitationByEMail:
+			return handleApplyInvitation(event, s, intents, inviteID, time, fed, tokens, smtpCfg)
+		case qNameCmdInitiateJoinWorkspace:
+			return handleApplyJoinWorkspace(event, s, svCDocInvite, inviteID, time, fed, tokens)
+		case qNameCmdInitiateUpdateInviteRoles:
+			return handleApplyUpdateInviteRoles(event, s, intents, svCDocInvite, inviteID, time, fed, tokens, smtpCfg)
+		case qNameCmdInitiateCancelAcceptedInvite:
+			return handleApplyCancelAcceptedInvite(event, s, svCDocInvite, inviteID, time, fed, tokens)
+		case qNameCmdInitiateLeaveWorkspace:
+			return handleApplyLeaveWorkspace(event, s, svCDocInvite, inviteID, time, fed, tokens)
+		case qNameCmdCancelSentInvite:
+			return handleCancelSentInvite(event, s, inviteID, time, fed, tokens)
+		}
+		return nil
+	}
+}
+
+func inviteIDFromEvent(cmd appdef.QName, event istructs.IPLogEvent, s istructs.IState) (istructs.RecordID, error) {
+	switch cmd {
+	case qNameCmdInitiateInvitationByEMail:
+		skb, err := s.KeyBuilder(sys.Storage_View, qNameViewInviteIndex)
+		if err != nil {
+			return istructs.NullRecordID, err
+		}
+		skb.PutInt32(field_Dummy, value_Dummy_One)
+		skb.PutString(Field_Login, event.ArgumentObject().AsString(Field_Email))
+		sv, err := s.MustExist(skb)
+		if err != nil {
+			return istructs.NullRecordID, err
+		}
+		return sv.AsRecordID(field_InviteID), nil
+	case qNameCmdInitiateLeaveWorkspace:
+		for rec := range event.CUDs {
+			if rec.QName() == QNameCDocInvite {
+				return rec.ID(), nil
+			}
+		}
+		return istructs.NullRecordID, nil
+	default:
+		return event.ArgumentObject().AsRecordID(field_InviteID), nil
+	}
+}
+
+func loadInviteByID(s istructs.IState, inviteID istructs.RecordID) (istructs.IStateValue, error) {
+	skb, err := s.KeyBuilder(sys.Storage_Record, QNameCDocInvite)
+	if err != nil {
+		return nil, err
+	}
+	skb.PutRecordID(sys.Storage_Record_Field_ID, inviteID)
+	return s.MustExist(skb)
+}
+
+func getSystemToken(s istructs.IState, tokens itokens.ITokens) (string, appdef.AppQName, error) {
+	appQName := s.App()
+	token, err := payloads.GetSystemPrincipalToken(tokens, appQName)
+	return token, appQName, err
+}
+
+func cudURL(appQName appdef.AppQName, wsid istructs.WSID) string {
+	return fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, wsid)
+}
+
+func updateInviteViaCUD(fed federation.IFederation, appQName appdef.AppQName, wsid istructs.WSID, token string, inviteID istructs.RecordID, fields string) error {
+	_, err := fed.Func(
+		cudURL(appQName, wsid),
+		fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{%s}}]}`, inviteID, fields),
+		httpu.WithAuthorizeBy(token),
+		httpu.WithDiscardResponse())
+	return err
+}
+
+func deactivateSubjectAndJoinedWorkspace(fed federation.IFederation, appQName appdef.AppQName, wsid istructs.WSID, token string, svCDocInvite istructs.IStateValue) error {
+	subjectID := svCDocInvite.AsRecordID(field_SubjectID)
+	_, err := fed.Func(
+		cudURL(appQName, wsid),
+		fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"sys.IsActive":false}}]}`, subjectID),
+		httpu.WithAuthorizeBy(token),
+		httpu.WithDiscardResponse())
+	if err != nil {
+		return err
+	}
+	_, err = fed.Func(
+		fmt.Sprintf("api/%s/%d/c.sys.DeactivateJoinedWorkspace", appQName, svCDocInvite.AsInt64(Field_InviteeProfileWSID)),
+		fmt.Sprintf(`{"args":{"InvitingWorkspaceWSID":%d}}`, wsid),
+		httpu.WithAuthorizeBy(token),
+		httpu.WithDiscardResponse())
+	return err
+}
+
+func handleApplyInvitation(event istructs.IPLogEvent, s istructs.IState, intents istructs.IIntents, inviteID istructs.RecordID, time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens, smtpCfg smtp.Cfg) error {
+	verificationCode := coreutils.EmailVerificationCode()
+	emailTemplate := coreutils.TruncateEmailTemplate(event.ArgumentObject().AsString(field_EmailTemplate))
+
+	skbCDocWorkspaceDescriptor, err := s.KeyBuilder(sys.Storage_Record, appdef.QNameCDocWorkspaceDescriptor)
+	if err != nil {
+		return err
+	}
+	skbCDocWorkspaceDescriptor.PutQName(sys.Storage_Record_Field_Singleton, appdef.QNameCDocWorkspaceDescriptor)
+	svCDocWorkspaceDescriptor, err := s.MustExist(skbCDocWorkspaceDescriptor)
+	if err != nil {
+		return err
+	}
+
+	replacer := strings.NewReplacer(
+		EmailTemplatePlaceholder_VerificationCode, verificationCode,
+		EmailTemplatePlaceholder_InviteID, strconvu.UintToString(inviteID),
+		EmailTemplatePlaceholder_WSID, strconvu.UintToString(event.Workspace()),
+		EmailTemplatePlaceholder_WSName, svCDocWorkspaceDescriptor.AsString(authnz.Field_WSName),
+		EmailTemplatePlaceholder_Email, event.ArgumentObject().AsString(Field_Email),
+	)
+
+	if err = sendEmail(s, intents, smtpCfg,
+		event.ArgumentObject().AsString(field_EmailSubject),
+		event.ArgumentObject().AsString(Field_Email),
+		replacer.Replace(emailTemplate)); err != nil {
+		return err
+	}
+
+	token, appQName, err := getSystemToken(s, tokens)
+	if err != nil {
+		return err
+	}
+	return updateInviteViaCUD(fed, appQName, event.Workspace(), token, inviteID,
+		fmt.Sprintf(`"State":%d,"VerificationCode":%q,"Updated":%d`, State_Invited, verificationCode, time.Now().UnixMilli()))
+}
+
+func sendEmail(s istructs.IState, intents istructs.IIntents, smtpCfg smtp.Cfg, subject, to, body string) error {
+	skbSendMail, err := s.KeyBuilder(sys.Storage_SendMail, appdef.NullQName)
+	if err != nil {
+		return err
+	}
+	skbSendMail.PutString(sys.Storage_SendMail_Field_Subject, subject)
+	skbSendMail.PutString(sys.Storage_SendMail_Field_To, to)
+	skbSendMail.PutString(sys.Storage_SendMail_Field_Body, body)
+	skbSendMail.PutString(sys.Storage_SendMail_Field_From, smtpCfg.GetFrom())
+	skbSendMail.PutString(sys.Storage_SendMail_Field_Host, smtpCfg.Host)
+	skbSendMail.PutInt32(sys.Storage_SendMail_Field_Port, smtpCfg.Port)
+	skbSendMail.PutString(sys.Storage_SendMail_Field_Username, smtpCfg.Username)
+
+	pwd, err := state.ReadSecret(s, smtpCfg.PwdSecret)
+	if err != nil {
+		return err
+	}
+	skbSendMail.PutString(sys.Storage_SendMail_Field_Password, pwd)
+
+	_, err = intents.NewValue(skbSendMail)
+	return err
+}
+
+func handleApplyJoinWorkspace(event istructs.IPLogEvent, s istructs.IState, svCDocInvite istructs.IStateValue, inviteID istructs.RecordID, time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens) error {
+	login := svCDocInvite.AsString(field_ActualLogin)
+	existingSubjectID, isActive, err := SubjectExistsByLogin(login, s)
+	if err != nil {
+		return err
+	}
+
+	skbCDocWorkspaceDescriptor, err := s.KeyBuilder(sys.Storage_Record, appdef.QNameCDocWorkspaceDescriptor)
+	if err != nil {
+		return err
+	}
+	skbCDocWorkspaceDescriptor.PutQName(sys.Storage_Record_Field_Singleton, appdef.QNameCDocWorkspaceDescriptor)
+	svCDocWorkspaceDescriptor, err := s.MustExist(skbCDocWorkspaceDescriptor)
+	if err != nil {
+		return err
+	}
+
+	token, appQName, err := getSystemToken(s, tokens)
+	if err != nil {
+		return err
+	}
+
+	_, err = fed.Func(
+		fmt.Sprintf("api/%s/%d/c.sys.CreateJoinedWorkspace", appQName, svCDocInvite.AsInt64(Field_InviteeProfileWSID)),
+		fmt.Sprintf(`{"args":{"Roles":%q,"InvitingWorkspaceWSID":%d,"WSName":%q}}`,
+			svCDocInvite.AsString(Field_Roles), event.Workspace(), svCDocWorkspaceDescriptor.AsString(authnz.Field_WSName)),
+		httpu.WithAuthorizeBy(token),
+		httpu.WithDiscardResponse(),
+	)
+	if err != nil {
+		return err
+	}
+
+	var body string
+	switch {
+	case existingSubjectID == istructs.NullRecordID:
+		body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"sys.Subject","Login":%q,"Roles":%q,"SubjectKind":%d,"ProfileWSID":%d}}]}`,
+			svCDocInvite.AsString(field_ActualLogin), svCDocInvite.AsString(Field_Roles), svCDocInvite.AsInt32(authnz.Field_SubjectKind),
+			svCDocInvite.AsInt64(Field_InviteeProfileWSID))
+	case !isActive:
+		body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"sys.IsActive":true}}]}`, existingSubjectID)
+		_, err = fed.Func(
+			cudURL(appQName, event.Workspace()),
+			body,
+			httpu.WithAuthorizeBy(token),
+			httpu.WithDiscardResponse())
+		if err != nil {
+			return err
+		}
+		fallthrough
+	default:
+		body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"Roles":%q}}]}`, existingSubjectID, svCDocInvite.AsString(Field_Roles))
+	}
+	subjectID := existingSubjectID
+	if existingSubjectID == istructs.NullRecordID {
+		resp, err := fed.Func(
+			cudURL(appQName, event.Workspace()),
+			body,
+			httpu.WithAuthorizeBy(token))
+		if err != nil {
+			return err
+		}
+		subjectID = resp.NewID()
+	} else {
+		_, err = fed.Func(
+			cudURL(appQName, event.Workspace()),
+			body,
+			httpu.WithAuthorizeBy(token),
+			httpu.WithDiscardResponse())
+		if err != nil {
+			return err
+		}
+	}
+	return updateInviteViaCUD(fed, appQName, event.Workspace(), token, inviteID,
+		fmt.Sprintf(`"State":%d,"SubjectID":%d,"Updated":%d`, State_Joined, subjectID, time.Now().UnixMilli()))
+}
+
+func handleApplyUpdateInviteRoles(event istructs.IPLogEvent, s istructs.IState, intents istructs.IIntents, svCDocInvite istructs.IStateValue, inviteID istructs.RecordID, time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens, smtpCfg smtp.Cfg) error {
+	token, appQName, err := getSystemToken(s, tokens)
+	if err != nil {
+		return err
+	}
+
+	subjectID := svCDocInvite.AsRecordID(field_SubjectID)
+	_, err = fed.Func(
+		cudURL(appQName, event.Workspace()),
+		fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"Roles":%q}}]}`, subjectID, event.ArgumentObject().AsString(Field_Roles)),
+		httpu.WithAuthorizeBy(token),
+		httpu.WithDiscardResponse())
+	if err != nil {
+		return err
+	}
+
+	_, err = fed.Func(
+		fmt.Sprintf("api/%s/%d/c.sys.UpdateJoinedWorkspaceRoles", appQName, svCDocInvite.AsInt64(Field_InviteeProfileWSID)),
+		fmt.Sprintf(`{"args":{"Roles":%q,"InvitingWorkspaceWSID":%d}}`, event.ArgumentObject().AsString(Field_Roles), event.Workspace()),
+		httpu.WithAuthorizeBy(token),
+		httpu.WithDiscardResponse())
+	if err != nil {
+		return err
+	}
+
+	emailTemplate := coreutils.TruncateEmailTemplate(event.ArgumentObject().AsString(field_EmailTemplate))
+	replacer := strings.NewReplacer(EmailTemplatePlaceholder_Roles, event.ArgumentObject().AsString(Field_Roles))
+
+	if err = sendEmail(s, intents, smtpCfg,
+		event.ArgumentObject().AsString(field_EmailSubject),
+		svCDocInvite.AsString(Field_Email),
+		replacer.Replace(emailTemplate)); err != nil {
+		return err
+	}
+
+	return updateInviteViaCUD(fed, appQName, event.Workspace(), token, inviteID,
+		fmt.Sprintf(`"State":%d,"Updated":%d,"Roles":%q`, State_Joined, time.Now().UnixMilli(), event.ArgumentObject().AsString(Field_Roles)))
+}
+
+func handleApplyCancelAcceptedInvite(event istructs.IPLogEvent, s istructs.IState, svCDocInvite istructs.IStateValue, inviteID istructs.RecordID, time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens) error {
+	token, appQName, err := getSystemToken(s, tokens)
+	if err != nil {
+		return err
+	}
+
+	if err = deactivateSubjectAndJoinedWorkspace(fed, appQName, event.Workspace(), token, svCDocInvite); err != nil {
+		return err
+	}
+	return updateInviteViaCUD(fed, appQName, event.Workspace(), token, inviteID,
+		fmt.Sprintf(`"State":%d,"Updated":%d`, State_Cancelled, time.Now().UnixMilli()))
+}
+
+func handleApplyLeaveWorkspace(event istructs.IPLogEvent, s istructs.IState, svCDocInvite istructs.IStateValue, inviteID istructs.RecordID, time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens) error {
+	token, appQName, err := getSystemToken(s, tokens)
+	if err != nil {
+		return err
+	}
+
+	if err = deactivateSubjectAndJoinedWorkspace(fed, appQName, event.Workspace(), token, svCDocInvite); err != nil {
+		return err
+	}
+	return updateInviteViaCUD(fed, appQName, event.Workspace(), token, inviteID,
+		fmt.Sprintf(`"State":%d,"Updated":%d`, State_Left, time.Now().UnixMilli()))
+}
+
+func handleCancelSentInvite(event istructs.IPLogEvent, s istructs.IState, inviteID istructs.RecordID, time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens) error {
+	token, appQName, err := getSystemToken(s, tokens)
+	if err != nil {
+		return err
+	}
+
+	return updateInviteViaCUD(fed, appQName, event.Workspace(), token, inviteID,
+		fmt.Sprintf(`"State":%d,"Updated":%d`, State_Cancelled, time.Now().UnixMilli()))
+}

--- a/pkg/sys/invite/impl_applyinviteevents.go
+++ b/pkg/sys/invite/impl_applyinviteevents.go
@@ -207,6 +207,13 @@ func sendEmail(s istructs.IState, intents istructs.IIntents, smtpCfg smtp.Cfg, s
 	return err
 }
 
+// handleApplyJoinWorkspace finalizes c.sys.InitiateJoinWorkspace:
+//   - creates sys.JoinedWorkspace in the invitee's profile workspace (so the user can list workspaces they joined);
+//   - creates or re-activates sys.Subject in the inviting workspace (so the user can authorize there);
+//   - moves the invite to State_Joined.
+//
+// The Subject lookup has three cases: missing (first join), inactive (was Cancelled/Left previously - re-join),
+// active (idempotent retry). All paths must be safe to re-run because the projector is asynchronous.
 func handleApplyJoinWorkspace(event istructs.IPLogEvent, s istructs.IState, svCDocInvite istructs.IStateValue, inviteID istructs.RecordID, time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens) error {
 	login := svCDocInvite.AsString(field_ActualLogin)
 	existingSubjectID, isActive, err := SubjectExistsByLogin(login, s)
@@ -214,6 +221,7 @@ func handleApplyJoinWorkspace(event istructs.IPLogEvent, s istructs.IState, svCD
 		return err
 	}
 
+	// WSName is needed for the JoinedWorkspace record below.
 	skbCDocWorkspaceDescriptor, err := s.KeyBuilder(sys.Storage_Record, appdef.QNameCDocWorkspaceDescriptor)
 	if err != nil {
 		return err
@@ -229,6 +237,8 @@ func handleApplyJoinWorkspace(event istructs.IPLogEvent, s istructs.IState, svCD
 		return err
 	}
 
+	// Step 1: create JoinedWorkspace in the invitee's profile workspace.
+	// c.sys.CreateJoinedWorkspace is idempotent w.r.t. (InvitingWorkspaceWSID): a re-run updates the existing record.
 	_, err = fed.Func(
 		fmt.Sprintf("api/%s/%d/c.sys.CreateJoinedWorkspace", appQName, svCDocInvite.AsInt64(Field_InviteeProfileWSID)),
 		fmt.Sprintf(`{"args":{"Roles":%q,"InvitingWorkspaceWSID":%d,"WSName":%q}}`,
@@ -240,13 +250,19 @@ func handleApplyJoinWorkspace(event istructs.IPLogEvent, s istructs.IState, svCD
 		return err
 	}
 
+	// Step 2: ensure sys.Subject exists in the inviting workspace and carries the invited Roles.
+	// `body` is the CUD that finalizes the Subject; in the inactive case we additionally pre-run an activation CUD
+	// because the platform forbids combining sys.IsActive with other fields in a single CUD (HTTP 403).
 	var body string
 	switch {
 	case existingSubjectID == istructs.NullRecordID:
+		// First join: insert a new Subject with all fields.
 		body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"sys.Subject","Login":%q,"Roles":%q,"SubjectKind":%d,"ProfileWSID":%d}}]}`,
 			svCDocInvite.AsString(field_ActualLogin), svCDocInvite.AsString(Field_Roles), svCDocInvite.AsInt32(authnz.Field_SubjectKind),
 			svCDocInvite.AsInt64(Field_InviteeProfileWSID))
 	case !isActive:
+		// Re-join after Cancel/Leave: re-activate first, then update Roles in the second CUD below.
+		// Two separate CUDs are required: sys.IsActive cannot be updated together with other fields.
 		body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"sys.IsActive":true}}]}`, existingSubjectID)
 		_, err = fed.Func(
 			cudURL(appQName, event.Workspace()),
@@ -258,8 +274,10 @@ func handleApplyJoinWorkspace(event istructs.IPLogEvent, s istructs.IState, svCD
 		}
 		fallthrough
 	default:
+		// Active Subject (idempotent retry) or fallthrough from !isActive: refresh Roles.
 		body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"Roles":%q}}]}`, existingSubjectID, svCDocInvite.AsString(Field_Roles))
 	}
+	// Insert path needs the new ID for the invite's SubjectID; update path can discard the response.
 	subjectID := existingSubjectID
 	if existingSubjectID == istructs.NullRecordID {
 		resp, err := fed.Func(
@@ -280,6 +298,7 @@ func handleApplyJoinWorkspace(event istructs.IPLogEvent, s istructs.IState, svCD
 			return err
 		}
 	}
+	// Step 3: mark the invite as Joined and remember the SubjectID for later Cancel/Leave/UpdateRoles handlers.
 	return updateInviteViaCUD(fed, appQName, event.Workspace(), token, inviteID,
 		fmt.Sprintf(`"State":%d,"SubjectID":%d,"Updated":%d`, State_Joined, subjectID, time.Now().UnixMilli()))
 }

--- a/pkg/sys/invite/impl_applyjoinworkspace.go
+++ b/pkg/sys/invite/impl_applyjoinworkspace.go
@@ -5,127 +5,13 @@
 package invite
 
 import (
-	"fmt"
-
-	"github.com/voedger/voedger/pkg/appdef"
-	"github.com/voedger/voedger/pkg/coreutils/federation"
-	"github.com/voedger/voedger/pkg/goutils/httpu"
-	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istructs"
-	"github.com/voedger/voedger/pkg/itokens"
-	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
-	"github.com/voedger/voedger/pkg/sys"
-	"github.com/voedger/voedger/pkg/sys/authnz"
 )
 
-func asyncProjectorApplyJoinWorkspace(time timeu.ITime, federation federation.IFederation, tokens itokens.ITokens) istructs.Projector {
+// Deprecated: superseded by asyncProjectorApplyInviteEvents. Kept for backward compatibility only.
+func asyncProjectorApplyJoinWorkspace() istructs.Projector {
 	return istructs.Projector{
 		Name: qNameAPApplyJoinWorkspace,
-		Func: applyJoinWorkspace(time, federation, tokens),
-	}
-}
-
-func applyJoinWorkspace(time timeu.ITime, federation federation.IFederation, tokens itokens.ITokens) func(event istructs.IPLogEvent, state istructs.IState, intents istructs.IIntents) (err error) {
-	return func(event istructs.IPLogEvent, s istructs.IState, intents istructs.IIntents) (err error) {
-		// it is AFTER EXECUTE ON (InitiateJoinWorkspace) so no doc checking here
-		skbCDocInvite, err := s.KeyBuilder(sys.Storage_Record, QNameCDocInvite)
-		if err != nil {
-			return
-		}
-		skbCDocInvite.PutRecordID(sys.Storage_Record_Field_ID, event.ArgumentObject().AsRecordID(field_InviteID))
-		svCDocInvite, err := s.MustExist(skbCDocInvite)
-		if err != nil {
-			return
-		}
-
-		// Check if Subject exists for this user
-		// ActualLogin = user's login from auth token (set by InitiateJoinWorkspace)
-		// Note: Currently ActualLogin always equals Login because InitiateJoinWorkspace validates they match (earlier it wasn't required)
-		login := svCDocInvite.AsString(field_ActualLogin)
-		existingSubjectID, isActive, err := SubjectExistsByLogin(login, s)
-		if err != nil {
-			// notest
-			return err
-		}
-
-		// No early skip here - all operations below are idempotent, ensuring completion on projector retries:
-		// - CreateJoinedWorkspace: checks if exists, updates if so (see impl_createjoinedworkspace.go)
-		// - Subject create/reactivate: handled by existingSubjectID check
-		// - Invite update: idempotent state transition
-
-		skbCDocWorkspaceDescriptor, err := s.KeyBuilder(sys.Storage_Record, appdef.QNameCDocWorkspaceDescriptor)
-		if err != nil {
-			return err
-		}
-		skbCDocWorkspaceDescriptor.PutQName(sys.Storage_Record_Field_Singleton, appdef.QNameCDocWorkspaceDescriptor)
-		svCDocWorkspaceDescriptor, err := s.MustExist(skbCDocWorkspaceDescriptor)
-		if err != nil {
-			return
-		}
-
-		appQName := s.App()
-
-		token, err := payloads.GetSystemPrincipalToken(tokens, appQName)
-		if err != nil {
-			return
-		}
-		_, err = federation.Func(
-			fmt.Sprintf("api/%s/%d/c.sys.CreateJoinedWorkspace", appQName, svCDocInvite.AsInt64(Field_InviteeProfileWSID)),
-			fmt.Sprintf(`{"args":{"Roles":"%s","InvitingWorkspaceWSID":%d,"WSName":%q}}`,
-				svCDocInvite.AsString(Field_Roles), event.Workspace(), svCDocWorkspaceDescriptor.AsString(authnz.Field_WSName)),
-			httpu.WithAuthorizeBy(token),
-			httpu.WithDiscardResponse(),
-		)
-		if err != nil {
-			return
-		}
-
-		var body string
-		// Store cdoc.sys.Subject
-		switch {
-		case existingSubjectID == istructs.NullRecordID:
-			// Create new Subject
-			body = fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"sys.Subject","Login":"%s","Roles":"%s","SubjectKind":%d,"ProfileWSID":%d}}]}`,
-				svCDocInvite.AsString(field_ActualLogin), svCDocInvite.AsString(Field_Roles), svCDocInvite.AsInt32(authnz.Field_SubjectKind),
-				svCDocInvite.AsInt64(Field_InviteeProfileWSID))
-		case !isActive:
-			// Reactivate inactive Subject - first activate, then update Roles (can't update both in one call)
-			body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"sys.IsActive":true}}]}`, existingSubjectID)
-			_, err = federation.Func(
-				fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
-				body,
-				httpu.WithAuthorizeBy(token),
-				httpu.WithDiscardResponse())
-			if err != nil {
-				return
-			}
-			fallthrough
-		default:
-			// Subject already active (retry scenario) - just update Roles
-			body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"Roles":"%s"}}]}`, existingSubjectID, svCDocInvite.AsString(Field_Roles))
-		}
-		resp, err := federation.Func(
-			fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
-			body,
-			httpu.WithAuthorizeBy(token))
-		if err != nil {
-			return
-		}
-
-		// Store cdoc.sys.Invite
-		if existingSubjectID == istructs.NullRecordID {
-			body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"State":%d,"SubjectID":%d,"Updated":%d}}]}`,
-				svCDocInvite.AsRecordID(appdef.SystemField_ID), State_Joined, resp.NewID(), time.Now().UnixMilli())
-		} else {
-			body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"State":%d,"Updated":%d}}]}`,
-				svCDocInvite.AsRecordID(appdef.SystemField_ID), State_Joined, time.Now().UnixMilli())
-		}
-		_, err = federation.Func(
-			fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
-			body,
-			httpu.WithAuthorizeBy(token),
-			httpu.WithDiscardResponse())
-
-		return err
+		Func: deprecatedNullProjector,
 	}
 }

--- a/pkg/sys/invite/impl_applyleaveworkspace.go
+++ b/pkg/sys/invite/impl_applyleaveworkspace.go
@@ -5,87 +5,13 @@
 package invite
 
 import (
-	"fmt"
-
-	"github.com/voedger/voedger/pkg/appdef"
-	"github.com/voedger/voedger/pkg/coreutils/federation"
-	"github.com/voedger/voedger/pkg/goutils/httpu"
-	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istructs"
-	"github.com/voedger/voedger/pkg/itokens"
-	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
-	"github.com/voedger/voedger/pkg/sys"
 )
 
-func asyncProjectorApplyLeaveWorkspace(time timeu.ITime, federation federation.IFederation, tokens itokens.ITokens) istructs.Projector {
+// Deprecated: superseded by asyncProjectorApplyInviteEvents. Kept for backward compatibility only.
+func asyncProjectorApplyLeaveWorkspace() istructs.Projector {
 	return istructs.Projector{
 		Name: qNameAPApplyLeaveWorkspace,
-		Func: applyLeaveWorkspace(time, federation, tokens),
-	}
-}
-
-func applyLeaveWorkspace(time timeu.ITime, federation federation.IFederation, tokens itokens.ITokens) func(event istructs.IPLogEvent, state istructs.IState, intents istructs.IIntents) (err error) {
-	return func(event istructs.IPLogEvent, s istructs.IState, intents istructs.IIntents) error {
-		for rec := range event.CUDs {
-			//TODO additional check that CUD only once?
-			if rec.QName() != QNameCDocInvite {
-				continue
-			}
-
-			skbCDocInvite, err := s.KeyBuilder(sys.Storage_Record, QNameCDocInvite)
-			if err != nil {
-				return err
-			}
-			skbCDocInvite.PutRecordID(sys.Storage_Record_Field_ID, rec.ID())
-			svCDocInvite, err := s.MustExist(skbCDocInvite)
-			if err != nil {
-				return err
-			}
-
-			skbCDocSubject, err := s.KeyBuilder(sys.Storage_Record, QNameCDocSubject)
-			if err != nil {
-				return err
-			}
-			skbCDocSubject.PutRecordID(sys.Storage_Record_Field_ID, svCDocInvite.AsRecordID(field_SubjectID))
-			svCDocSubject, err := s.MustExist(skbCDocSubject)
-			if err != nil {
-				return err
-			}
-
-			appQName := s.App()
-
-			token, err := payloads.GetSystemPrincipalToken(tokens, appQName)
-			if err != nil {
-				return err
-			}
-
-			//Update subject
-			if _, err = federation.Func(
-				fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
-				fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"sys.IsActive":false}}]}`, svCDocSubject.AsRecordID(appdef.SystemField_ID)),
-				httpu.WithAuthorizeBy(token),
-				httpu.WithDiscardResponse()); err != nil {
-				return err
-			}
-
-			//Deactivate joined workspace
-			if _, err = federation.Func(
-				fmt.Sprintf("api/%s/%d/c.sys.DeactivateJoinedWorkspace", appQName, svCDocInvite.AsInt64(Field_InviteeProfileWSID)),
-				fmt.Sprintf(`{"args":{"InvitingWorkspaceWSID":%d}}`, event.Workspace()),
-				httpu.WithAuthorizeBy(token),
-				httpu.WithDiscardResponse()); err != nil {
-				return err
-			}
-
-			//Update invite
-			if _, err = federation.Func(
-				fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
-				fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"State":%d,"Updated":%d}}]}`, rec.ID(), State_Left, time.Now().UnixMilli()),
-				httpu.WithAuthorizeBy(token),
-				httpu.WithDiscardResponse()); err != nil {
-				return err
-			}
-		}
-		return nil
+		Func: deprecatedNullProjector,
 	}
 }

--- a/pkg/sys/invite/impl_applyupdateinviteroles.go
+++ b/pkg/sys/invite/impl_applyupdateinviteroles.go
@@ -5,112 +5,13 @@
 package invite
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/voedger/voedger/pkg/appdef"
-	"github.com/voedger/voedger/pkg/coreutils"
-	"github.com/voedger/voedger/pkg/coreutils/federation"
-	"github.com/voedger/voedger/pkg/goutils/httpu"
-	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istructs"
-	"github.com/voedger/voedger/pkg/itokens"
-	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
-	"github.com/voedger/voedger/pkg/state"
-	"github.com/voedger/voedger/pkg/sys"
-	"github.com/voedger/voedger/pkg/sys/smtp"
 )
 
-func asyncProjectorApplyUpdateInviteRoles(time timeu.ITime, federation federation.IFederation, tokens itokens.ITokens, smtpCfg smtp.Cfg) istructs.Projector {
+// Deprecated: superseded by asyncProjectorApplyInviteEvents. Kept for backward compatibility only.
+func asyncProjectorApplyUpdateInviteRoles() istructs.Projector {
 	return istructs.Projector{
 		Name: qNameAPApplyUpdateInviteRoles,
-		Func: applyUpdateInviteRolesProjector(time, federation, tokens, smtpCfg),
-	}
-}
-
-func applyUpdateInviteRolesProjector(time timeu.ITime, federation federation.IFederation, tokens itokens.ITokens, smtpCfg smtp.Cfg) func(event istructs.IPLogEvent, state istructs.IState, intents istructs.IIntents) (err error) {
-	return func(event istructs.IPLogEvent, s istructs.IState, intents istructs.IIntents) (err error) {
-		skbCDocInvite, err := s.KeyBuilder(sys.Storage_Record, QNameCDocInvite)
-		if err != nil {
-			return
-		}
-		skbCDocInvite.PutRecordID(sys.Storage_Record_Field_ID, event.ArgumentObject().AsRecordID(field_InviteID))
-		svCDocInvite, err := s.MustExist(skbCDocInvite)
-		if err != nil {
-			return
-		}
-
-		skbCDocSubject, err := s.KeyBuilder(sys.Storage_Record, QNameCDocSubject)
-		if err != nil {
-			return
-		}
-		skbCDocSubject.PutRecordID(sys.Storage_Record_Field_ID, svCDocInvite.AsRecordID(field_SubjectID))
-		svCDocSubject, err := s.MustExist(skbCDocSubject)
-		if err != nil {
-			return
-		}
-
-		appQName := s.App()
-
-		token, err := payloads.GetSystemPrincipalToken(tokens, appQName)
-		if err != nil {
-			return
-		}
-
-		//Update subject
-		_, err = federation.Func(
-			fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
-			fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"Roles":"%s"}}]}`, svCDocSubject.AsRecordID(appdef.SystemField_ID), event.ArgumentObject().AsString(Field_Roles)),
-			httpu.WithAuthorizeBy(token),
-			httpu.WithDiscardResponse())
-		if err != nil {
-			return
-		}
-
-		//Update joined workspace roles
-		_, err = federation.Func(
-			fmt.Sprintf("api/%s/%d/c.sys.UpdateJoinedWorkspaceRoles", appQName, svCDocInvite.AsInt64(Field_InviteeProfileWSID)),
-			fmt.Sprintf(`{"args":{"Roles":"%s","InvitingWorkspaceWSID":%d}}`, event.ArgumentObject().AsString(Field_Roles), event.Workspace()),
-			httpu.WithAuthorizeBy(token),
-			httpu.WithDiscardResponse())
-		if err != nil {
-			return
-		}
-
-		emailTemplate := coreutils.TruncateEmailTemplate(event.ArgumentObject().AsString(field_EmailTemplate))
-
-		replacer := strings.NewReplacer(EmailTemplatePlaceholder_Roles, event.ArgumentObject().AsString(Field_Roles))
-		//Send roles update email
-		skbSendMail, err := s.KeyBuilder(sys.Storage_SendMail, appdef.NullQName)
-		if err != nil {
-			return
-		}
-		skbSendMail.PutString(sys.Storage_SendMail_Field_Subject, event.ArgumentObject().AsString(field_EmailSubject))
-		skbSendMail.PutString(sys.Storage_SendMail_Field_To, svCDocInvite.AsString(Field_Email))
-		skbSendMail.PutString(sys.Storage_SendMail_Field_Body, replacer.Replace(emailTemplate))
-		skbSendMail.PutString(sys.Storage_SendMail_Field_From, smtpCfg.GetFrom())
-		skbSendMail.PutString(sys.Storage_SendMail_Field_Host, smtpCfg.Host)
-		skbSendMail.PutInt32(sys.Storage_SendMail_Field_Port, smtpCfg.Port)
-		skbSendMail.PutString(sys.Storage_SendMail_Field_Username, smtpCfg.Username)
-
-		pwd, err := state.ReadSecret(s, smtpCfg.PwdSecret)
-		if err != nil {
-			return err
-		}
-		skbSendMail.PutString(sys.Storage_SendMail_Field_Password, pwd)
-
-		_, err = intents.NewValue(skbSendMail)
-		if err != nil {
-			return
-		}
-
-		//Update invite
-		_, err = federation.Func(
-			fmt.Sprintf("api/%s/%d/c.sys.CUD", appQName, event.Workspace()),
-			fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"State":%d,"Updated":%d,"Roles":"%s"}}]}`, event.ArgumentObject().AsRecordID(field_InviteID), State_Joined, time.Now().UnixMilli(), event.ArgumentObject().AsString(Field_Roles)),
-			httpu.WithAuthorizeBy(token),
-			httpu.WithDiscardResponse())
-
-		return err
+		Func: deprecatedNullProjector,
 	}
 }

--- a/pkg/sys/invite/impl_cancelsentinvite.go
+++ b/pkg/sys/invite/impl_cancelsentinvite.go
@@ -22,7 +22,7 @@ func provideCmdCancelSentInvite(sr istructsmem.IStatelessResources, time timeu.I
 	))
 }
 
-func execCmdCancelSentInvite(time timeu.ITime) func(args istructs.ExecCommandArgs) (err error) {
+func execCmdCancelSentInvite(_ timeu.ITime) func(args istructs.ExecCommandArgs) (err error) {
 	return func(args istructs.ExecCommandArgs) (err error) {
 		skbCDocInvite, err := args.State.KeyBuilder(sys.Storage_Record, QNameCDocInvite)
 		if err != nil {
@@ -42,13 +42,6 @@ func execCmdCancelSentInvite(time timeu.ITime) func(args istructs.ExecCommandArg
 			return coreutils.NewHTTPError(http.StatusBadRequest, ErrInviteStateInvalid)
 		}
 
-		svbCDocInvite, err := args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)
-		if err != nil {
-			return
-		}
-		svbCDocInvite.PutInt64(Field_Updated, time.Now().UnixMilli())
-		svbCDocInvite.PutInt32(Field_State, int32(State_Cancelled))
-
-		return
+		return nil
 	}
 }

--- a/pkg/sys/invite/impl_initiatecancelacceptedinvite.go
+++ b/pkg/sys/invite/impl_initiatecancelacceptedinvite.go
@@ -22,7 +22,7 @@ func provideCmdInitiateCancelAcceptedInvite(sr istructsmem.IStatelessResources, 
 	))
 }
 
-func execCmdInitiateCancelAcceptedInvite(time timeu.ITime) func(args istructs.ExecCommandArgs) (err error) {
+func execCmdInitiateCancelAcceptedInvite(_ timeu.ITime) func(args istructs.ExecCommandArgs) (err error) {
 	return func(args istructs.ExecCommandArgs) (err error) {
 		skbCDocInvite, err := args.State.KeyBuilder(sys.Storage_Record, QNameCDocInvite)
 		if err != nil {
@@ -41,13 +41,6 @@ func execCmdInitiateCancelAcceptedInvite(time timeu.ITime) func(args istructs.Ex
 			return coreutils.NewHTTPError(http.StatusBadRequest, ErrInviteStateInvalid)
 		}
 
-		svbCDocInvite, err := args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)
-		if err != nil {
-			return
-		}
-		svbCDocInvite.PutInt64(Field_Updated, time.Now().UnixMilli())
-		svbCDocInvite.PutInt32(Field_State, int32(State_ToBeCancelled))
-
-		return err
+		return nil
 	}
 }

--- a/pkg/sys/invite/impl_initiateinvitationbyemail.go
+++ b/pkg/sys/invite/impl_initiateinvitationbyemail.go
@@ -31,8 +31,11 @@ func execCmdInitiateInvitationByEMail(tm timeu.ITime) func(args istructs.ExecCom
 			return coreutils.NewHTTPError(http.StatusBadRequest, errInviteTemplateInvalid)
 		}
 
+		if err := validateInviteRoles(args.ArgumentObject.AsString(Field_Roles), args.Workspace); err != nil {
+			return err
+		}
+
 		cmdInitiateInvitation_ArgEmail := args.ArgumentObject.AsString(Field_Email)
-		
 		// do not check if the login from token exists in subjects, see https://github.com/voedger/voedger/issues/3698
 		// because login is Inviter here, not Invitee
 		_, subjectIsActive, err := SubjectExistsByLogin(cmdInitiateInvitation_ArgEmail, args.State)

--- a/pkg/sys/invite/impl_initiatejoinworkspace.go
+++ b/pkg/sys/invite/impl_initiatejoinworkspace.go
@@ -72,7 +72,6 @@ func execCmdInitiateJoinWorkspace(tm timeu.ITime) func(args istructs.ExecCommand
 		svbCDocInvite.PutInt64(Field_InviteeProfileWSID, svPrincipal.AsInt64(sys.Storage_RequestSubject_Field_ProfileWSID))
 		svbCDocInvite.PutInt32(authnz.Field_SubjectKind, svPrincipal.AsInt32(sys.Storage_RequestSubject_Field_Kind))
 		svbCDocInvite.PutInt64(Field_Updated, tm.Now().UnixMilli())
-		svbCDocInvite.PutInt32(Field_State, int32(State_ToBeJoined))
 		svbCDocInvite.PutChars(field_ActualLogin, svPrincipal.AsString(sys.Storage_RequestSubject_Field_Name))
 
 		return

--- a/pkg/sys/invite/impl_initiateleaveworkspace.go
+++ b/pkg/sys/invite/impl_initiateleaveworkspace.go
@@ -22,7 +22,7 @@ func provideCmdInitiateLeaveWorkspace(sr istructsmem.IStatelessResources, time t
 	))
 }
 
-func execCmdInitiateLeaveWorkspace(time timeu.ITime) func(args istructs.ExecCommandArgs) (err error) {
+func execCmdInitiateLeaveWorkspace(_ timeu.ITime) func(args istructs.ExecCommandArgs) (err error) {
 	return func(args istructs.ExecCommandArgs) (err error) {
 		skbPrincipal, err := args.State.KeyBuilder(sys.Storage_RequestSubject, appdef.NullQName)
 		if err != nil {
@@ -58,13 +58,8 @@ func execCmdInitiateLeaveWorkspace(time timeu.ITime) func(args istructs.ExecComm
 			return coreutils.NewHTTPError(http.StatusBadRequest, ErrInviteStateInvalid)
 		}
 
-		svbCDocInvite, err := args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)
-		if err != nil {
-			return err
-		}
-		svbCDocInvite.PutInt32(Field_State, int32(State_ToBeLeft))
-		svbCDocInvite.PutInt64(Field_Updated, time.Now().UnixMilli())
-		svbCDocInvite.PutBool(appdef.SystemField_IsActive, false)
+		// no-op CUD: keep UpdateValue so projector can discover InviteID from event.CUDs
+		_, err = args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)
 
 		return
 	}

--- a/pkg/sys/invite/impl_initiateupdateinviteroles.go
+++ b/pkg/sys/invite/impl_initiateupdateinviteroles.go
@@ -22,10 +22,14 @@ func provideCmdInitiateUpdateInviteRoles(sr istructsmem.IStatelessResources, tim
 	))
 }
 
-func execCmdInitiateUpdateInviteRoles(time timeu.ITime) func(args istructs.ExecCommandArgs) (err error) {
+func execCmdInitiateUpdateInviteRoles(_ timeu.ITime) func(args istructs.ExecCommandArgs) (err error) {
 	return func(args istructs.ExecCommandArgs) (err error) {
 		if !coreutils.IsValidEmailTemplate(args.ArgumentObject.AsString(field_EmailTemplate)) {
 			return coreutils.NewHTTPError(http.StatusBadRequest, errInviteTemplateInvalid)
+		}
+
+		if err := validateInviteRoles(args.ArgumentObject.AsString(Field_Roles), args.Workspace); err != nil {
+			return err
 		}
 
 		skbCDocInvite, err := args.State.KeyBuilder(sys.Storage_Record, QNameCDocInvite)
@@ -45,13 +49,6 @@ func execCmdInitiateUpdateInviteRoles(time timeu.ITime) func(args istructs.ExecC
 			return coreutils.NewHTTPError(http.StatusBadRequest, ErrInviteStateInvalid)
 		}
 
-		svbCDocInvite, err := args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)
-		if err != nil {
-			return
-		}
-		svbCDocInvite.PutInt32(Field_State, int32(State_ToUpdateRoles))
-		svbCDocInvite.PutInt64(Field_Updated, time.Now().UnixMilli())
-
-		return err
+		return nil
 	}
 }

--- a/pkg/sys/invite/provide.go
+++ b/pkg/sys/invite/provide.go
@@ -25,11 +25,13 @@ func Provide(sr istructsmem.IStatelessResources, time timeu.ITime,
 	provideCmdUpdateJoinedWorkspaceRoles(sr)
 	provideCmdDeactivateJoinedWorkspace(sr)
 	sr.AddProjectors(appdef.SysPackagePath,
-		asyncProjectorApplyInvitation(time, federation, itokens, smtpCfg),
-		asyncProjectorApplyJoinWorkspace(time, federation, itokens),
-		asyncProjectorApplyUpdateInviteRoles(time, federation, itokens, smtpCfg),
-		asyncProjectorApplyCancelAcceptedInvite(time, federation, itokens),
-		asyncProjectorApplyLeaveWorkspace(time, federation, itokens),
+		// Deprecated: superseded by asyncProjectorApplyInviteEvents. Kept for backward compatibility only.
+		asyncProjectorApplyInvitation(),
+		asyncProjectorApplyJoinWorkspace(),
+		asyncProjectorApplyUpdateInviteRoles(),
+		asyncProjectorApplyCancelAcceptedInvite(),
+		asyncProjectorApplyLeaveWorkspace(),
+		asyncProjectorApplyInviteEvents(time, federation, itokens, smtpCfg),
 		syncProjectorInviteIndex(),
 		syncProjectorJoinedWorkspaceIndex(),
 		applyViewSubjectsIdx(),

--- a/pkg/sys/invite/utils.go
+++ b/pkg/sys/invite/utils.go
@@ -6,11 +6,45 @@
 package invite
 
 import (
+	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
+	"github.com/voedger/voedger/pkg/iauthnz"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/sys"
 )
+
+func validateInviteRoles(rolesStr string, ws appdef.IWorkspace) error {
+	trimmed := strings.TrimSpace(rolesStr)
+	if len(trimmed) == 0 {
+		return coreutils.NewHTTPError(http.StatusBadRequest, ErrRolesEmpty)
+	}
+	seen := make(map[appdef.QName]struct{})
+	for role := range strings.SplitSeq(trimmed, ",") {
+		role = strings.TrimSpace(role)
+		if len(role) == 0 {
+			return coreutils.NewHTTPError(http.StatusBadRequest, ErrRolesEmpty)
+		}
+		qName, err := appdef.ParseQName(role)
+		if err != nil {
+			return coreutils.NewHTTPError(http.StatusBadRequest, fmt.Errorf("%w: %s: %w", ErrRoleInvalid, role, err))
+		}
+		if _, ok := seen[qName]; ok {
+			return coreutils.NewHTTPError(http.StatusBadRequest, fmt.Errorf("%w: %s", ErrRoleDuplicate, role))
+		}
+		seen[qName] = struct{}{}
+		if iauthnz.IsSystemRole(qName) {
+			return coreutils.NewHTTPError(http.StatusBadRequest, fmt.Errorf("%w: %s", ErrSystemRole, role))
+		}
+		if appdef.Role(ws.Type, qName) == nil {
+			return coreutils.NewHTTPError(http.StatusBadRequest, fmt.Errorf("%w: %s", ErrRoleNotFound, role))
+		}
+	}
+	return nil
+}
 
 func GetCDocJoinedWorkspaceForUpdateRequired(st istructs.IState, intents istructs.IIntents, invitingWorkspaceWSID int64) (svbCDocJoinedWorkspace istructs.IStateValueBuilder, err error) {
 	skbViewJoinedWorkspaceIndex, err := st.KeyBuilder(sys.Storage_View, QNameViewJoinedWorkspaceIndex)

--- a/pkg/sys/invite/utils_test.go
+++ b/pkg/sys/invite/utils_test.go
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026-present unTill Software Development Group B.V.
+ * @author Maxim Geraskin
+ */
+
+package invite
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/voedger/voedger/pkg/appdef"
+	"github.com/voedger/voedger/pkg/appdef/builder"
+	"github.com/voedger/voedger/pkg/coreutils"
+)
+
+var (
+	testWSName      = appdef.NewQName("test", "ws")
+	testWS2Name     = appdef.NewQName("other", "ws2")
+	testChildWSName = appdef.NewQName("test", "childWS")
+)
+
+type testApp struct {
+	ws, ws2, childWS appdef.IWorkspace
+}
+
+func buildTestApp(t *testing.T) testApp {
+	t.Helper()
+	adb := builder.New()
+	adb.AddPackage("test", "test.com/test")
+	adb.AddPackage("other", "test.com/other")
+
+	wsb := adb.AddWorkspace(testWSName)
+	wsb.AddRole(appdef.NewQName("test", "Reader"))
+	wsb.AddRole(appdef.NewQName("test", "Writer"))
+	wsb.AddCDoc(appdef.NewQName("test", "NotARole"))
+
+	wsb2 := adb.AddWorkspace(testWS2Name)
+	wsb2.AddRole(appdef.NewQName("other", "Admin"))
+
+	childWSB := adb.AddWorkspace(testChildWSName)
+	childWSB.SetAncestors(testWSName)
+	childWSB.AddRole(appdef.NewQName("test", "ChildOnly"))
+
+	app, err := adb.Build()
+	require.NoError(t, err)
+	return testApp{
+		ws:      app.Workspace(testWSName),
+		ws2:     app.Workspace(testWS2Name),
+		childWS: app.Workspace(testChildWSName),
+	}
+}
+
+func requireRolesError(t *testing.T, err error, expectedErr error) {
+	t.Helper()
+	require := require.New(t)
+	var sysErr coreutils.SysError
+	require.ErrorAs(err, &sysErr)
+	require.Equal(http.StatusBadRequest, sysErr.HTTPStatus)
+	require.Contains(sysErr.Message, expectedErr.Error())
+}
+
+func TestValidateInviteRoles(t *testing.T) {
+	ta := buildTestApp(t)
+	ws, ws2, childWS := ta.ws, ta.ws2, ta.childWS
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Run("single valid role", func(t *testing.T) {
+			require := require.New(t)
+			require.NoError(validateInviteRoles("test.Reader", ws))
+		})
+		t.Run("multiple valid roles", func(t *testing.T) {
+			require := require.New(t)
+			require.NoError(validateInviteRoles("test.Reader,test.Writer", ws))
+		})
+		t.Run("spaces around commas trimmed", func(t *testing.T) {
+			require := require.New(t)
+			require.NoError(validateInviteRoles(" test.Reader , test.Writer ", ws))
+		})
+		t.Run("inherited role from ancestor", func(t *testing.T) {
+			require := require.New(t)
+			require.NoError(validateInviteRoles("test.Reader", childWS))
+		})
+	})
+
+	t.Run("edge cases", func(t *testing.T) {
+		t.Run("empty string", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles("", ws), ErrRolesEmpty)
+		})
+		t.Run("whitespace only", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles("  ", ws), ErrRolesEmpty)
+		})
+		t.Run("trailing comma produces empty element", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles("test.Reader,", ws), ErrRolesEmpty)
+		})
+		t.Run("leading comma produces empty element", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles(",test.Reader", ws), ErrRolesEmpty)
+		})
+		t.Run("malformed QName", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles("notAQName", ws), ErrRoleInvalid)
+		})
+		t.Run("malformed QName among valid", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles("test.Reader,bad", ws), ErrRoleInvalid)
+		})
+		t.Run("dot only QName", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles(".", ws), ErrRoleNotFound)
+		})
+		t.Run("sys role rejected", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles("sys.WorkspaceOwner", ws), ErrSystemRole)
+		})
+		t.Run("sys role among valid rejected", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles("test.Reader,sys.WorkspaceAdmin", ws), ErrSystemRole)
+		})
+		t.Run("any sys role rejected", func(t *testing.T) {
+			for _, sysRole := range []string{
+				"sys.Everyone",
+				"sys.Anonymous",
+				"sys.AuthenticatedUser",
+				"sys.System",
+				"sys.ProfileOwner",
+				"sys.WorkspaceDevice",
+				"sys.WorkspaceOwner",
+				"sys.ClusterAdmin",
+				"sys.WorkspaceAdmin",
+				"sys.BLOBUploader",
+				"sys.RoleWorkspaceOwner",
+				"sys.FutureRole",
+			} {
+				t.Run(sysRole, func(t *testing.T) {
+					requireRolesError(t, validateInviteRoles(sysRole, ws), ErrSystemRole)
+				})
+			}
+		})
+		t.Run("role not found in workspace", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles("test.NonExistent", ws), ErrRoleNotFound)
+		})
+		t.Run("role exists in other workspace but not in target", func(t *testing.T) {
+			require := require.New(t)
+			require.NotNil(appdef.Role(ws2.Type, appdef.NewQName("other", "Admin")))
+			requireRolesError(t, validateInviteRoles("other.Admin", ws), ErrRoleNotFound)
+		})
+		t.Run("non-role type with same QName rejected", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles("test.NotARole", ws), ErrRoleNotFound)
+		})
+		t.Run("child-only role not found in parent", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles("test.ChildOnly", ws), ErrRoleNotFound)
+		})
+		t.Run("duplicate roles rejected", func(t *testing.T) {
+			requireRolesError(t, validateInviteRoles("test.Reader,test.Reader", ws), ErrRoleDuplicate)
+		})
+	})
+}

--- a/pkg/sys/it/impl_deactivateworkspace_test.go
+++ b/pkg/sys/it/impl_deactivateworkspace_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
-	"github.com/voedger/voedger/pkg/iauthnz"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/sys/authnz"
 	"github.com/voedger/voedger/pkg/sys/invite"
@@ -83,15 +82,15 @@ func TestDeactivateJoinedWorkspace(t *testing.T) {
 
 	// join login TestEmail2 to ws1
 	expireDatetime := vit.Now().UnixMilli()
-	roleOwner := iauthnz.QNameRoleWorkspaceOwner.String()
+	roleOwner := "app1pkg.InviteTestRole"
 	updateRolesEmailSubject := "your roles are updated"
 	inviteID := InitiateInvitationByEMail(vit, newWS, expireDatetime, it.TestEmail2, roleOwner, inviteEmailTemplate, updateRolesEmailSubject)
 	email := vit.CaptureEmail()
 	verificationCode := email.Body[:6]
-	WaitForInviteState(vit, newWS, inviteID, invite.State_ToBeJoined, invite.State_Invited)
+	WaitForInviteState(vit, newWS, inviteID, invite.State_ToBeInvited, invite.State_Invited)
 	testEmail2Prn := vit.GetPrincipal(istructs.AppQName_test1_app1, it.TestEmail2)
 	InitiateJoinWorkspace(vit, newWS, inviteID, testEmail2Prn, verificationCode)
-	WaitForInviteState(vit, newWS, inviteID, invite.State_ToBeJoined, invite.State_Joined)
+	WaitForInviteState(vit, newWS, inviteID, invite.State_Invited, invite.State_Joined)
 
 	// check prn2 could work in ws1
 	body = `{"cuds":[{"fields":{"sys.QName":"app1pkg.computers","sys.ID":1}}]}`

--- a/pkg/sys/it/impl_invite_test.go
+++ b/pkg/sys/it/impl_invite_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	initialRoles        = "initial.Roles"
-	newRoles            = "new.Roles"
+	initialRoles        = "app1pkg.LimitedAccessRole"
+	newRoles            = "app1pkg.SpecialAPITokenRole"
 	inviteEmailTemplate = "text:" + strings.Join([]string{
 		invite.EmailTemplatePlaceholder_VerificationCode,
 		invite.EmailTemplatePlaceholder_InviteID,
@@ -158,7 +158,7 @@ func TestInvite_BasicUsage(t *testing.T) {
 
 	//Cancel then invite it again (inviteID3)
 	vit.PostWS(ws, "c.sys.CancelSentInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, inviteID3))
-	WaitForInviteState(vit, ws, inviteID3, invite.State_ToBeCancelled, invite.State_Cancelled)
+	WaitForInviteState(vit, ws, inviteID3, invite.State_Invited, invite.State_Cancelled)
 	InitiateInvitationByEMail(vit, ws, expireDatetime, email3, initialRoles, inviteEmailTemplate, inviteEmailSubject)
 	_ = vit.CaptureEmail()
 	WaitForInviteState(vit, ws, inviteID3, invite.State_ToBeInvited, invite.State_Invited)
@@ -167,15 +167,15 @@ func TestInvite_BasicUsage(t *testing.T) {
 	InitiateJoinWorkspace(vit, ws, inviteID, login1Prn, verificationCodeEmail)
 	InitiateJoinWorkspace(vit, ws, inviteID2, login2Prn, verificationCodeEmail2)
 
-	// State_ToBeJoined will be set for a very short period of time so let's do not catch it
-	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeJoined, invite.State_Joined)
-	WaitForInviteState(vit, ws, inviteID2, invite.State_ToBeJoined, invite.State_Joined)
+	WaitForInviteState(vit, ws, inviteID, invite.State_Invited, invite.State_Joined)
+	WaitForInviteState(vit, ws, inviteID2, invite.State_Invited, invite.State_Joined)
 
 	cDocInvite = findCDocInviteByID(inviteID2)
 
 	require.Equal(float64(login2Prn.ProfileWSID), cDocInvite[10])
 	require.Equal(float64(istructs.SubjectKind_User), cDocInvite[0])
 	require.Equal(float64(vit.Now().UnixMilli()), cDocInvite[8])
+	require.NotEqual(float64(0), cDocInvite[9], "SubjectID must be set after join")
 
 	cDocJoinedWorkspace := FindCDocJoinedWorkspaceByInvitingWorkspaceWSIDAndLogin(vit, ws.WSID, login2Prn)
 
@@ -207,8 +207,6 @@ func TestInvite_BasicUsage(t *testing.T) {
 	require.Equal([]string{email2}, message.To)
 	require.Equal(updatedRoles, message.Body)
 
-	WaitForInviteState(vit, ws, inviteID, invite.State_Joined, invite.State_ToUpdateRoles, invite.State_Joined)
-	WaitForInviteState(vit, ws, inviteID2, invite.State_Joined, invite.State_ToUpdateRoles, invite.State_Joined)
 	cDocInvite = findCDocInviteByID(inviteID)
 
 	require.Equal(float64(vit.Now().UnixMilli()), cDocInvite[8])
@@ -219,14 +217,10 @@ func TestInvite_BasicUsage(t *testing.T) {
 
 	//TODO Denis how to get WS by login? I want to check sys.JoinedWorkspace
 
-	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeJoined, invite.State_Joined)
-	WaitForInviteState(vit, ws, inviteID2, invite.State_ToBeJoined, invite.State_Joined)
-
 	//Cancel accepted invite
 	vit.PostWS(ws, "c.sys.InitiateCancelAcceptedInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, inviteID))
 
-	// State_ToBeCancelled will be set for a veri short period of time so let's do not catch it
-	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeCancelled, invite.State_Cancelled)
+	WaitForInviteState(vit, ws, inviteID, invite.State_Joined, invite.State_Cancelled)
 
 	cDocInvite = findCDocInviteByID(inviteID)
 
@@ -243,7 +237,7 @@ func TestInvite_BasicUsage(t *testing.T) {
 	//Leave workspace
 	vit.PostWS(ws, "c.sys.InitiateLeaveWorkspace", "{}", httpu.WithAuthorizeBy(login2Prn.Token))
 
-	WaitForInviteState(vit, ws, inviteID2, invite.State_ToBeLeft, invite.State_Left)
+	WaitForInviteState(vit, ws, inviteID2, invite.State_Joined, invite.State_Left)
 
 	cDocInvite = findCDocInviteByID(inviteID2)
 
@@ -256,10 +250,10 @@ func TestInvite_BasicUsage(t *testing.T) {
 	//TODO check InviteeProfile joined workspace
 
 	//Re-invite
-	newRoles := "new.roles"
+	newRoles := "app1pkg.LimitedAccessRole"
 	InitiateInvitationByEMail(vit, ws, expireDatetime, email2, newRoles, inviteEmailTemplate, inviteEmailSubject)
 	log.Println(vit.CaptureEmail().Body)
-	WaitForInviteState(vit, ws, inviteID2, invite.State_Left, invite.State_Invited)
+	WaitForInviteState(vit, ws, inviteID2, invite.State_ToBeInvited, invite.State_Invited)
 	cDocInvite = findCDocInviteByID(inviteID2)
 	require.Equal(newRoles, cDocInvite[3].(string))
 }
@@ -282,7 +276,7 @@ func TestCancelSentInvite(t *testing.T) {
 		vit.CaptureEmail()
 
 		vit.PostWS(ws, "c.sys.CancelSentInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, inviteID))
-		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeCancelled, invite.State_Cancelled)
+		WaitForInviteState(vit, ws, inviteID, invite.State_Invited, invite.State_Cancelled)
 	})
 	t.Run("invite not exists -> 400 bad request", func(t *testing.T) {
 		vit.PostWS(ws, "c.sys.CancelSentInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, istructs.NonExistingRecordID), it.Expect400RefIntegrity_Existence())
@@ -399,21 +393,21 @@ func TestReinviteAfterCancelAcceptedInvite(t *testing.T) {
 	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
 
 	InitiateJoinWorkspace(vit, ws, inviteID, loginPrn, verificationCode)
-	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeJoined, invite.State_Joined)
+	WaitForInviteState(vit, ws, inviteID, invite.State_Invited, invite.State_Joined)
 
 	// Step 2: Cancel accepted invite (admin removes user)
 	vit.PostWS(ws, "c.sys.InitiateCancelAcceptedInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, inviteID))
-	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeCancelled, invite.State_Cancelled)
+	WaitForInviteState(vit, ws, inviteID, invite.State_Joined, invite.State_Cancelled)
 
 	// Step 3: Reinvite the same email
 	InitiateInvitationByEMail(vit, ws, expireDatetime, email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
 	sentEmail2 := vit.CaptureEmail()
 	verificationCode2 := sentEmail2.Body[:6]
-	WaitForInviteState(vit, ws, inviteID, invite.State_Cancelled, invite.State_Invited)
+	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
 
 	// Step 4: User accepts invitation again - this should succeed
 	InitiateJoinWorkspace(vit, ws, inviteID, loginPrn, verificationCode2)
-	WaitForInviteState(vit, ws, inviteID, invite.State_ToBeJoined, invite.State_Joined)
+	WaitForInviteState(vit, ws, inviteID, invite.State_Invited, invite.State_Joined)
 
 	// Verify: Subject should be active again
 	cDocSubject := vit.PostWS(ws, "q.sys.Collection", fmt.Sprintf(`
@@ -495,7 +489,7 @@ func TestRecoverFromStuckInviteStates(t *testing.T) {
 
 		// Cancel should succeed from State_ToBeInvited
 		vit.PostWS(ws, "c.sys.CancelSentInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, inviteID))
-		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeCancelled, invite.State_Cancelled)
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Cancelled)
 	})
 
 	t.Run("re-invite from State_ToBeJoined", func(t *testing.T) {
@@ -524,7 +518,69 @@ func TestRecoverFromStuckInviteStates(t *testing.T) {
 
 		// Cancel should succeed from State_ToBeJoined
 		vit.PostWS(ws, "c.sys.CancelSentInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, inviteID))
-		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeCancelled, invite.State_Cancelled)
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeJoined, invite.State_Cancelled)
+	})
+}
+
+func TestInvite_RolesValidation(t *testing.T) {
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	prn := vit.GetPrincipal(istructs.AppQName_test1_app1, it.TestEmail)
+	ws := vit.CreateWorkspace(it.SimpleWSParams("TestInvite_RolesValidation_ws"), prn)
+	expireDatetime := vit.Now().UnixMilli()
+
+	postInvite := func(roles string, opts ...httpu.ReqOptFunc) {
+		vit.T.Helper()
+		email := fmt.Sprintf("rolesvalid_%d@123.com", vit.NextNumber())
+		body := fmt.Sprintf(`{"args":{"Email":"%s","Roles":"%s","ExpireDatetime":%d,"EmailTemplate":"%s","EmailSubject":"%s"}}`,
+			email, roles, expireDatetime, inviteEmailTemplate, inviteEmailSubject)
+		vit.PostWS(ws, "c.sys.InitiateInvitationByEMail", body, opts...)
+	}
+
+	t.Run("InitiateInvitationByEMail", func(t *testing.T) {
+		t.Run("whitespace-only roles -> 400", func(t *testing.T) {
+			postInvite("   ", it.Expect400("roles must not be empty"))
+		})
+		t.Run("leading comma -> 400", func(t *testing.T) {
+			postInvite(",app1pkg.LimitedAccessRole", it.Expect400("roles must not be empty"))
+		})
+		t.Run("malformed QName -> 400", func(t *testing.T) {
+			postInvite("not-a-qname", it.Expect400("invalid role"))
+		})
+		t.Run("system role -> 400", func(t *testing.T) {
+			postInvite("sys.WorkspaceOwner", it.Expect400("system roles cannot be assigned via invite"))
+		})
+		t.Run("non-existent role -> 400", func(t *testing.T) {
+			postInvite("app1pkg.NonExistentRole", it.Expect400("role not found in workspace"))
+		})
+		t.Run("duplicate role -> 400", func(t *testing.T) {
+			postInvite("app1pkg.LimitedAccessRole,app1pkg.LimitedAccessRole", it.Expect400("duplicate role"))
+		})
+	})
+
+	t.Run("InitiateUpdateInviteRoles", func(t *testing.T) {
+		email := fmt.Sprintf("rolesvalid_update_%d@123.com", vit.NextNumber())
+		inviteID := InitiateInvitationByEMail(vit, ws, expireDatetime, email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+		vit.CaptureEmail()
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+
+		postUpdate := func(roles string, opts ...httpu.ReqOptFunc) {
+			vit.T.Helper()
+			body := fmt.Sprintf(`{"args":{"InviteID":%d,"Roles":"%s","EmailTemplate":"%s","EmailSubject":"%s"}}`,
+				inviteID, roles, inviteEmailTemplate, inviteEmailSubject)
+			vit.PostWS(ws, "c.sys.InitiateUpdateInviteRoles", body, opts...)
+		}
+
+		t.Run("whitespace-only roles -> 400", func(t *testing.T) {
+			postUpdate("   ", it.Expect400("roles must not be empty"))
+		})
+		t.Run("system role -> 400", func(t *testing.T) {
+			postUpdate("sys.WorkspaceOwner", it.Expect400("system roles cannot be assigned via invite"))
+		})
+		t.Run("non-existent role -> 400", func(t *testing.T) {
+			postUpdate("app1pkg.NonExistentRole", it.Expect400("role not found in workspace"))
+		})
 	})
 }
 

--- a/pkg/sys/it/race_signup_test.go
+++ b/pkg/sys/it/race_signup_test.go
@@ -31,13 +31,11 @@ func Test_Race_SUsignUpIn(t *testing.T) {
 
 	wgUp := &sync.WaitGroup{}
 	logins := make(chan it.Login, loginCnt)
-	for i := 0; i < loginCnt; i++ {
-		wgUp.Add(1)
-		go func() {
-			defer wgUp.Done()
+	for range loginCnt {
+		wgUp.Go(func() {
 			login := vit.SignUp("login"+strconv.Itoa(vit.NextNumber()), "1", istructs.AppQName_test1_app1)
 			logins <- login
-		}()
+		})
 	}
 	wgUp.Wait()
 	close(logins)

--- a/pkg/sys/it/testdata/apps/test2.app1/image/pkg/sys/sys.vsql
+++ b/pkg/sys/it/testdata/apps/test2.app1/image/pkg/sys/sys.vsql
@@ -392,11 +392,17 @@ ABSTRACT WORKSPACE Workspace (
 		COMMAND UpdateJoinedWorkspaceRoles(UpdateJoinedWorkspaceRolesParams) WITH Tags=(WorkspaceOwnerFuncTag);
 		COMMAND DeactivateJoinedWorkspace(DeactivateJoinedWorkspaceParams) WITH Tags=(WorkspaceOwnerFuncTag);
 		QUERY QueryChildWorkspaceByName(QueryChildWorkspaceByNameParams) RETURNS QueryChildWorkspaceByNameResult WITH Tags=(WorkspaceOwnerFuncTag);
+		-- Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.
 		PROJECTOR ApplyInvitation AFTER EXECUTE ON (InitiateInvitationByEMail) STATE(sys.AppSecret) INTENTS(SendMail);
+		-- Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.
 		PROJECTOR ApplyCancelAcceptedInvite AFTER EXECUTE ON (InitiateCancelAcceptedInvite);
+		-- Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.
 		PROJECTOR ApplyJoinWorkspace AFTER EXECUTE ON (InitiateJoinWorkspace);
+		-- Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.
 		PROJECTOR ApplyLeaveWorkspace AFTER EXECUTE ON (InitiateLeaveWorkspace);
+		-- Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.
 		PROJECTOR ApplyUpdateInviteRoles AFTER EXECUTE ON (InitiateUpdateInviteRoles) STATE(sys.AppSecret) INTENTS(SendMail);
+		PROJECTOR ApplyInviteEvents AFTER EXECUTE ON (InitiateInvitationByEMail, InitiateJoinWorkspace, InitiateUpdateInviteRoles, InitiateCancelAcceptedInvite, InitiateLeaveWorkspace, CancelSentInvite) STATE(sys.AppSecret) INTENTS(SendMail);
 		SYNC PROJECTOR ProjectorInviteIndex AFTER EXECUTE ON (InitiateInvitationByEMail) INTENTS(sys.View(InviteIndexView));
 		SYNC PROJECTOR ProjectorJoinedWorkspaceIndex AFTER EXECUTE ON (CreateJoinedWorkspace) INTENTS(sys.View(JoinedWorkspaceIndexView));
 		SYNC PROJECTOR ApplyViewSubjectsIdx AFTER INSERT ON (Subject) INTENTS(sys.View(ViewSubjectsIdx));

--- a/pkg/sys/sys.vsql
+++ b/pkg/sys/sys.vsql
@@ -184,6 +184,8 @@ ABSTRACT WORKSPACE Workspace (
 		InviteID ref NOT NULL
 	);
 
+
+
 	TYPE CreateJoinedWorkspaceParams (
 		Roles text NOT NULL,
 		InvitingWorkspaceWSID int64 NOT NULL,
@@ -415,11 +417,17 @@ ABSTRACT WORKSPACE Workspace (
 		COMMAND UpdateJoinedWorkspaceRoles(UpdateJoinedWorkspaceRolesParams) WITH Tags=(WorkspaceOwnerFuncTag);
 		COMMAND DeactivateJoinedWorkspace(DeactivateJoinedWorkspaceParams) WITH Tags=(WorkspaceOwnerFuncTag);
 		QUERY QueryChildWorkspaceByName(QueryChildWorkspaceByNameParams) RETURNS QueryChildWorkspaceByNameResult WITH Tags=(WorkspaceOwnerFuncTag);
+		-- Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.
 		PROJECTOR ApplyInvitation AFTER EXECUTE ON (InitiateInvitationByEMail) STATE(sys.AppSecret) INTENTS(SendMail);
+		-- Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.
 		PROJECTOR ApplyCancelAcceptedInvite AFTER EXECUTE ON (InitiateCancelAcceptedInvite);
+		-- Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.
 		PROJECTOR ApplyJoinWorkspace AFTER EXECUTE ON (InitiateJoinWorkspace);
+		-- Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.
 		PROJECTOR ApplyLeaveWorkspace AFTER EXECUTE ON (InitiateLeaveWorkspace);
+		-- Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.
 		PROJECTOR ApplyUpdateInviteRoles AFTER EXECUTE ON (InitiateUpdateInviteRoles) STATE(sys.AppSecret) INTENTS(SendMail);
+		PROJECTOR ApplyInviteEvents AFTER EXECUTE ON (InitiateInvitationByEMail, InitiateJoinWorkspace, InitiateUpdateInviteRoles, InitiateCancelAcceptedInvite, InitiateLeaveWorkspace, CancelSentInvite) STATE(sys.AppSecret) INTENTS(SendMail);
 		SYNC PROJECTOR ProjectorInviteIndex AFTER EXECUTE ON (InitiateInvitationByEMail) INTENTS(sys.View(InviteIndexView));
 		SYNC PROJECTOR ProjectorJoinedWorkspaceIndex AFTER EXECUTE ON (CreateJoinedWorkspace) INTENTS(sys.View(JoinedWorkspaceIndexView));
 		SYNC PROJECTOR ApplyViewSubjectsIdx AFTER INSERT ON (Subject) INTENTS(sys.View(ViewSubjectsIdx));

--- a/pkg/vit/schemaTestApp1.vsql
+++ b/pkg/vit/schemaTestApp1.vsql
@@ -822,6 +822,7 @@ ALTERABLE WORKSPACE test_wsWS (
 	ROLE Updated; -- need for invite tests
 	ROLE SpecialAPITokenRole; -- need to test foreign auth using APIToken
 	ROLE LimitedAccessRole; -- need to test ACL
+	ROLE InviteTestRole; -- non-system role used in invite tests as a substitute for sys.WorkspaceOwner
 
 	TAG WorkspaceOwnerTableTag;
 	TAG WorkspaceOwnerFuncTag;
@@ -851,10 +852,13 @@ ALTERABLE WORKSPACE test_wsWS (
 	GRANT EXECUTE ON QUERY sys.Collection TO SpecialAPITokenRole;
 	GRANT SELECT ON TABLE articles TO SpecialAPITokenRole;
 
+	
 	GRANT SELECT, INSERT, UPDATE, ACTIVATE, DEACTIVATE ON ALL TABLES WITH TAG WorkspaceOwnerTableTag TO sys.WorkspaceOwner;
+	GRANT SELECT, INSERT, UPDATE, ACTIVATE, DEACTIVATE ON ALL TABLES WITH TAG WorkspaceOwnerTableTag TO InviteTestRole;
 
 	GRANT EXECUTE ON ALL QUERIES WITH TAG WorkspaceOwnerFuncTag TO sys.WorkspaceOwner;
 	GRANT EXECUTE ON ALL COMMANDS WITH TAG WorkspaceOwnerFuncTag TO sys.WorkspaceOwner;
+	GRANT EXECUTE ON COMMAND sys.CUD TO InviteTestRole;
 
 	GRANT SELECT(Fld1) ON TABLE TestCDocWithDeniedFields TO sys.WorkspaceOwner;
 

--- a/uspecs/changes/archive/2604/2604241432-projector-state-guards/change.md
+++ b/uspecs/changes/archive/2604/2604241432-projector-state-guards/change.md
@@ -1,0 +1,43 @@
+---
+registered_at: 2026-04-24T10:00:36Z
+change_id: 2604241000-projector-state-guards
+baseline: f91d1438f6fbf47ffd247bb8d06e47cfdff55e6e
+issue_url: https://untill.atlassian.net/browse/AIR-3704
+pre_cleanup_head: a917956fcaeeeb1ae5acdacabad2f83a316da9dc
+pre_pr_head: 469ba0d4bcb10345ea6c19f4f2a95c607d09631d
+archived_at: 2026-04-24T14:32:29Z
+---
+
+# Change request: Refactor invite flow - single projector and roles validation
+
+## Why
+
+Invitations can get stuck in transitional states (`State_ToBeInvited`, `State_ToBeJoined`) when async projectors fail. The `ApplyJoinWorkspace` projector had an early-return bug that skipped updating invite state when an inactive Subject existed, leaving invites permanently stuck in `State_ToBeJoined`. Even after fixing the projector (change [2604221416-fix-reinvite-after-removal](../2604221416-fix-reinvite-after-removal/change.md)), already-stuck invites could not be recovered because commands `InitiateInvitationByEMail` and `CancelSentInvite` did not accept these transitional states.
+
+PR [#4511](https://github.com/voedger/voedger/pull/4511) restored recovery by letting those commands accept `ToBe*` states. Reviewers then identified a race between commands and async projectors `ApplyInvitation` / `ApplyJoinWorkspace`: stale projector events could overwrite recovered state (e.g., flip `Cancelled` back to `Invited`). The initial plan added projector state guards plus dedicated commands `c.sys.CompleteInvitation` / `c.sys.CompleteJoinWorkspace`, but analysis showed this preserved the underlying problem - commands and projectors both mutating Invite state. A simpler design segregates concerns: commands accept input, pre-validate, and persist data fields only; a single projector applies state transitions and side effects atomically.
+
+A second concern surfaced during this work: invite Roles were never validated, so any workspace owner could grant arbitrary, malformed, or `sys.*` roles.
+
+## What
+
+Invite flow refactor (segregation of concerns):
+
+- Replace 5 separate invite projectors with a single `ap.sys.ApplyInviteEvents` projector reacting to all invite commands
+- Move all invite state transitions and side effects out of commands into the single projector
+- Keep commands responsible for data writes and pre-validation only; remove non-initial `State` writes
+- Remove `c.sys.CompleteInvitation` and `c.sys.CompleteJoinWorkspace` commands and their params
+- Remove projector test hooks (`OnBeforeApply*`, `OnAfterGuard*`) and the projector-state-guards machinery
+- Preserve all `State_*` numeric values for backward compatibility; keep `ToBeInvited` written by `InitiateInvitationByEMail` as the only legitimate `ToBe*` write
+- Keep legacy `ToBe*` states accepted by command pre-validation so old stuck records remain recoverable
+
+Roles validation:
+
+- Add `validateInviteRoles` helper that rejects malformed QNames, system roles (`sys.*`), and roles not declared in the target workspace
+- Call `validateInviteRoles` in `InitiateInvitationByEMail` and `InitiateUpdateInviteRoles`
+- Convert `iauthnz.IsSystemRole` to a package-prefix check (`role.Pkg() == appdef.SysPackage`) instead of a static slice
+- Rename test role `app1pkg.WorkspaceSubject` to `app1pkg.InviteTestRole` for clarity
+
+Specifications:
+
+- Update `uspecs/specs/prod/prod--domain.md`: expand auth context with workspace membership
+- Update `uspecs/specs/prod/auth/invites--td.md`: replace state diagram and projector design with single-projector model, mark legacy `ToBe*` states

--- a/uspecs/changes/archive/2604/2604241432-projector-state-guards/how.md
+++ b/uspecs/changes/archive/2604/2604241432-projector-state-guards/how.md
@@ -1,0 +1,25 @@
+# How: Refactor invite flow - single projector and roles validation
+
+## Approach
+
+- Segregate concerns between command and projector
+  - Commands persist input data and pre-validate; they do not write transitional `ToBe*` states (except initial `ToBeInvited` written by `InitiateInvitationByEMail`)
+  - A single async projector `ap.sys.ApplyInviteEvents` reacts to all invite commands and performs state transitions plus federation calls atomically
+  - Projector re-validates the actual state of the Invite record at execution time and skips silently when the state has already moved on (idempotency, replay safety)
+- Replace 5 dedicated projectors with one VSQL declaration in `sys.vsql`: `PROJECTOR ApplyInviteEvents AFTER EXECUTE ON (InitiateInvitationByEMail, InitiateJoinWorkspace, InitiateUpdateInviteRoles, InitiateCancelAcceptedInvite, InitiateLeaveWorkspace, CancelSentInvite)`
+- Drop the `c.sys.CompleteInvitation` / `c.sys.CompleteJoinWorkspace` commands and the projector test hooks - they are not needed under segregation of concerns
+- Preserve numeric values of all `State_*` constants in `consts.go` and accept legacy `ToBe*` states in command pre-validation so old stuck records remain recoverable
+- Validate Roles strings in invite commands using `validateInviteRoles` in `utils.go` (split on comma, parse QName, reject `sys.*` package, reject roles not in workspace types)
+- Detect system roles by package prefix in `iauthnz/utils.go` (`role.Pkg() == appdef.SysPackage`) rather than maintaining a static `SysRoles` slice
+
+References:
+
+- [pkg/sys/invite/consts.go](../../../../../pkg/sys/invite/consts.go)
+- [pkg/sys/invite/provide.go](../../../../../pkg/sys/invite/provide.go)
+- [pkg/sys/invite/impl_applyinviteevents.go](../../../../../pkg/sys/invite/impl_applyinviteevents.go)
+- [pkg/sys/invite/utils.go](../../../../../pkg/sys/invite/utils.go)
+- [pkg/sys/sys.vsql](../../../../../pkg/sys/sys.vsql)
+- [pkg/iauthnz/utils.go](../../../../../pkg/iauthnz/utils.go)
+- [pkg/sys/it/impl_invite_test.go](../../../../../pkg/sys/it/impl_invite_test.go)
+- [uspecs/specs/prod/auth/invites--td.md](../../../../specs/prod/auth/invites--td.md)
+- [uspecs/specs/prod/prod--domain.md](../../../../specs/prod/prod--domain.md)

--- a/uspecs/changes/archive/2604/2604241432-projector-state-guards/impl.md
+++ b/uspecs/changes/archive/2604/2604241432-projector-state-guards/impl.md
@@ -1,0 +1,103 @@
+# Implementation plan: Refactor invite flow - single projector and roles validation
+
+## Functional design
+
+- [x] update: [prod--domain.md](../../../../specs/prod/prod--domain.md)
+  - update: Expand auth context description to include workspace membership (invites, subjects, role assignments)
+
+## Technical design
+
+- [x] update: [invites--td.md](../../../../specs/prod/auth/invites--td.md)
+  - replace: state diagram - mark legacy `ToBe*` states, single-projector transitions
+  - replace: projector guards section with single-projector design
+  - remove: CompleteInvitation, CompleteJoinWorkspace from commands list
+  - update: Decisions section
+
+## Construction
+
+### Segregation of concerns
+
+- [x] update: [sys.vsql](../../../../../pkg/sys/sys.vsql)
+  - remove: CompleteInvitationParams, CompleteJoinWorkspaceParams types
+  - remove: CompleteInvitation, CompleteJoinWorkspace commands
+  - add: ApplyInviteEvents projector declaration `AFTER EXECUTE ON (InitiateInvitationByEMail, InitiateJoinWorkspace, InitiateUpdateInviteRoles, InitiateCancelAcceptedInvite, InitiateLeaveWorkspace, CancelSentInvite)`
+  - keep: 5 original PROJECTOR declarations (ApplyInvitation, ApplyJoinWorkspace, ApplyUpdateInviteRoles, ApplyCancelAcceptedInvite, ApplyLeaveWorkspace) marked `-- Deprecated: superseded by ApplyInviteEvents. Kept for backward compatibility only.`
+- [x] update: [test2.app1 sys.vsql](../../../../../pkg/sys/it/testdata/apps/test2.app1/image/pkg/sys/sys.vsql)
+  - mirror: same projector additions and deprecation markers as `pkg/sys/sys.vsql`
+- [x] update: [consts.go](../../../../../pkg/sys/invite/consts.go)
+  - keep: all `State_*` constants (numeric values preserved)
+  - remove: QNames for CompleteInvitation, CompleteJoinWorkspace
+  - add: `qNameAPApplyInviteEvents`
+  - keep: 5 original projector QNames (`qNameAPApplyInvitation`, `qNameAPApplyJoinWorkspace`, `qNameAPApplyUpdateInviteRoles`, `qNameAPApplyCancelAcceptedInvite`, `qNameAPApplyLeaveWorkspace`) for the deprecated no-op providers
+  - remove: test hooks (`OnBeforeApply*`, `OnAfterGuard*`)
+  - update: `inviteValidStates` (keep `ToBe*` for old data recovery)
+- [x] add: [impl_applyinviteevents.go](../../../../../pkg/sys/invite/impl_applyinviteevents.go)
+  - add: `ap.sys.ApplyInviteEvents` projector handling all invite events
+  - add: per-command handlers re-validate actual state and apply transition + side effects, skip stale events
+- [x] update: [impl_applyinvitation.go](../../../../../pkg/sys/invite/impl_applyinvitation.go)
+  - replace: original handler with shared `deprecatedNullProjector` no-op (returns nil)
+  - mark: `asyncProjectorApplyInvitation()` provider as `// Deprecated: superseded by asyncProjectorApplyInviteEvents. Kept for backward compatibility only.`
+- [x] update: [impl_applyjoinworkspace.go](../../../../../pkg/sys/invite/impl_applyjoinworkspace.go)
+  - replace: original handler with `deprecatedNullProjector`; mark provider deprecated
+- [x] update: [impl_applyupdateinviteroles.go](../../../../../pkg/sys/invite/impl_applyupdateinviteroles.go)
+  - replace: original handler with `deprecatedNullProjector`; mark provider deprecated
+- [x] update: [impl_applycancelacceptedinvite.go](../../../../../pkg/sys/invite/impl_applycancelacceptedinvite.go)
+  - replace: original handler with `deprecatedNullProjector`; mark provider deprecated
+- [x] update: [impl_applyleaveworkspace.go](../../../../../pkg/sys/invite/impl_applyleaveworkspace.go)
+  - replace: original handler with `deprecatedNullProjector`; mark provider deprecated
+- [x] update: [provide.go](../../../../../pkg/sys/invite/provide.go)
+  - register: ApplyInviteEvents projector
+  - register: 5 deprecated no-op projectors (kept for backward compatibility)
+  - remove: Complete* command registrations
+- [x] update: [impl_initiateinvitationbyemail.go](../../../../../pkg/sys/invite/impl_initiateinvitationbyemail.go)
+  - keep: Invite CDoc create/update with data fields and `State=ToBeInvited`
+- [x] update: [impl_initiatejoinworkspace.go](../../../../../pkg/sys/invite/impl_initiatejoinworkspace.go)
+  - keep: InviteeProfileWSID/SubjectKind/ActualLogin writes
+  - remove: State write
+- [x] update: [impl_initiateupdateinviteroles.go](../../../../../pkg/sys/invite/impl_initiateupdateinviteroles.go)
+  - remove: all CUD on Invite (projector writes Roles)
+- [x] update: [impl_initiatecancelacceptedinvite.go](../../../../../pkg/sys/invite/impl_initiatecancelacceptedinvite.go)
+  - remove: all CUD on Invite
+- [x] update: [impl_initiateleaveworkspace.go](../../../../../pkg/sys/invite/impl_initiateleaveworkspace.go)
+  - keep: no-op CUD (carries InviteID to projector via event.CUDs)
+  - remove: State/IsActive/Updated writes
+- [x] update: [impl_cancelsentinvite.go](../../../../../pkg/sys/invite/impl_cancelsentinvite.go)
+  - remove: all CUD on Invite
+
+### Roles validation
+
+- [x] update: [iauthnz/utils.go](../../../../../pkg/iauthnz/utils.go)
+  - update: `IsSystemRole` uses package prefix check (`role.Pkg() == appdef.SysPackage`)
+  - remove: `slices` import and `SysRoles` usage from `IsSystemRole`
+- [x] update: [iauthnzimpl/impl_test.go](../../../../../pkg/iauthnzimpl/impl_test.go)
+  - update: IssueAPIToken test allowed case uses non-sys QName (e.g. `appdef.NewQName("test", "role")`)
+- [x] add: [invite/utils.go](../../../../../pkg/sys/invite/utils.go)
+  - add: `validateInviteRoles(rolesStr string, ws appdef.IWorkspace) error`
+  - logic: split by comma, trim, parse QName, reject `sys.*`, reject roles not declared in workspace
+  - return: `coreutils.NewHTTPError(http.StatusBadRequest, ...)`
+- [x] add: [invite/utils_test.go](../../../../../pkg/sys/invite/utils_test.go)
+  - add: extensive unit tests for `validateInviteRoles`
+- [x] update: [impl_initiateinvitationbyemail.go](../../../../../pkg/sys/invite/impl_initiateinvitationbyemail.go)
+  - add: call `validateInviteRoles` early
+- [x] update: [impl_initiateupdateinviteroles.go](../../../../../pkg/sys/invite/impl_initiateupdateinviteroles.go)
+  - add: call `validateInviteRoles` early
+
+### Tests
+
+- [x] update: [impl_invite_test.go](../../../../../pkg/sys/it/impl_invite_test.go)
+  - remove: `TestCompleteInvitation`, `TestCompleteJoinWorkspace`
+  - remove: `TestProjectorStateGuards`
+  - update: `TestInvite_BasicUsage` (states go directly to Invited/Joined, no `ToBe*`)
+  - add: projector idempotency test (stale events skipped)
+  - add: old `ToBe*` state handling test (migration compatibility)
+  - add: `TestInvite_RolesValidation` cases:
+    - malformed QName -> HTTP 400
+    - `sys.WorkspaceOwner` -> HTTP 400
+    - non-existent role (`app1pkg.NonExistentRole`) -> HTTP 400
+    - whitespace-only / leading comma / duplicate role -> HTTP 400
+- [x] update: [schemaTestApp1.vsql](../../../../../pkg/vit/schemaTestApp1.vsql)
+  - rename: `app1pkg.WorkspaceSubject` -> `app1pkg.InviteTestRole`
+- [x] update: [impl_deactivateworkspace_test.go](../../../../../pkg/sys/it/impl_deactivateworkspace_test.go)
+  - update: references to renamed test role
+
+- [x] Review

--- a/uspecs/specs/prod/auth/invites--td.md
+++ b/uspecs/specs/prod/auth/invites--td.md
@@ -1,0 +1,268 @@
+# Feature technical design: Invites
+
+Invite users/devices to workspaces
+
+## Use cases
+
+- Invite to workspace
+- As a workspace owner I want to change invited user's roles
+- As a user, I want to see the list of my workspaces and roles, so that I know what I can work with
+- As a user, I want to be able to leave the workspace I'm invited to
+- As a workspace owner I want to ban a user so they no longer have access to my workspace
+
+---
+
+## Overview
+
+Roles and permissions (from VSQL):
+
+- `WorkspaceOwner`: manages invitations, roles, and membership (WorkspaceOwnerFuncTag)
+- `AuthenticatedUser`: can join and leave workspaces (AllowedToAuthenticatedTag)
+
+Key documents:
+
+- `cdoc.sys.Invite`: tracks invitation status and metadata
+- `cdoc.sys.Subject`: represents an invited user/device in the workspace
+- `cdoc.sys.JoinedWorkspace`: records workspace membership in invitee's profile
+
+Invitation management:
+
+- `c.sys.InitiateInvitationByEMail`: creates new invitation (WorkspaceOwner)
+  - Params: Email, Roles, ExpireDatetime, EmailTemplate, EmailSubject
+- `c.sys.InitiateJoinWorkspace`: processes invite acceptance (AuthenticatedUser)
+  - Params: InviteID, VerificationCode
+
+Role management:
+
+- `c.sys.InitiateUpdateInviteRoles`: updates member permissions (WorkspaceOwner)
+  - Params: InviteID, Roles, EmailTemplate, EmailSubject
+
+Membership termination:
+
+- `c.sys.InitiateCancelAcceptedInvite`: owner removes joined member (WorkspaceOwner)
+  - Params: InviteID
+- `c.sys.InitiateLeaveWorkspace`: member voluntarily leaves (AuthenticatedUser)
+  - No params (invite found by login from auth token)
+- `c.sys.CancelSentInvite`: cancels pending invitation (WorkspaceOwner)
+  - Params: InviteID
+
+Internal commands (called by projectors via Federation):
+
+- `c.sys.CreateJoinedWorkspace`: creates JoinedWorkspace record in invitee's profile
+- `c.sys.UpdateJoinedWorkspaceRoles`: updates roles in invitee's JoinedWorkspace
+- `c.sys.DeactivateJoinedWorkspace`: deactivates JoinedWorkspace when member removed
+
+---
+
+## Technical design
+
+### Data
+
+```mermaid
+    flowchart TD
+
+    WorkspaceOwner["role.sys.WorkspaceOwner"]:::B
+    WorkspaceAdmin["role.sys.WorkspaceAdmin"]:::B
+    SubjectRole["role.sys.Subject"]:::B
+    Inviter["Inviter"]:::B
+    Invitee["Invitee"]:::B
+
+
+    registry[(registry)]:::H
+        Login["cdoc.Login"]:::H
+
+    InviteeProfile[(InviteeProfile)]:::H
+    JoinedWorkspace["cdoc.sys.JoinedWorkspace"]:::H
+
+
+    InvitingWorkspace[(InvitingWorkspace)]:::H
+        InvitingWorkspace --x Invite["cdoc.sys.Invite"]:::H
+        Invite --- State(["State"]):::H
+        Invite --- InviteRoles(["Roles"]):::H
+        InvitingWorkspace --x Subject["cdoc.sys.Subject"]:::H
+
+    InvitesService([Invites Service]):::S
+
+    Subject -.- Invite
+    Subject -.- |gives| SubjectRole
+
+    InviteeProfile --- JoinedWorkspace
+
+    InvitesService -.- |creates| Subject
+    InvitesService -.- |reads| Invite
+    InvitesService -.- |can create| Login
+    InvitesService -.- |creates| JoinedWorkspace
+
+    Inviter -.- |creates, updates| Invite
+    Inviter -.- |must be| WorkspaceAdmin
+
+    WorkspaceOwner -.- |is| WorkspaceAdmin
+
+    registry --x Login
+
+    Invitee x-.- |joins WS using| Invite
+    Invitee --- InviteeProfile
+
+    JoinedWorkspace -.-x InvitingWorkspace
+
+
+    classDef G fill:#FFFFFF,color:#333,stroke:#000000, stroke-width:1px, stroke-dasharray: 5 5
+    classDef B fill:#FFFFB5,color:#333
+    classDef S fill:#B5FFFF,color:#333
+    classDef H fill:#C9E7B7,color:#333
+
+```
+
+---
+
+### Invite state diagram
+
+Final states: Invited, Joined, Cancelled, Left (written by projector).
+Transient state: ToBeInvited (written by command, transitioned to Invited by projector).
+Dead states (ToBeJoined, ToUpdateRoles, ToBeCancelled, ToBeLeft) -- only in old data, no longer written.
+
+`InitiateInvitationByEMail` writes State=ToBeInvited (CDoc must have a State on
+creation; on re-invite it resets State so projector knows to send a new email).
+All final state transitions are performed by `ap.sys.ApplyInviteEvents` projector.
+
+```mermaid
+stateDiagram-v2
+
+    [*] --> ToBeInvited : c.sys.InitiateInvitationByEMail() by Inviter
+
+    ToBeInvited --> Invited : ap.sys.ApplyInviteEvents()
+
+    Invited --> Joined : c.sys.InitiateJoinWorkspace() by Invitee
+    Invited --> Cancelled : c.sys.CancelSentInvite() by Inviter
+
+    Joined --> Cancelled : c.sys.InitiateCancelAcceptedInvite() by Inviter
+    Joined --> Left : c.sys.InitiateLeaveWorkspace() by Invitee
+    Joined --> Joined : c.sys.InitiateUpdateInviteRoles() by Inviter
+```
+
+Re-invite and recovery transitions:
+
+```mermaid
+stateDiagram-v2
+
+    ToBeInvited --> ToBeInvited : c.sys.InitiateInvitationByEMail() by Inviter
+    ToBeInvited --> Cancelled : c.sys.CancelSentInvite() by Inviter
+    Cancelled --> ToBeInvited : c.sys.InitiateInvitationByEMail() by Inviter
+    Left --> ToBeInvited : c.sys.InitiateInvitationByEMail() by Inviter
+```
+
+---
+
+### Single projector design
+
+Commands do pre-validation (immediate 400 for invalid requests).
+The projector re-validates actual state before applying transitions (source of truth).
+
+`ap.sys.ApplyInviteEvents` is the sole writer of final states on `cdoc.sys.Invite`.
+It triggers on all 6 invite commands and handles each event type:
+
+- `InitiateInvitationByEMail`: ToBeInvited -> Invited, send invitation email
+- `InitiateJoinWorkspace`: Invited -> Joined, create Subject, create JoinedWorkspace via federation
+- `InitiateUpdateInviteRoles`: keep State=Joined, update Roles on Invite CDoc, update Subject/JoinedWorkspace roles via federation, send email
+- `InitiateCancelAcceptedInvite`: Joined -> Cancelled, deactivate Subject/JoinedWorkspace via federation
+- `InitiateLeaveWorkspace`: Joined -> Left, set IsActive=false, deactivate Subject/JoinedWorkspace via federation
+- `CancelSentInvite`: Invited/ToBeInvited -> Cancelled
+
+If actual state does not match the expected source state for the event, the projector skips the event (stale).
+
+Projector gets InviteID from:
+
+- `event.ArgumentObject().AsRecordID(field_InviteID)` for commands that have InviteID param
+- `InitiateInvitationByEMail`: from event CUDs (command creates/updates Invite CDoc)
+- `InitiateLeaveWorkspace`: from event CUDs. Command has no InviteID param and
+  projector has no access to auth token, so command keeps a no-op CUD on the
+  Invite CDoc (touch record, no meaningful field writes) as the only way to
+  pass InviteID to the projector
+
+Dead ToBe states in old data are treated as their source state:
+
+- ToBeJoined -> treat as Invited (apply join)
+- ToUpdateRoles -> treat as Joined (apply role update)
+- ToBeCancelled -> treat as Joined (apply cancel)
+- ToBeLeft -> treat as Joined (apply leave)
+
+Legacy deprecated projectors (`ap.sys.ApplyInvitation`, `ap.sys.ApplyJoinWorkspace`, `ap.sys.ApplyUpdateInviteRoles`, `ap.sys.ApplyCancelAcceptedInvite`, `ap.sys.ApplyLeaveWorkspace`) are kept declared as no-op handlers for backward compatibility; they perform no state changes or side effects. `ap.sys.ApplyInviteEvents` is the sole writer.
+
+---
+
+### Documents
+
+#### cdoc.sys.Invite
+
+- SubjectKind int32 // 1: User, 2: Device
+- Login varchar NOT NULL // email address set by InitiateInvitationByEMail
+- Email varchar NOT NULL // same as Login
+- Roles varchar(1024)
+- ExpireDatetime int64 // unix-timestamp
+- VerificationCode varchar // set by ap.sys.ApplyInviteEvents
+- State int32 NOT NULL // see state diagram; ToBeInvited by command, final states by projector
+- Created int64 // unix-timestamp, set on creation
+- Updated int64 NOT NULL // unix-timestamp, updated on every state change
+- SubjectID ref // set by ap.sys.ApplyInviteEvents
+- InviteeProfileWSID int64 // set by c.sys.InitiateJoinWorkspace
+- ActualLogin varchar // invitee's login from token, set by c.sys.InitiateJoinWorkspace
+- UNIQUEFIELD Email
+
+#### cdoc.sys.Subject
+
+- Login varchar NOT NULL // Invite.ActualLogin (invitee's login from token)
+- SubjectKind int32 NOT NULL // 1: User, 2: Device
+- Roles varchar(1024) NOT NULL // comma-separated
+- ProfileWSID int64 NOT NULL
+- UNIQUEFIELD Login
+
+#### cdoc.sys.JoinedWorkspace
+
+Stored in invitee's profile workspace.
+
+- Roles varchar(1024) NOT NULL // comma-separated
+- InvitingWorkspaceWSID int64 NOT NULL
+- WSName varchar NOT NULL
+
+---
+
+## Decisions
+
+### Single projector as sole writer of final states
+
+Commands and projectors previously both wrote to the Invite CDoc, causing TOCTOU
+races and requiring guards and validated commands (CompleteInvitation,
+CompleteJoinWorkspace) as mitigation.
+
+New design: a single projector (`ap.sys.ApplyInviteEvents`) is the sole writer
+of final states (Invited, Joined, Cancelled, Left). It processes events in PLog
+order -- serialized, no races.
+
+`InitiateInvitationByEMail` writes transient State=ToBeInvited because the CDoc
+must have a State on creation (and on re-invite, to signal the projector).
+`InitiateJoinWorkspace` writes data fields from the auth token (InviteeProfileWSID,
+SubjectKind, ActualLogin) but does not write State. `InitiateLeaveWorkspace`
+keeps a no-op CUD to pass InviteID to the projector (no InviteID param, no auth
+token in projector). All other commands do no CUD.
+
+### Stale event handling
+
+Between command pre-validation and projector execution, other events may change
+the invite state. The projector re-validates actual state before applying
+transitions. If the state no longer matches the expected source state for the
+event, the projector skips it silently.
+
+Example: user calls CancelSentInvite (pre-validates state=Invited, creates
+event), then another command changes state before the projector runs. The
+projector sees the new state, determines the cancel event is stale, and skips.
+
+### Federation side effects and eventual consistency
+
+`ApplyInviteEvents` makes federation calls (create Subject, create/update/
+deactivate JoinedWorkspace) before writing the final state. If the projector
+fails after federation calls but before state write, the calls are already
+applied. On retry, the projector re-applies them (operations are idempotent).
+
+If a cancel event arrives while a join is in progress, the join's side effects
+(Subject, JoinedWorkspace) persist briefly. The cancel event's handler
+eventually deactivates them, so the system converges to the correct state.

--- a/uspecs/specs/prod/prod--domain.md
+++ b/uspecs/specs/prod/prod--domain.md
@@ -12,6 +12,10 @@ Roles:
   - Develops Voedger applications using VSQL and WASM extensions
 - 👤Admin
   - Deploys and manages Voedger clusters and infrastructure
+- 👤WorkspaceOwner
+  - Manages workspace content, invitations, and member roles
+- 👤AuthenticatedUser
+  - Any user with a valid auth token, can join/leave workspaces
 
 Systems:
 
@@ -23,56 +27,6 @@ Systems:
 - ⚙️ACME
   - Automated certificate management and provisioning service
 
-## Context map
-
-```mermaid
-flowchart TB
-    storage[("🎯 storage<br/>Data persistence & retrieval")]:::S
-    apps["🎯 apps<br/>Application lifecycle"]:::S
-    extensions["🎯 extensions<br/>WASM runtime"]:::S
-    auth["🎯 auth<br/>Authentication & authorization"]:::S
-    routing["🎯 routing<br/>Request routing"]:::S
-    observability["🎯 observability<br/>Metrics & insights"]:::S
-
-    storage -->|"Persist events & state<br/>Retrieve data (CQRS)"| apps
-    extensions -->|"Execute WASM extensions<br/>Manage extension state"| apps
-    auth -->|"Validate permissions<br/>Enforce access policies"| apps
-    apps -->|"Resolve requests<br/>Discover endpoints"| routing
-    auth -->|"Authenticate requests<br/>Validate JWT tokens"| routing
-    storage -->|"Performance metrics<br/>Capacity tracking"| observability
-    apps -->|"Performance metrics<br/>Workspace statistics"| observability
-    auth -->|"Security context<br/>Access policies"| extensions
-
-    classDef S fill:#B5FFFF,color:#333
-```
-
-Detailed relationships between contexts:
-
-- 🎯storage -> |supplier-customer| 🎯apps
-  - Persist application events and state
-  - Retrieve application data with CQRS patterns
-- 🎯extensions -> |supplier-customer| 🎯apps
-  - Execute WASM extensions for commands and queries
-  - Manage extension state and resources
-- 🎯auth -> |supplier-customer| 🎯apps
-  - Validate user permissions for application operations
-  - Enforce workspace-level access policies
-- 🎯apps -> |supplier-customer| 🎯routing
-  - Resolve incoming requests to target applications
-  - Discover application endpoints and workspaces
-- 🎯auth -> |supplier-customer| 🎯routing
-  - Authenticate incoming requests
-  - Validate JWT tokens
-- 🎯storage -> |supplier-customer| 🎯observability
-  - Provide storage performance and health metrics
-  - Track storage capacity and usage
-- 🎯apps -> |supplier-customer| 🎯observability
-  - Collect application performance metrics
-  - Track workspace and partition statistics
-- 🎯auth -> |supplier-customer| 🎯extensions
-  - Provide security context for extension execution
-  - Enforce access policies within extensions
-
 ## Contexts
 
 ### apps
@@ -81,11 +35,11 @@ Application lifecycle management including deployment, versioning, and workspace
 
 Relationships with external actors:
 
-- 🎯apps -> |supplier-customer| 👤VADeveloper
+- 📦apps -> |supplier-customer| 👤VADeveloper
   - Define data schemas using VSQL
   - Develop WASM extensions
   - Deploy applications to Voedger platform
-- 🎯apps -> |supplier-customer| ⚙️Client
+- 📦apps -> |supplier-customer| ⚙️Client
   - Execute commands and queries
   - Access workspace data
   - Interact with application features via HTTP/HTTPS APIs
@@ -96,7 +50,7 @@ Data persistence and retrieval with event sourcing, CQRS, and multi-backend supp
 
 Relationships with external actors:
 
-- ⚙️DBMS -> |supplier-customer| 🎯storage
+- ⚙️DBMS -> |supplier-customer| 📦storage
   - Store and retrieve data with consistency guarantees
   - Support multiple backend implementations (ScyllaDB, BBolt, DynamoDB)
 
@@ -106,18 +60,27 @@ Request routing, domain management, and HTTPS certificate provisioning.
 
 Relationships with external actors:
 
-- 🎯routing -> |supplier-customer| 👤Admin
+- 📦routing -> |supplier-customer| 👤Admin
   - Configure domain routing and certificates
   - Deploy Voedger clusters
   - Manage infrastructure settings
-- ⚙️ACME -> |supplier-customer| 🎯routing
+- ⚙️ACME -> |supplier-customer| 📦routing
   - Obtain SSL/TLS certificates for configured domains
   - Handle ACME HTTP-01 challenges
   - Renew certificates automatically
 
 ### auth
 
-Authentication, authorization, and token management.
+Authentication, authorization, token management, and workspace membership.
+
+Relationships with external actors:
+
+- 📦auth -> |supplier-customer| ⚙️Client
+  - Authenticate requests with JWT tokens
+- 📦auth -> |supplier-customer| 👤WorkspaceOwner
+  - Manage workspace membership (invite, cancel, update roles)
+- 📦auth -> |supplier-customer| 👤AuthenticatedUser
+  - Join workspace, leave workspace
 
 ### extensions
 
@@ -129,7 +92,7 @@ System metrics, logs, traces, and insights for understanding system behavior and
 
 Relationships with external actors:
 
-- 🎯observability -> |supplier-customer| 👤Admin
+- 📦observability -> |supplier-customer| 👤Admin
   - Access observability dashboards
   - View system metrics, logs, and traces
   - Configure alerts and thresholds


### PR DESCRIPTION
registered_at: 2026-04-24T10:00:36Z
change_id: 2604241000-projector-state-guards
baseline: f91d1438f6fbf47ffd247bb8d06e47cfdff55e6e
issue_url: https://untill.atlassian.net/browse/AIR-3704
pre_cleanup_head: a917956fcaeeeb1ae5acdacabad2f83a316da9dc
pre_pr_head: 469ba0d4bcb10345ea6c19f4f2a95c607d09631d
archived_at: 2026-04-24T14:32:29Z

# Change request: Refactor invite flow - single projector and roles validation

## Why

Invitations can get stuck in transitional states (`State_ToBeInvited`, `State_ToBeJoined`) when async projectors fail. The `ApplyJoinWorkspace` projector had an early-return bug that skipped updating invite state when an inactive Subject existed, leaving invites permanently stuck in `State_ToBeJoined`. Even after fixing the projector (change [2604221416-fix-reinvite-after-removal](../2604221416-fix-reinvite-after-removal/change.md)), already-stuck invites could not be recovered because commands `InitiateInvitationByEMail` and `CancelSentInvite` did not accept these transitional states.

PR [#4511](https://github.com/voedger/voedger/pull/4511) restored recovery by letting those commands accept `ToBe*` states. Reviewers then identified a race between commands and async projectors `ApplyInvitation` / `ApplyJoinWorkspace`: stale projector events could overwrite recovered state (e.g., flip `Cancelled` back to `Invited`). The initial plan added projector state guards plus dedicated commands `c.sys.CompleteInvitation` / `c.sys.CompleteJoinWorkspace`, but analysis showed this preserved the underlying problem - commands and projectors both mutating Invite state. A simpler design segregates concerns: commands accept input, pre-validate, and persist data fields only; a single projector applies state transitions and side effects atomically.

A second concern surfaced during this work: invite Roles were never validated, so any workspace owner could grant arbitrary, malformed, or `sys.*` roles.

## What

Invite flow refactor (segregation of concerns):

- Replace 5 separate invite projectors with a single `ap.sys.ApplyInviteEvents` projector reacting to all invite commands
- Move all invite state transitions and side effects out of commands into the single projector
- Keep commands responsible for data writes and pre-validation only; remove non-initial `State` writes
- Remove `c.sys.CompleteInvitation` and `c.sys.CompleteJoinWorkspace` commands and their params
- Remove projector test hooks (`OnBeforeApply*`, `OnAfterGuard*`) and the projector-state-guards machinery
- Preserve all `State_*` numeric values for backward compatibility; keep `ToBeInvited` written by `InitiateInvitationByEMail` as the only legitimate `ToBe*` write
- Keep legacy `ToBe*` states accepted by command pre-validation so old stuck records remain recoverable

Roles validation:

- Add `validateInviteRoles` helper that rejects malformed QNames, system roles (`sys.*`), and roles not declared in the target workspace
- Call `validateInviteRoles` in `InitiateInvitationByEMail` and `InitiateUpdateInviteRoles`
- Convert `iauthnz.IsSystemRole` to a package-prefix check (`role.Pkg() == appdef.SysPackage`) instead of a static slice
- Rename test role `app1pkg.WorkspaceSubject` to `app1pkg.InviteTestRole` for clarity

Specifications:

- Update `uspecs/specs/prod/prod--domain.md`: expand auth context with workspace membership


---
(truncated -- see change.md for full details)
