### PR TITLE
[AIR-3768] Skip pre-refactor invite events in ap.sys.ApplyInviteEvents via Version marker

### DIFF
--- a/pkg/sys/invite/consts.go
+++ b/pkg/sys/invite/consts.go
@@ -61,6 +61,7 @@ const (
 	Field_SubjectID             = "SubjectID"
 	Field_LoginHash             = "LoginHash"
 	field_ActualLogin           = "ActualLogin"
+	Field_Version               = "Version"
 )
 
 //go:generate stringer -type=State -output=stringer_state.go

--- a/pkg/sys/invite/impl_applyinviteevents.go
+++ b/pkg/sys/invite/impl_applyinviteevents.go
@@ -43,7 +43,14 @@ func asyncProjectorApplyInviteEvents(time timeu.ITime, fed federation.IFederatio
 func applyInviteEvents(time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens, smtpCfg smtp.Cfg) func(event istructs.IPLogEvent, state istructs.IState, intents istructs.IIntents) (err error) {
 	return func(event istructs.IPLogEvent, s istructs.IState, intents istructs.IIntents) (err error) {
 		cmd := event.QName()
-		inviteID, err := inviteIDFromEvent(cmd, event, s)
+		// Pre-refactor events (before AIR-3704) did not carry a Version on the cdoc.sys.Invite CUD
+		// and were already fully processed by the deprecated per-command projectors. Replaying them
+		// here would re-execute side effects (emails, federation calls). Skip them.
+		inviteCUD := findInviteCUD(event)
+		if inviteCUD == nil || inviteCUD.AsInt32(Field_Version) == 0 {
+			return nil
+		}
+		inviteID, err := inviteIDFromEvent(cmd, event, s, inviteCUD)
 		if err != nil {
 			return err
 		}
@@ -75,7 +82,19 @@ func applyInviteEvents(time timeu.ITime, fed federation.IFederation, tokens itok
 	}
 }
 
-func inviteIDFromEvent(cmd appdef.QName, event istructs.IPLogEvent, s istructs.IState) (istructs.RecordID, error) {
+func findInviteCUD(event istructs.IPLogEvent) istructs.ICUDRow {
+	var inviteCUD istructs.ICUDRow
+	event.CUDs(func(rec istructs.ICUDRow) bool {
+		if rec.QName() == QNameCDocInvite {
+			inviteCUD = rec
+			return false
+		}
+		return true
+	})
+	return inviteCUD
+}
+
+func inviteIDFromEvent(cmd appdef.QName, event istructs.IPLogEvent, s istructs.IState, inviteCUD istructs.ICUDRow) (istructs.RecordID, error) {
 	switch cmd {
 	case qNameCmdInitiateInvitationByEMail:
 		skb, err := s.KeyBuilder(sys.Storage_View, qNameViewInviteIndex)
@@ -90,12 +109,7 @@ func inviteIDFromEvent(cmd appdef.QName, event istructs.IPLogEvent, s istructs.I
 		}
 		return sv.AsRecordID(field_InviteID), nil
 	case qNameCmdInitiateLeaveWorkspace:
-		for rec := range event.CUDs {
-			if rec.QName() == QNameCDocInvite {
-				return rec.ID(), nil
-			}
-		}
-		return istructs.NullRecordID, nil
+		return inviteCUD.ID(), nil
 	default:
 		return event.ArgumentObject().AsRecordID(field_InviteID), nil
 	}

--- a/pkg/sys/invite/impl_applyinviteevents_test.go
+++ b/pkg/sys/invite/impl_applyinviteevents_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026-present unTill Software Development Group B.V.
+ * @author Maxim Geraskin
+ */
+
+package invite
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/voedger/voedger/pkg/appdef"
+	"github.com/voedger/voedger/pkg/coreutils"
+	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/sys"
+	"github.com/voedger/voedger/pkg/sys/smtp"
+)
+
+func newMockEventWithCUDs(t *testing.T, cmdQName appdef.QName, cuds []istructs.ICUDRow) *coreutils.MockPLogEvent {
+	t.Helper()
+	event := &coreutils.MockPLogEvent{}
+	event.On("QName").Return(cmdQName)
+	event.On("CUDs", mock.Anything).Run(func(args mock.Arguments) {
+		cb := args.Get(0).(func(istructs.ICUDRow) bool)
+		for _, c := range cuds {
+			if !cb(c) {
+				return
+			}
+		}
+	})
+	return event
+}
+
+func newInviteCUD(version int32, id istructs.RecordID) *coreutils.TestObject {
+	return &coreutils.TestObject{
+		Name: QNameCDocInvite,
+		ID_:  id,
+		Data: map[string]any{Field_Version: version},
+	}
+}
+
+// TestApplyInviteEvents_SkipsEventsWithoutVersionMarker verifies that ap.sys.ApplyInviteEvents
+// returns nil without touching state/intents/federation when the event's cdoc.sys.Invite CUD
+// is missing or carries Version == 0 (pre-refactor events whose effects were already produced
+// by deprecated per-command projectors). Strict mocks for IState and IIntents are used so that
+// any unexpected call fails the test, making the "no side effects" half of the contract explicit.
+func TestApplyInviteEvents_SkipsEventsWithoutVersionMarker(t *testing.T) {
+	projectorFn := applyInviteEvents(nil, nil, nil, smtp.Cfg{})
+
+	run := func(t *testing.T, cmdQName appdef.QName, cuds []istructs.ICUDRow) {
+		t.Helper()
+		require := require.New(t)
+		st := &coreutils.MockState{}
+		in := &coreutils.MockIntents{}
+		event := newMockEventWithCUDs(t, cmdQName, cuds)
+		require.NoError(projectorFn(event, st, in))
+		st.AssertExpectations(t)
+		in.AssertExpectations(t)
+	}
+
+	t.Run("no cdoc.sys.Invite CUD", func(t *testing.T) {
+		run(t, qNameCmdInitiateInvitationByEMail, nil)
+	})
+
+	t.Run("cdoc.sys.Invite CUD with Version=0", func(t *testing.T) {
+		run(t, qNameCmdInitiateJoinWorkspace, []istructs.ICUDRow{newInviteCUD(0, 42)})
+	})
+
+	t.Run("only non-invite CUDs", func(t *testing.T) {
+		otherCUD := &coreutils.TestObject{
+			Name: appdef.NewQName(appdef.SysPackage, "Subject"),
+			ID_:  3,
+			Data: map[string]any{},
+		}
+		run(t, qNameCmdCancelSentInvite, []istructs.ICUDRow{otherCUD})
+	})
+
+	t.Run("invite CUD listed after a non-invite CUD with Version=0", func(t *testing.T) {
+		otherCUD := &coreutils.TestObject{
+			Name: appdef.NewQName(appdef.SysPackage, "Subject"),
+			Data: map[string]any{},
+		}
+		run(t, qNameCmdInitiateLeaveWorkspace, []istructs.ICUDRow{otherCUD, newInviteCUD(0, 7)})
+	})
+}
+
+// TestApplyInviteEvents_Version1ReachesDispatch verifies that when the event's cdoc.sys.Invite
+// CUD carries Version == 1 the projector progresses past the skip check and reaches loadInviteByID,
+// proven by an injected state.KeyBuilder error propagating back as the projector's return value.
+func TestApplyInviteEvents_Version1ReachesDispatch(t *testing.T) {
+	require := require.New(t)
+	expectedErr := errors.New("expected propagated error")
+
+	st := &coreutils.MockState{}
+	st.On("KeyBuilder", sys.Storage_Record, QNameCDocInvite).
+		Return(&coreutils.MockStateKeyBuilder{}, expectedErr)
+
+	projectorFn := applyInviteEvents(nil, nil, nil, smtp.Cfg{})
+
+	// qNameCmdInitiateLeaveWorkspace: inviteIDFromEvent reads InviteID directly from the located
+	// CUD (no state interaction), so the next state call is loadInviteByID -> s.KeyBuilder, whose
+	// error propagation proves the projector advanced past the Version check.
+	event := newMockEventWithCUDs(t, qNameCmdInitiateLeaveWorkspace, []istructs.ICUDRow{
+		newInviteCUD(1, 42),
+	})
+
+	err := projectorFn(event, st, nil)
+	require.ErrorIs(err, expectedErr)
+	st.AssertCalled(t, "KeyBuilder", sys.Storage_Record, QNameCDocInvite)
+}

--- a/pkg/sys/invite/impl_cancelsentinvite.go
+++ b/pkg/sys/invite/impl_cancelsentinvite.go
@@ -42,6 +42,13 @@ func execCmdCancelSentInvite(_ timeu.ITime) func(args istructs.ExecCommandArgs) 
 			return coreutils.NewHTTPError(http.StatusBadRequest, ErrInviteStateInvalid)
 		}
 
+		// no-op CUD: marks this as a post-refactor event (ap.sys.ApplyInviteEvents skips Version==0)
+		svbCDocInvite, err := args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)
+		if err != nil {
+			return err
+		}
+		svbCDocInvite.PutInt32(Field_Version, 1)
+
 		return nil
 	}
 }

--- a/pkg/sys/invite/impl_initiatecancelacceptedinvite.go
+++ b/pkg/sys/invite/impl_initiatecancelacceptedinvite.go
@@ -41,6 +41,13 @@ func execCmdInitiateCancelAcceptedInvite(_ timeu.ITime) func(args istructs.ExecC
 			return coreutils.NewHTTPError(http.StatusBadRequest, ErrInviteStateInvalid)
 		}
 
+		// no-op CUD: marks this as a post-refactor event (ap.sys.ApplyInviteEvents skips Version==0)
+		svbCDocInvite, err := args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)
+		if err != nil {
+			return err
+		}
+		svbCDocInvite.PutInt32(Field_Version, 1)
+
 		return nil
 	}
 }

--- a/pkg/sys/invite/impl_initiateinvitationbyemail.go
+++ b/pkg/sys/invite/impl_initiateinvitationbyemail.go
@@ -87,6 +87,7 @@ func execCmdInitiateInvitationByEMail(tm timeu.ITime) func(args istructs.ExecCom
 			svbCDocInvite.PutInt32(Field_State, int32(State_ToBeInvited))
 			svbCDocInvite.PutInt64(Field_Updated, tm.Now().UnixMilli())
 			svbCDocInvite.PutString(field_ActualLogin, "") // to be filled with Invitee's login by ap.sys.Apply
+			svbCDocInvite.PutInt32(Field_Version, 1)
 
 			return nil
 		}
@@ -108,6 +109,7 @@ func execCmdInitiateInvitationByEMail(tm timeu.ITime) func(args istructs.ExecCom
 		svbCDocInvite.PutInt64(field_Created, now)
 		svbCDocInvite.PutInt64(Field_Updated, now)
 		svbCDocInvite.PutInt32(Field_State, int32(State_ToBeInvited))
+		svbCDocInvite.PutInt32(Field_Version, 1)
 		// do not fill cdoc.sys.Invite.ActualLogin because it must be Invitee's login. It is unknown here
 
 		return

--- a/pkg/sys/invite/impl_initiatejoinworkspace.go
+++ b/pkg/sys/invite/impl_initiatejoinworkspace.go
@@ -73,6 +73,7 @@ func execCmdInitiateJoinWorkspace(tm timeu.ITime) func(args istructs.ExecCommand
 		svbCDocInvite.PutInt32(authnz.Field_SubjectKind, svPrincipal.AsInt32(sys.Storage_RequestSubject_Field_Kind))
 		svbCDocInvite.PutInt64(Field_Updated, tm.Now().UnixMilli())
 		svbCDocInvite.PutChars(field_ActualLogin, svPrincipal.AsString(sys.Storage_RequestSubject_Field_Name))
+		svbCDocInvite.PutInt32(Field_Version, 1)
 
 		return
 	}

--- a/pkg/sys/invite/impl_initiateleaveworkspace.go
+++ b/pkg/sys/invite/impl_initiateleaveworkspace.go
@@ -58,8 +58,13 @@ func execCmdInitiateLeaveWorkspace(_ timeu.ITime) func(args istructs.ExecCommand
 			return coreutils.NewHTTPError(http.StatusBadRequest, ErrInviteStateInvalid)
 		}
 
-		// no-op CUD: keep UpdateValue so projector can discover InviteID from event.CUDs
-		_, err = args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)
+		// no-op CUD: keep UpdateValue so projector can discover InviteID from event.CUDs;
+		// Version=1 marks this as a post-refactor event (ap.sys.ApplyInviteEvents skips Version==0)
+		svbCDocInvite, err := args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)
+		if err != nil {
+			return err
+		}
+		svbCDocInvite.PutInt32(Field_Version, 1)
 
 		return
 	}

--- a/pkg/sys/invite/impl_initiateupdateinviteroles.go
+++ b/pkg/sys/invite/impl_initiateupdateinviteroles.go
@@ -49,6 +49,13 @@ func execCmdInitiateUpdateInviteRoles(_ timeu.ITime) func(args istructs.ExecComm
 			return coreutils.NewHTTPError(http.StatusBadRequest, ErrInviteStateInvalid)
 		}
 
+		// no-op CUD: marks this as a post-refactor event (ap.sys.ApplyInviteEvents skips Version==0)
+		svbCDocInvite, err := args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)
+		if err != nil {
+			return err
+		}
+		svbCDocInvite.PutInt32(Field_Version, 1)
+
 		return nil
 	}
 }

--- a/pkg/sys/it/impl_invite_test.go
+++ b/pkg/sys/it/impl_invite_test.go
@@ -590,3 +590,82 @@ func setInviteState(vit *it.VIT, ws *it.AppWorkspace, inviteID istructs.RecordID
 	body := fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"State":%d}}]}`, inviteID, state)
 	vit.PostWS(ws, "c.sys.CUD", body)
 }
+
+// TestInvite_VersionMarker asserts that every current invite command writes Version=1
+// on its cdoc.sys.Invite CUD. ap.sys.ApplyInviteEvents uses this discriminator to skip
+// pre-refactor events whose CUD has Version==0 (or no cdoc.sys.Invite CUD at all).
+func TestInvite_VersionMarker(t *testing.T) {
+	require := require.New(t)
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	expireDatetime := vit.Now().UnixMilli()
+	ownerPrn := vit.GetPrincipal(istructs.AppQName_test1_app1, it.TestEmail)
+
+	getInviteVersion := func(ws *it.AppWorkspace, inviteID istructs.RecordID) int32 {
+		row := vit.PostWS(ws, "q.sys.Collection", fmt.Sprintf(`
+			{"args":{"Schema":"sys.Invite"},
+			"elements":[{"fields":["Version","sys.ID"]}],
+			"filters":[{"expr":"eq","args":{"field":"sys.ID","value":%d}}]}`, inviteID)).SectionRow(0)
+		return int32(row[0].(float64))
+	}
+
+	t.Run("create+cancelsent+reinvite+join+updateroles+leave", func(t *testing.T) {
+		ws := vit.CreateWorkspace(it.SimpleWSParams("TestInvite_VersionMarker_A_ws"), ownerPrn)
+		email := fmt.Sprintf("invite_version_a_%d@test.com", vit.NextNumber())
+		login := vit.SignUp(email, "1", istructs.AppQName_test1_app1)
+		loginPrn := vit.SignIn(login)
+
+		// 1. InitiateInvitationByEMail (create branch)
+		inviteID := InitiateInvitationByEMail(vit, ws, expireDatetime, email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+		vit.CaptureEmail()
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+		require.Equal(int32(1), getInviteVersion(ws, inviteID), "after InitiateInvitationByEMail (create)")
+
+		// 2. CancelSentInvite
+		vit.PostWS(ws, "c.sys.CancelSentInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, inviteID))
+		WaitForInviteState(vit, ws, inviteID, invite.State_Invited, invite.State_Cancelled)
+		require.Equal(int32(1), getInviteVersion(ws, inviteID), "after CancelSentInvite")
+
+		// 3. InitiateInvitationByEMail (re-invite update branch)
+		InitiateInvitationByEMail(vit, ws, expireDatetime, email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+		verificationCode := vit.CaptureEmail().Body[:6]
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+		require.Equal(int32(1), getInviteVersion(ws, inviteID), "after InitiateInvitationByEMail (re-invite)")
+
+		// 4. InitiateJoinWorkspace
+		InitiateJoinWorkspace(vit, ws, inviteID, loginPrn, verificationCode)
+		WaitForInviteState(vit, ws, inviteID, invite.State_Invited, invite.State_Joined)
+		require.Equal(int32(1), getInviteVersion(ws, inviteID), "after InitiateJoinWorkspace")
+
+		// 5. InitiateUpdateInviteRoles (state stays Joined)
+		vit.PostWS(ws, "c.sys.InitiateUpdateInviteRoles", fmt.Sprintf(
+			`{"args":{"InviteID":%d,"Roles":"%s","EmailTemplate":"%s","EmailSubject":"%s"}}`,
+			inviteID, newRoles, inviteEmailTemplate, inviteEmailSubject))
+		vit.CaptureEmail()
+		require.Equal(int32(1), getInviteVersion(ws, inviteID), "after InitiateUpdateInviteRoles")
+
+		// 6. InitiateLeaveWorkspace (called by invitee)
+		vit.PostWS(ws, "c.sys.InitiateLeaveWorkspace", "{}", httpu.WithAuthorizeBy(loginPrn.Token))
+		WaitForInviteState(vit, ws, inviteID, invite.State_Joined, invite.State_Left)
+		require.Equal(int32(1), getInviteVersion(ws, inviteID), "after InitiateLeaveWorkspace")
+	})
+
+	t.Run("InitiateCancelAcceptedInvite", func(t *testing.T) {
+		ws := vit.CreateWorkspace(it.SimpleWSParams("TestInvite_VersionMarker_B_ws"), ownerPrn)
+		email := fmt.Sprintf("invite_version_b_%d@test.com", vit.NextNumber())
+		login := vit.SignUp(email, "1", istructs.AppQName_test1_app1)
+		loginPrn := vit.SignIn(login)
+
+		inviteID := InitiateInvitationByEMail(vit, ws, expireDatetime, email, initialRoles, inviteEmailTemplate, inviteEmailSubject)
+		verificationCode := vit.CaptureEmail().Body[:6]
+		WaitForInviteState(vit, ws, inviteID, invite.State_ToBeInvited, invite.State_Invited)
+
+		InitiateJoinWorkspace(vit, ws, inviteID, loginPrn, verificationCode)
+		WaitForInviteState(vit, ws, inviteID, invite.State_Invited, invite.State_Joined)
+
+		vit.PostWS(ws, "c.sys.InitiateCancelAcceptedInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, inviteID))
+		WaitForInviteState(vit, ws, inviteID, invite.State_Joined, invite.State_Cancelled)
+		require.Equal(int32(1), getInviteVersion(ws, inviteID), "after InitiateCancelAcceptedInvite")
+	})
+}

--- a/pkg/sys/sys.vsql
+++ b/pkg/sys/sys.vsql
@@ -95,6 +95,8 @@ ABSTRACT WORKSPACE Workspace (
 		-- Currently always equals Login because InitiateJoinWorkspace validates they match
 		-- Used for cdoc.sys.Subject.Login field
 		ActualLogin varchar,
+		-- Version: command-side discriminator; current commands write 1, pre-refactor events have 0 and are skipped by ap.sys.ApplyInviteEvents
+		Version int32,
 		UNIQUEFIELD Email
 	) WITH Tags=(WorkspaceOwnerTableTag);
 

--- a/uspecs/changes/archive/2604/2604290959-guard-empty-actuallogin-join/analysis.md
+++ b/uspecs/changes/archive/2604/2604290959-guard-empty-actuallogin-join/analysis.md
@@ -1,0 +1,110 @@
+# Root cause analysis: empty `Login` key on `sys.ViewSubjectsIdx`
+
+## Symptom
+
+Async actualizer log entries of the form:
+
+```text
+level=ERROR
+msg="field is empty: view «sys.ViewSubjectsIdx» key string-field «Login»: validate error code 4"
+extension=ap.sys.ApplyInviteEvents
+evqname=sys.InitiateJoinWorkspace
+woffset=6 poffset=7583
+wsid=140737488488661
+vapp=untill/airs-bp
+```
+
+The view-records storage rejects a key whose required string field `Login` is empty. The error surfaces from `pkg/sys/invite/impl_applyinviteevents.go::handleApplyJoinWorkspace` -> `SubjectExistsByLogin(login, s)` -> `GetSubjectIdxViewKeyBuilder(login, s)`, which calls `skb.PutString(Field_Login, login)` with `login == ""`.
+
+## Impact of commit `82dba9f7` (AIR-3704)
+
+PR [#4521](https://github.com/voedger/voedger/pull/4521) refactored the invite flow:
+
+- The five per-command async projectors (`ApplyInvitation`, `ApplyJoinWorkspace`, `ApplyUpdateInviteRoles`, `ApplyCancelAcceptedInvite`, `ApplyLeaveWorkspace`) were replaced with a single `ap.sys.ApplyInviteEvents` projector.
+- The legacy projectors are kept as `deprecatedNullProjector` placeholders for backward compatibility (their QNames must keep existing in `provide.go` so previously stored offsets remain valid).
+- All invite state transitions and side effects moved out of the commands into the new projector.
+- `c.sys.InitiateJoinWorkspace` no longer writes `Field_State = State_ToBeJoined`; the cmd only persists `ActualLogin`, `InviteeProfileWSID`, `SubjectKind`, `Updated`. The state transition to `State_Joined` is performed by the projector.
+
+The new projector dispatches by `event.QName()` and validates the current `cdoc.sys.Invite.State` against `projectorValidStates[cmd]`. For `qNameCmdInitiateJoinWorkspace` this set is `{State_Invited, State_ToBeJoined}`. The projector then loads the *current* `cdoc.sys.Invite` via `loadInviteByID` and reads `ActualLogin` from it.
+
+## Why the new projector replays from offset 0
+
+Async actualizers persist their last-applied PLog/WLog offset per projector QName. When a new projector QName is registered, the platform has no stored offset for it and starts from offset 0, walking forward through every event the projector subscribes to.
+
+`ap.sys.ApplyInviteEvents` is a brand new QName (`qNameAPApplyInviteEvents`). Even though the body of the deprecated projectors is now `deprecatedNullProjector`, their offsets are not transferable to a different QName. Consequently, in every workspace that ever contained invite events, the new projector replays the full history of `sys.InitiateInvitationByEMail`, `sys.InitiateJoinWorkspace`, `sys.InitiateUpdateInviteRoles`, `sys.InitiateCancelAcceptedInvite`, `sys.InitiateLeaveWorkspace`, and `sys.CancelSentInvite` events from WLog offset 0 onwards. The log line `woffset=6` confirms this is a very early historical event being replayed.
+
+Because the projector reads the *current* state of the `cdoc.sys.Invite` (not the state it had when the event was originally produced), a replay of an old event sees today's record and decides what to do based on it.
+
+## Replay is not just "noisy" - it has externally visible side effects
+
+The crash on empty `Login` is one symptom. The deeper problem is that `ap.sys.ApplyInviteEvents` produces real side effects in *other* workspaces and to *external systems*. Replaying historical events re-executes those side effects against the current world. Concretely:
+
+- `handleApplyInvitation` calls `sendEmail(...)` (`pkg/sys/invite/impl_applyinviteevents.go`) - replaying every historical `c.sys.InitiateInvitationByEMail` would re-send invitation emails to the original invitees.
+- `handleApplyUpdateInviteRoles` calls `fed.Func(".../c.sys.UpdateJoinedWorkspaceRoles", ...)` against the invitee's profile workspace and `sendEmail(...)` for the role-change notification - replaying re-issues role-update HTTP calls and re-sends emails for changes that may have since been reverted, cancelled, or further updated.
+- `handleApplyJoinWorkspace` creates/activates a `cdoc.sys.Subject` and calls `c.sys.CreateJoinedWorkspace` in the invitee's profile workspace - replaying can resurrect subjects whose membership has since been cancelled/left.
+- `handleApplyCancelAcceptedInvite` and `handleApplyLeaveWorkspace` deactivate the subject and joined workspace - replaying can flip an active membership back to inactive.
+
+None of these effects are guarded by idempotency against the *historical* intent of the event. The deprecated per-command projectors already produced these effects when the events were first written; running them a second time against today's database state is observable to end users (unwanted emails, ghost subjects, role flapping).
+
+The empty-`Login` crash is therefore a stop-gap accident: it happens to halt the actualizer before it can re-send emails. Once that single field is patched, every other side-effecting handler will silently re-execute. The correct behaviour is to refuse to replay any pre-refactor invite event at all.
+
+## Why `ActualLogin` can be empty
+
+Two independent paths produce an empty `ActualLogin` on a record whose state is in `{State_Invited, State_ToBeJoined}`:
+
+- Re-invitation. `pkg/sys/invite/impl_initiateinvitationbyemail.go` (line 89) explicitly resets the field on the existing `cdoc.sys.Invite`:
+
+  ```go
+  svbCDocInvite.PutString(field_ActualLogin, "") // to be filled with Invitee's login by ap.sys.Apply
+  ```
+
+  After re-invite, state passes through `State_ToBeInvited` -> (projector) -> `State_Invited`. While the record sits in `State_Invited` waiting for the new invitee to accept, the projector replays the *old* `sys.InitiateJoinWorkspace` event from the previous join cycle. The state guard `{State_Invited, State_ToBeJoined}` admits the event, `handleApplyJoinWorkspace` runs, and `ActualLogin` is `""`.
+
+- Pre-`d53d48e9` history. `field_ActualLogin` was first written by `c.sys.InitiateJoinWorkspace` in commit `d53d48e9` (#1107). Records created and joined before that commit never had the field populated. If such a record was ever re-invited and is currently in `State_Invited`, the same replay path applies.
+
+## Proposed fix: skip pre-refactor events outright via a `Version` marker
+
+The empty `ActualLogin` is one symptom of a wider invariant break: the new projector should not be applying pre-refactor events at all. Their effects were already produced by the deprecated per-command projectors. Replaying them against the *current* cdoc state (which has moved on through re-invites and re-joins) is meaningless at best and crashing at worst.
+
+Discriminator. Add field `Version int32` to `cdoc.sys.Invite`. Every current invite command writes `Version = 1` to its `cdoc.sys.Invite` CUD. Pre-refactor events written before the discriminator existed have no `Version` write in their CUD, so the field reads `0`.
+
+Why a CUD-side marker works mechanically. `event.CUDs(...)` iterates the per-CUD changes recorded by the command handler, not the merged record (`pkg/istructsmem/event-types.go::cudType.enumRecs` yields `&rec.changes`). A field that the command never `Put*`-d reads back as the type's zero value, even after a PLog round-trip - the dynobuffer encodes set vs unset.
+
+Projector dispatch (`pkg/sys/invite/impl_applyinviteevents.go`). Before `loadInviteByID`, walk `event.CUDs`:
+
+```go
+var version int32
+for cud := range event.CUDs {
+    if cud.QName() == QNameCDocInvite {
+        version = cud.AsInt32(Field_Version)
+        break
+    }
+}
+if version == 0 {
+    return nil // pre-refactor event - effects already applied by deprecated projector
+}
+```
+
+Command audit. Of the six current invite commands:
+
+- `InitiateInvitationByEMail`, `InitiateJoinWorkspace`, `InitiateLeaveWorkspace` already update `cdoc.sys.Invite`; they only need the extra `PutInt32(Field_Version, 1)`. `InitiateLeaveWorkspace` already established the "no-op CUD to surface the InviteID" pattern.
+- `InitiateUpdateInviteRoles`, `InitiateCancelAcceptedInvite`, `CancelSentInvite` currently have no `Intents.UpdateValue` on `cdoc.sys.Invite`; they must add one (mirroring the `InitiateLeaveWorkspace` no-op pattern) carrying `Version = 1`. This also means subsequent handlers can rely on the cdoc.Invite CUD always being present in invite events.
+
+Why this is preferred over a per-field guard
+
+- It is event-scoped, not state-scoped. The decision is made from the immutable event payload, not from current cdoc fields that may have been re-written since.
+- It generalises. The same dispatch-level filter protects `handleApplyCancelAcceptedInvite` and `handleApplyLeaveWorkspace` from analogous replays without per-handler patches.
+- It is self-documenting. A single explicit field signals "this event came from the post-refactor command set"; future invite commands need only write `Version = 1` to participate.
+- It does not require auditing which `State_*` values still appear in new CUDs, unlike a state-shape filter.
+
+Trade-offs
+
+- Schema change on a system cdoc. Because the field is added with a zero default, existing records remain valid; only the projector's interpretation of `Version == 0` changes.
+- Six command handlers must be updated (three of which gain a no-op `Intents.UpdateValue` on `cdoc.sys.Invite`). This is a one-time, localised change and does not affect the public command argument contract.
+- Future invite commands must remember to set `Version = 1`. Mitigated by adding a small helper or comment in `consts.go`.
+
+Considered and rejected
+
+- Per-field guard `if svCDocInvite.AsString(field_ActualLogin) == "" { return nil }`. Fixes only the empty-`ActualLogin` crash; leaves analogous replay risks in `handleApplyCancelAcceptedInvite` and `handleApplyLeaveWorkspace`; reads from current cdoc state instead of the event.
+- CUD shape (presence of legacy `State_*` values). Works mechanically but depends on auditing every current command for which `State_*` it writes; the marker subset is non-obvious and brittle to future refactors.
+- Version on the command argument. Would require updating every external client that calls these commands.

--- a/uspecs/changes/archive/2604/2604290959-guard-empty-actuallogin-join/change.md
+++ b/uspecs/changes/archive/2604/2604290959-guard-empty-actuallogin-join/change.md
@@ -1,0 +1,56 @@
+---
+registered_at: 2026-04-29T08:00:13Z
+change_id: 2604290800-guard-empty-actuallogin-join
+baseline: 82dba9f71f8a2248b7f8ffc81b1d312628dfff9c
+pre_pr_head: cc6a7eb0d927ec67cad1990adfc40f6cc379c2cf
+issue_url: https://untill.atlassian.net/browse/AIR-3768
+archived_at: 2026-04-29T09:59:41Z
+---
+
+# Change request: Skip pre-refactor invite events in ap.sys.ApplyInviteEvents via Version marker
+
+## Why
+
+After PR [#4521](https://github.com/voedger/voedger/pull/4521) (commit `82dba9f7`, AIR-3704) replaced the per-command invite projectors with the single `ap.sys.ApplyInviteEvents` projector, the actualizer has no stored offset under the new projector QName and replays every workspace's invite history from WLog offset 0.
+
+The pre-refactor events were already fully processed by the deprecated per-command projectors at the time they were written. Replaying them now re-executes their side effects against today's database state. Those side effects are not internal bookkeeping - they are externally visible:
+
+- re-send invitation emails to the original invitees (`handleApplyInvitation` -> `sendEmail`)
+- re-issue role-update HTTP calls into the invitee's profile workspace and re-send role-change emails (`handleApplyUpdateInviteRoles` -> `fed.Func("c.sys.UpdateJoinedWorkspaceRoles")` + `sendEmail`)
+- resurrect cancelled subjects (`handleApplyJoinWorkspace`)
+- flip active memberships back to inactive (`handleApplyCancelAcceptedInvite`, `handleApplyLeaveWorkspace`)
+
+The crash currently observed in production (`field is empty: view «sys.ViewSubjectsIdx» key string-field «Login»: validate error code 4`, `evqname=sys.InitiateJoinWorkspace`, `extension=ap.sys.ApplyInviteEvents`) is a stop-gap accident that happens to halt the actualizer before it can re-send emails on the affected event. Once that single field is patched, every other side-effecting handler will silently re-execute on every replayed pre-refactor event in every workspace.
+
+The correct fix is therefore to refuse to replay any pre-refactor invite event at all, not to patch individual symptom fields.
+
+See [analysis.md](analysis.md) for the full root cause analysis.
+
+## What
+
+Add a `Version` discriminator on `cdoc.sys.Invite` so the projector can cheaply tell a pre-refactor event apart from a post-refactor one and skip the former.
+
+Schema:
+
+- Add field `Version int32` to `cdoc.sys.Invite` (default `0` for all existing records)
+
+Commands (every current invite cmd writes `Version = 1` in its `cdoc.sys.Invite` CUD):
+
+- `c.sys.InitiateInvitationByEMail` (`pkg/sys/invite/impl_initiateinvitationbyemail.go`) - writes `Version = 1` on both create and update branches
+- `c.sys.InitiateJoinWorkspace` (`pkg/sys/invite/impl_initiatejoinworkspace.go`) - writes `Version = 1` on its update
+- `c.sys.InitiateUpdateInviteRoles` (`pkg/sys/invite/impl_initiateupdateinviteroles.go`) - currently has no CUD; add a `args.Intents.UpdateValue` carrying `Version = 1`
+- `c.sys.InitiateCancelAcceptedInvite` (`pkg/sys/invite/impl_initiatecancelacceptedinvite.go`) - currently has no CUD; add the same
+- `c.sys.InitiateLeaveWorkspace` (`pkg/sys/invite/impl_initiateleaveworkspace.go`) - already has a no-op CUD ("keep UpdateValue so projector can discover InviteID from event.CUDs"); extend it to write `Version = 1`
+- `c.sys.CancelSentInvite` (`pkg/sys/invite/impl_cancelsentinvite.go`) - currently has no CUD; add the same
+
+Projector (`pkg/sys/invite/impl_applyinviteevents.go`):
+
+- At the dispatch site (before `loadInviteByID`), iterate `event.CUDs` looking for the cdoc.sys.Invite CUD
+- If no `cdoc.sys.Invite` CUD is present, or its `Version` reads `0`, `return nil` (pre-refactor event - already applied by deprecated projector, must not be replayed)
+- Otherwise dispatch to the per-command handler as today
+
+Tests:
+
+- Drive the projector with a synthesised pre-refactor event (CUD on cdoc.sys.Invite without `Version`) and assert the projector returns `nil` and writes nothing
+- Drive the projector with a post-refactor event (`Version = 1`) and assert normal processing
+- Re-invite scenario: assert that an old `sys.InitiateJoinWorkspace` event in the WLog is skipped after re-invite, while the new join's event proceeds to create the subject

--- a/uspecs/changes/archive/2604/2604290959-guard-empty-actuallogin-join/impl.md
+++ b/uspecs/changes/archive/2604/2604290959-guard-empty-actuallogin-join/impl.md
@@ -1,0 +1,63 @@
+# Implementation plan: Skip pre-refactor invite events in ap.sys.ApplyInviteEvents via Version marker
+
+## Technical design
+
+- [x] update: [auth/invites--td.md](../../../../specs/prod/auth/invites--td.md)
+  - add: `Version int32` field to the `cdoc.sys.Invite` document description in section "Documents"
+  - update: section "Single projector design" with a forward reference to the dedicated Versioning subsection
+  - update: decision "Single projector as sole writer of final states" to note that the three commands without prior CDoc writes (`InitiateUpdateInviteRoles`, `InitiateCancelAcceptedInvite`, `CancelSentInvite`) now carry a no-op CUD writing `Version = 1`, mirroring the existing `InitiateLeaveWorkspace` pattern
+  - add: new subsection "Versioning" under "Technical design" explaining the replay risk that motivates the discriminator, the rule (commands write `Version = 1`; projector skips `Version == 0` via `event.CUDs`), why the discriminator lives on the CUD rather than the merged record (`event.CUDs` yields per-CUD changes only via `cudType.enumRecs`; never-`Put*`-d field reads back as zero through the dynobuffer's set/unset encoding; event-scoped vs state-scoped; single dispatch-level filter protects all side-effecting handlers; no external contract change), and the rejected alternatives (per-field `ActualLogin` guard, CUD-shape filter, command-argument version)
+
+## Construction
+
+### Schema and constants
+
+- [x] update: [pkg/sys/sys.vsql](../../../../../pkg/sys/sys.vsql)
+  - add: `Version int32` field to `TABLE Invite` (default `0` for existing records; current commands write `1`)
+
+- [x] update: [pkg/sys/invite/consts.go](../../../../../pkg/sys/invite/consts.go)
+  - add: `Field_Version = "Version"` constant in the field-name `const` block
+
+### Command handlers writing Version = 1
+
+- [x] update: [pkg/sys/invite/impl_initiateinvitationbyemail.go](../../../../../pkg/sys/invite/impl_initiateinvitationbyemail.go)
+  - add: `svbCDocInvite.PutInt32(Field_Version, 1)` on both the existing-invite update branch and the create branch
+
+- [x] update: [pkg/sys/invite/impl_initiatejoinworkspace.go](../../../../../pkg/sys/invite/impl_initiatejoinworkspace.go)
+  - add: `svbCDocInvite.PutInt32(Field_Version, 1)` on the `Intents.UpdateValue` already produced by the handler
+
+- [x] update: [pkg/sys/invite/impl_initiateleaveworkspace.go](../../../../../pkg/sys/invite/impl_initiateleaveworkspace.go)
+  - update: extend the existing no-op CUD - obtain the `svbCDocInvite` from `args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)` and write `Field_Version = 1`
+
+- [x] update: [pkg/sys/invite/impl_initiateupdateinviteroles.go](../../../../../pkg/sys/invite/impl_initiateupdateinviteroles.go)
+  - add: no-op CUD on `cdoc.sys.Invite` (mirroring the existing pattern in `impl_initiateleaveworkspace.go`) writing only `Field_Version = 1`
+
+- [x] update: [pkg/sys/invite/impl_initiatecancelacceptedinvite.go](../../../../../pkg/sys/invite/impl_initiatecancelacceptedinvite.go)
+  - add: no-op CUD on `cdoc.sys.Invite` writing only `Field_Version = 1`
+
+- [x] update: [pkg/sys/invite/impl_cancelsentinvite.go](../../../../../pkg/sys/invite/impl_cancelsentinvite.go)
+  - add: no-op CUD on `cdoc.sys.Invite` writing only `Field_Version = 1`
+
+### Projector skip logic
+
+- [x] update: [pkg/sys/invite/impl_applyinviteevents.go](../../../../../pkg/sys/invite/impl_applyinviteevents.go)
+  - add: helper `findInviteCUD(event)` that iterates `event.CUDs` and returns the first `QNameCDocInvite` CUD (or `nil`)
+  - add: at the top of `applyInviteEvents` returned func (before `inviteIDFromEvent`), call `findInviteCUD` and `return nil` when the CUD is absent or its `Field_Version` reads `0` (pre-refactor event - already applied by deprecated per-command projectors, must not be replayed)
+  - update: change `inviteIDFromEvent` signature to accept the located `inviteCUD` and, for `qNameCmdInitiateLeaveWorkspace`, return `inviteCUD.ID()` directly, removing the redundant `event.CUDs` pass that the previous implementation performed
+
+### Tests
+
+- [x] update: [pkg/sys/it/impl_invite_test.go](../../../../../pkg/sys/it/impl_invite_test.go)
+  - add: dedicated `TestInvite_VersionMarker` with a local `getInviteVersion` helper (q.sys.Collection query projecting `Version`), asserting `Version == 1` after each of the six commands runs:
+    - create branch of `c.sys.InitiateInvitationByEMail`
+    - `c.sys.CancelSentInvite`
+    - re-invite update branch of `c.sys.InitiateInvitationByEMail` (after `CancelSentInvite`)
+    - `c.sys.InitiateJoinWorkspace`
+    - `c.sys.InitiateUpdateInviteRoles`
+    - `c.sys.InitiateLeaveWorkspace`
+    - `c.sys.InitiateCancelAcceptedInvite`
+
+- [x] create: [pkg/sys/invite/impl_applyinviteevents_test.go](../../../../../pkg/sys/invite/impl_applyinviteevents_test.go)
+  - add: `newMockEventWithCUDs` / `newInviteCUD` helpers building a `coreutils.MockPLogEvent` and `coreutils.TestObject` with the configured CUD list and Version
+  - add: `TestApplyInviteEvents_SkipsEventsWithoutVersionMarker` - drives `applyInviteEvents` with strict `coreutils.MockState` and `coreutils.MockIntents` (no `On(...)` registrations, so any state/intents call fails the test) for four sub-cases: no `cdoc.sys.Invite` CUD; invite CUD with `Version == 0`; only non-invite CUDs; invite CUD with `Version == 0` listed after a non-invite CUD. All sub-cases assert `projectorFn` returns `nil`
+  - add: `TestApplyInviteEvents_Version1ReachesDispatch` - positive-case unit test for `qNameCmdInitiateLeaveWorkspace` with `Version == 1`; `MockState.KeyBuilder(sys.Storage_Record, QNameCDocInvite)` is wired to return an injected error, and the test asserts the projector propagates that error back, proving execution advanced past the Version check into `loadInviteByID`

--- a/uspecs/specs/prod/auth/invites--td.md
+++ b/uspecs/specs/prod/auth/invites--td.md
@@ -170,6 +170,8 @@ It triggers on all 6 invite commands and handles each event type:
 
 If actual state does not match the expected source state for the event, the projector skips the event (stale).
 
+Pre-refactor events are filtered out at dispatch time via a CUD-side `Version` discriminator -- see Versioning section below.
+
 Projector gets InviteID from:
 
 - `event.ArgumentObject().AsRecordID(field_InviteID)` for commands that have InviteID param
@@ -190,6 +192,43 @@ Legacy deprecated projectors (`ap.sys.ApplyInvitation`, `ap.sys.ApplyJoinWorkspa
 
 ---
 
+### Versioning
+
+`ap.sys.ApplyInviteEvents` is registered against all six invite commands and, on registration, replays the entire PLog from offset 0. Pre-refactor events (before AIR-3704) were already fully processed by the deprecated per-command projectors; replaying them through `ap.sys.ApplyInviteEvents` would re-execute side effects (emails, federation calls). A CUD-side `Version` field on `cdoc.sys.Invite` discriminates post-refactor events from pre-refactor ones.
+
+All six current commands write a CUD on `cdoc.sys.Invite` carrying `Version = 1`. Three of them (`InitiateUpdateInviteRoles`, `InitiateCancelAcceptedInvite`, `CancelSentInvite`) carry a no-op CUD on `cdoc.sys.Invite` for that purpose, mirroring the existing `InitiateLeaveWorkspace` pattern. The projector reads `Version` from the event's `cdoc.sys.Invite` CUD via `event.CUDs` and skips events with `Version == 0`.
+
+Why the discriminator lives on the CUD, not on the merged record:
+
+- `event.CUDs` yields per-CUD changes only (`cudType.enumRecs` returns
+  `&rec.changes`), not the merged record. A field a command never `Put*`-d reads
+  back as the type's zero value through the dynobuffer's set/unset encoding,
+  even after a PLog round-trip. So pre-refactor events naturally read
+  `Version == 0` while post-refactor events (where the command writes
+  `Version = 1`) read `1`.
+- The decision is event-scoped, not state-scoped: it is made from the immutable
+  event payload, so re-invites and re-joins on the current cdoc do not affect
+  whether a historical event is replayed.
+- A single dispatch-level filter protects all side-effecting handlers
+  (`handleApplyInvitation`, `handleApplyJoinWorkspace`,
+  `handleApplyUpdateInviteRoles`, `handleApplyCancelAcceptedInvite`,
+  `handleApplyLeaveWorkspace`) without per-handler patches against missing or
+  emptied fields (`ActualLogin`, `SubjectID`).
+- The cmd argument schemas are unchanged, so external clients are unaffected.
+
+Considered and rejected:
+
+- Per-field guard (e.g. `if ActualLogin == "" return nil`): patches one symptom
+  only, reads from current cdoc state instead of the immutable event, leaves
+  analogous replay risks in cancel/leave handlers, and does not stop unwanted
+  emails or role-update HTTP calls.
+- CUD-shape filter (presence of legacy `State_*` values): brittle to future
+  refactors and depends on auditing which `State_*` values still appear in
+  current commands.
+- Version on the command argument: would break external clients.
+
+---
+
 ### Documents
 
 #### cdoc.sys.Invite
@@ -206,6 +245,7 @@ Legacy deprecated projectors (`ap.sys.ApplyInvitation`, `ap.sys.ApplyJoinWorkspa
 - SubjectID ref // set by ap.sys.ApplyInviteEvents
 - InviteeProfileWSID int64 // set by c.sys.InitiateJoinWorkspace
 - ActualLogin varchar // invitee's login from token, set by c.sys.InitiateJoinWorkspace
+- Version int32 // command-side discriminator; current commands write 1, pre-refactor events have 0 and are skipped by ap.sys.ApplyInviteEvents
 - UNIQUEFIELD Email
 
 #### cdoc.sys.Subject
@@ -241,9 +281,11 @@ order -- serialized, no races.
 `InitiateInvitationByEMail` writes transient State=ToBeInvited because the CDoc
 must have a State on creation (and on re-invite, to signal the projector).
 `InitiateJoinWorkspace` writes data fields from the auth token (InviteeProfileWSID,
-SubjectKind, ActualLogin) but does not write State. `InitiateLeaveWorkspace`
-keeps a no-op CUD to pass InviteID to the projector (no InviteID param, no auth
-token in projector). All other commands do no CUD.
+SubjectKind, ActualLogin) but does not write State. `InitiateLeaveWorkspace`,
+`InitiateUpdateInviteRoles`, `InitiateCancelAcceptedInvite`, and `CancelSentInvite`
+keep a no-op CUD on cdoc.sys.Invite (only writing `Version = 1`) so the projector
+can discover the InviteID from `event.CUDs` and so the Version discriminator is
+present on every post-refactor event.
 
 ### Stale event handling
 


### PR DESCRIPTION
```yaml
registered_at: 2026-04-29T08:00:13Z
change_id: 2604290800-guard-empty-actuallogin-join
baseline: 82dba9f71f8a2248b7f8ffc81b1d312628dfff9c
pre_pr_head: cc6a7eb0d927ec67cad1990adfc40f6cc379c2cf
issue_url: https://untill.atlassian.net/browse/AIR-3768
archived_at: 2026-04-29T09:59:41Z
```

# Change request: Skip pre-refactor invite events in ap.sys.ApplyInviteEvents via Version marker

## Why

After PR [#4521](https://github.com/voedger/voedger/pull/4521) (commit `82dba9f7`, AIR-3704) replaced the per-command invite projectors with the single `ap.sys.ApplyInviteEvents` projector, the actualizer has no stored offset under the new projector QName and replays every workspace's invite history from WLog offset 0.

The pre-refactor events were already fully processed by the deprecated per-command projectors at the time they were written. Replaying them now re-executes their side effects against today's database state. Those side effects are not internal bookkeeping - they are externally visible:

- re-send invitation emails to the original invitees (`handleApplyInvitation` -> `sendEmail`)
- re-issue role-update HTTP calls into the invitee's profile workspace and re-send role-change emails (`handleApplyUpdateInviteRoles` -> `fed.Func("c.sys.UpdateJoinedWorkspaceRoles")` + `sendEmail`)
- resurrect cancelled subjects (`handleApplyJoinWorkspace`)
- flip active memberships back to inactive (`handleApplyCancelAcceptedInvite`, `handleApplyLeaveWorkspace`)

The crash currently observed in production (`field is empty: view «sys.ViewSubjectsIdx» key string-field «Login»: validate error code 4`, `evqname=sys.InitiateJoinWorkspace`, `extension=ap.sys.ApplyInviteEvents`) is a stop-gap accident that happens to halt the actualizer before it can re-send emails on the affected event. Once that single field is patched, every other side-effecting handler will silently re-execute on every replayed pre-refactor event in every workspace.

The correct fix is therefore to refuse to replay any pre-refactor invite event at all, not to patch individual symptom fields.

See [analysis.md](analysis.md) for the full root cause analysis.

## What

Add a `Version` discriminator on `cdoc.sys.Invite` so the projector can cheaply tell a pre-refactor event apart from a post-refactor one and skip the former.

Schema:

- Add field `Version int32` to `cdoc.sys.Invite` (default `0` for all existing records)

Commands (every current invite cmd writes `Version = 1` in its `cdoc.sys.Invite` CUD):

- `c.sys.InitiateInvitationByEMail` (`pkg/sys/invite/impl_initiateinvitationbyemail.go`) - writes `Version = 1` on both create and update branches
- `c.sys.InitiateJoinWorkspace` (`pkg/sys/invite/impl_initiatejoinworkspace.go`) - writes `Version = 1` on its update
- `c.sys.InitiateUpdateInviteRoles` (`pkg/sys/invite/impl_initiateupdateinviteroles.go`) - currently has no CUD; add a `args.Intents.UpdateValue` carrying `Version = 1`
- `c.sys.InitiateCancelAcceptedInvite` (`pkg/sys/invite/impl_initiatecancelacceptedinvite.go`) - currently has no CUD; add the same


---
(truncated -- see change.md for full details)
