### PR TITLE
[AIR-3888] Fix double channel cleanup panic in async actualizer

### DIFF
--- a/pkg/processors/actualizers/async.go
+++ b/pkg/processors/actualizers/async.go
@@ -113,6 +113,7 @@ func (a *asyncActualizer) Run(vvmCtx context.Context) {
 			// i.e. 2nd finit will panic if an error is returned from 2nd init before the place where the pipeline is re-created
 			// see https://untill.atlassian.net/browse/AIR-2302
 			a.pipeline = nil
+			a.channelCleanup = nil
 			return err
 		})
 	}

--- a/pkg/processors/actualizers/async.go
+++ b/pkg/processors/actualizers/async.go
@@ -113,6 +113,11 @@ func (a *asyncActualizer) Run(vvmCtx context.Context) {
 			// i.e. 2nd finit will panic if an error is returned from 2nd init before the place where the pipeline is re-created
 			// see https://untill.atlassian.net/browse/AIR-2302
 			a.pipeline = nil
+			
+			// avoiding panic on cleanup of the already terminated n10n channel. Same lifecycle as a.pipeline:
+			// init (NewChannel sets channelCleanup), error, finit (channelCleanup terminates the channel),
+			// init again but error before NewChannel re-assigns channelCleanup, then 2nd finit -> panic in N10nBroker.cleanupChannel ("channel terminated")
+			// see https://untill.atlassian.net/browse/AIR-3888
 			a.channelCleanup = nil
 			return err
 		})

--- a/pkg/processors/actualizers/async.go
+++ b/pkg/processors/actualizers/async.go
@@ -113,7 +113,7 @@ func (a *asyncActualizer) Run(vvmCtx context.Context) {
 			// i.e. 2nd finit will panic if an error is returned from 2nd init before the place where the pipeline is re-created
 			// see https://untill.atlassian.net/browse/AIR-2302
 			a.pipeline = nil
-			
+
 			// avoiding panic on cleanup of the already terminated n10n channel. Same lifecycle as a.pipeline:
 			// init (NewChannel sets channelCleanup), error, finit (channelCleanup terminates the channel),
 			// init again but error before NewChannel re-assigns channelCleanup, then 2nd finit -> panic in N10nBroker.cleanupChannel ("channel terminated")

--- a/pkg/processors/actualizers/async_test.go
+++ b/pkg/processors/actualizers/async_test.go
@@ -1218,17 +1218,24 @@ func Test_AsynchronousActualizer_ChannelCleanupPanicReproduction(t *testing.T) {
 	tick := time.NewTicker(time.Millisecond)
 	defer tick.Stop()
 	deadline := time.After(5 * time.Second)
-	for {
+	recovered := false
+	for !recovered {
 		select {
 		case p := <-panicCh:
 			t.Fatalf("asyncActualizer panicked due to stale channelCleanup:\n%s", p)
 		case <-deadline:
 			t.Fatal("actualizer did not recover from injected failures")
 		case <-tick.C:
-			if flaky.appDefCalls.Load() >= 3 && flaky.waitForBorrowCalls.Load() >= 3 {
-				return
-			}
+			recovered = flaky.appDefCalls.Load() >= 3 && flaky.waitForBorrowCalls.Load() >= 3
 		}
+	}
+
+	vvmCancel()
+	<-done
+	select {
+	case p := <-panicCh:
+		t.Fatalf("asyncActualizer panicked during shutdown:\n%s", p)
+	default:
 	}
 }
 

--- a/pkg/processors/actualizers/async_test.go
+++ b/pkg/processors/actualizers/async_test.go
@@ -7,8 +7,10 @@
 package actualizers
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -18,7 +20,9 @@ import (
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/appdef/filter"
+	"github.com/voedger/voedger/pkg/appparts"
 	"github.com/voedger/voedger/pkg/goutils/logger"
+	retrier "github.com/voedger/voedger/pkg/goutils/retry"
 	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/in10n"
 	"github.com/voedger/voedger/pkg/in10nmem"
@@ -1148,4 +1152,102 @@ func Test_AsynchronousActualizer_Stress_Buffered(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Logf("FlushesTotal: %d", actMetrics.total(aaFlushesTotal))
+}
+
+// Reproduces https://untill.atlassian.net/browse/AIR-3888.
+//
+// Drives asyncActualizer.Run through a transient failure sequence using a flaky
+// IAppPartitions decorator:
+//   - iter 1: AppDef OK, WaitForBorrow (readOffset) OK, NewChannel sets
+//     channelCleanup, then WaitForBorrow (readPlogToTheEnd) fails -> finit
+//     terminates the channel.
+//   - iter 2: AppDef fails -> init returns BEFORE NewChannel reassigns
+//     channelCleanup -> finit invokes the stale closure from iter 1.
+//
+// Without the `a.channelCleanup = nil` reset after finit() in Run(), the second
+// finit() panics in N10nBroker.cleanupChannel with "channel terminated".
+func Test_AsynchronousActualizer_ChannelCleanupPanicReproduction(t *testing.T) {
+	appName, partitionNr := istructs.AppQName_test1_app1, istructs.PartitionID(1)
+
+	broker, bCleanup := in10nmem.NewN10nBroker(in10n.Quotas{
+		Channels: 10, ChannelsPerSubject: 10, Subscriptions: 10, SubscriptionsPerSubject: 10,
+	}, timeu.NewITime())
+	defer bCleanup()
+
+	actCfg := &BasicAsyncActualizerConfig{Broker: broker}
+	appParts, _, stop := deployTestApp(appName, 1, false, testWorkspace, testWorkspaceDescriptor,
+		func(wsb appdef.IWorkspaceBuilder) {
+			ProvideViewDef(wsb, incProjectionView, buildProjectionView)
+			wsb.AddCommand(testQName)
+			wsb.AddProjector(incrementorName).Events().Add(
+				[]appdef.OperationKind{appdef.OperationKind_Execute}, filter.QNames(testQName))
+		},
+		func(cfg *istructsmem.AppConfigType) {
+			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+			cfg.AddAsyncProjectors(testIncrementor)
+		},
+		actCfg)
+	defer stop()
+	appParts.DeployAppPartitions(appName, []istructs.PartitionID{partitionNr})
+
+	flaky := &flakyAppParts{IAppPartitions: appParts}
+	act := &asyncActualizer{
+		projectorQName: incrementorName,
+		conf: AsyncActualizerConf{
+			BasicAsyncActualizerConfig: *actCfg, AppQName: appName, PartitionID: partitionNr,
+		},
+		appParts:   flaky,
+		retrierCfg: retrier.NewConfig(time.Millisecond, 5*time.Millisecond),
+	}
+	vvmCtx, vvmCancel := context.WithCancel(context.Background())
+	act.Prepare(vvmCtx)
+
+	panicCh := make(chan string, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() {
+			if r := recover(); r != nil {
+				panicCh <- fmt.Sprintf("%v\n%s", r, debug.Stack())
+			}
+		}()
+		act.Run(vvmCtx)
+	}()
+	defer func() { vvmCancel(); <-done }()
+
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case p := <-panicCh:
+			t.Fatalf("asyncActualizer panicked due to stale channelCleanup:\n%s", p)
+		case <-deadline:
+			t.Fatal("actualizer did not recover from injected failures")
+		case <-tick.C:
+			if flaky.appDefCalls.Load() >= 3 && flaky.waitForBorrowCalls.Load() >= 3 {
+				return
+			}
+		}
+	}
+}
+
+type flakyAppParts struct {
+	appparts.IAppPartitions
+	appDefCalls        atomic.Int32
+	waitForBorrowCalls atomic.Int32
+}
+
+func (f *flakyAppParts) AppDef(name appdef.AppQName) (appdef.IAppDef, error) {
+	if f.appDefCalls.Add(1) == 2 {
+		return nil, errors.New("flaky AppDef failure")
+	}
+	return f.IAppPartitions.AppDef(name)
+}
+
+func (f *flakyAppParts) WaitForBorrow(ctx context.Context, app appdef.AppQName, partID istructs.PartitionID, kind appparts.ProcessorKind) (appparts.IAppPartition, error) {
+	if f.waitForBorrowCalls.Add(1) == 2 {
+		return nil, errors.New("flaky WaitForBorrow failure")
+	}
+	return f.IAppPartitions.WaitForBorrow(ctx, app, partID, kind)
 }

--- a/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/change.md
+++ b/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/change.md
@@ -1,0 +1,18 @@
+---
+registered_at: 2026-05-13T15:07:03Z
+change_id: 2605131507-fix-actualizer-channel-cleanup-panic
+baseline: 5b5dd6d7881494fafcc7571ebcdf196acd987d82
+issue_url: https://untill.atlassian.net/browse/AIR-3888
+---
+
+# Change request: Fix double channel cleanup panic in async actualizer
+
+## Why
+
+`TestVITResetPreservingStorage` sometimes fails with `panic: channel terminated` originating from `N10nBroker.cleanupChannel` when invoked twice on the same channel via `asyncActualizer.finit`. See [issue.md](issue.md) for details.
+
+## What
+
+Prevent stale `channelCleanup` reuse across retry iterations of `asyncActualizer.Run`:
+
+- Reset `a.channelCleanup` to `nil` after `finit()` in the retry loop, alongside the existing `a.pipeline = nil` reset

--- a/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/change.md
+++ b/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/change.md
@@ -16,3 +16,4 @@ issue_url: https://untill.atlassian.net/browse/AIR-3888
 Prevent stale `channelCleanup` reuse across retry iterations of `asyncActualizer.Run`:
 
 - Reset `a.channelCleanup` to `nil` after `finit()` in the retry loop, alongside the existing `a.pipeline = nil` reset
+- Add a regression test that drives the retry loop through the production failure path via a flaky `IAppPartitions` decorator

--- a/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/decs.md
+++ b/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/decs.md
@@ -1,0 +1,57 @@
+# Decisions: Fix double channel cleanup panic in async actualizer
+
+## Root cause of `panic: channel terminated`
+
+The panic is caused by `a.channelCleanup` retaining a closure that references an already-terminated channel across retry iterations of `asyncActualizer.Run`, not by `finit()` being invoked twice within a single iteration (confidence: high).
+
+Rationale:
+
+The panic stack shows `cleanupChannel` reaching the guard at [pkg/in10nmem/impl.go:265](../../../../../pkg/in10nmem/impl.go):
+
+```go
+if channel.terminated {
+    panic(in10n.ErrChannelTerminated)
+}
+```
+
+For this guard to fire, the same cleanup closure instance must be invoked twice on the same `*channel`. The codebase admits exactly one such path:
+
+- `channel.terminated = true` is set ONLY inside `cleanupChannel` itself ([impl.go:274](../../../../../pkg/in10nmem/impl.go)). No other path can pre-mark a channel terminated.
+- The cleanup closure is created uniquely per `NewChannel` call ([impl.go:58](../../../../../pkg/in10nmem/impl.go)), capturing one specific `&channel`, `channelID`, `metric` triple. It is the only call site of `cleanupChannel`.
+- In the actualizer, `a.channelCleanup` is written ONLY at [async.go:222](../../../../../pkg/processors/actualizers/async.go) (multi-value assignment from `Broker.NewChannel`; on `NewChannel` error the field is overwritten to `nil`).
+- `a.channelCleanup` is read ONLY at [async.go:237](../../../../../pkg/processors/actualizers/async.go) inside `finit()`.
+- `finit()` is called from a single site ([async.go:109](../../../../../pkg/processors/actualizers/async.go)) — exactly once per `RetryNoResult` attempt; `RetryNoResult` calls its op once per attempt and retries on error ([retry/utils.go](../../../../../pkg/goutils/retry/utils.go)).
+- `Run` is invoked from one goroutine per `asyncActualizer` (`PartitionActualizers.start` → `actualizers.NewAndRun` → `asyncActualizer.Run`), so no concurrent `finit`.
+
+Combining these facts, the only way the same closure can run twice is across iterations:
+
+1. Iteration N: `init()` succeeds → `a.channelCleanup` = closure_N → `keepReading()` → `finit()` invokes closure_N → channel marked `terminated`
+2. After `finit()`, `a.pipeline = nil` is reset (per AIR-2302) but `a.channelCleanup` is NOT reset
+3. Iteration N+1: `init()` returns early before reaching [async.go:222](../../../../../pkg/processors/actualizers/async.go) (e.g., `appParts.AppDef` returns error, `appdef.Projector` returns nil, or `readOffset` fails — all plausible during VIT reset when app parts are torn down/restored)
+4. `a.channelCleanup` still references closure_N → `finit()` invokes closure_N again → `cleanupChannel` panics on the terminated channel
+
+The existing comment at [async.go:111-114](../../../../../pkg/processors/actualizers/async.go) describes this exact bug class for `a.pipeline` (AIR-2302). The fix nilled `a.pipeline` but missed `a.channelCleanup`, which has identical lifecycle semantics.
+
+Alternatives considered and ruled out:
+
+- `finit()` invoked twice within the same iteration (confidence: ruled out)
+  - `Run.func1` has a single linear `a.finit()` call. `RetryNoResult` is a standard one-call-per-attempt loop. No second invocation site exists.
+- Concurrent `finit()` from another goroutine (confidence: ruled out)
+  - Each `asyncActualizer` is owned by exactly one goroutine started by `PartitionActualizers.start`. The struct is not shared.
+- Channel terminated via a different path (e.g., broker shutdown, `WatchChannel`, `Unsubscribe`) (confidence: ruled out)
+  - `channel.terminated = true` has only one assignment site (inside `cleanupChannel`). Broker shutdown does not mark individual channels terminated.
+- Closure aliasing across two distinct `NewChannel` calls (confidence: ruled out)
+  - Each `NewChannel` invocation constructs a fresh `channel` value and a fresh closure capturing its address. No reuse across calls.
+
+## Fix placement: reset in `Run` vs. inside `finit()` vs. broker idempotency
+
+Reset `a.channelCleanup = nil` in `Run` immediately after `finit()`, next to `a.pipeline = nil` (confidence: high).
+
+Rationale: matches the established AIR-2302 pattern at the same call site, keeps the two related lifecycle resets together, and preserves the broker invariant that `cleanupChannel` is called exactly once per channel (a double call remains a programming error, not a silently tolerated condition).
+
+Alternatives:
+
+- Reset inside `finit()` itself (confidence: medium)
+  - Makes `finit` idempotent through better encapsulation, but diverges from the existing convention in this file where post-`finit` resets live in the caller
+- Make `cleanupChannel` idempotent in the broker (confidence: low)
+  - Would mask the contract violation broker-wide and hide future regressions in other callers

--- a/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/decs.md
+++ b/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/decs.md
@@ -55,3 +55,16 @@ Alternatives:
   - Makes `finit` idempotent through better encapsulation, but diverges from the existing convention in this file where post-`finit` resets live in the caller
 - Make `cleanupChannel` idempotent in the broker (confidence: low)
   - Would mask the contract violation broker-wide and hide future regressions in other callers
+
+## Reproduction strategy in unit test
+
+Drive `asyncActualizer.Run` through its natural retry loop with a `flakyAppParts` decorator over `IAppPartitions`, failing `WaitForBorrow` #2 then `AppDef` #2 (confidence: high).
+
+Rationale: exercises the exact production code path (`init` → `keepReading` → `finit` → `init` again) without invasively double-calling `finit()`, mirroring the real-world cause (transient app-part availability during VIT reset).
+
+Alternatives:
+
+- Inject a failing projector function to fail `keepReading` (confidence: medium)
+  - Projector errors are caught by `asyncErrorHandler` and do not propagate as `RetryNoResult` op errors, so iter 2 init-time failure cannot be triggered
+- Cancel `readCtx` from outside via reflection (confidence: low)
+  - Invasive, brittle, couples test to internal field names

--- a/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/impl.md
+++ b/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/impl.md
@@ -1,0 +1,6 @@
+# Implementation plan: Fix double channel cleanup panic in async actualizer
+
+## Construction
+
+- [x] update: [async.go](../../../../../pkg/processors/actualizers/async.go)
+  - fix: reset `a.channelCleanup = nil` after `finit()` in `Run` retry loop, alongside `a.pipeline = nil`, to prevent stale cleanup closure invocation when `init()` returns early before re-acquiring a channel

--- a/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/impl.md
+++ b/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/impl.md
@@ -4,3 +4,8 @@
 
 - [x] update: [async.go](../../../../../pkg/processors/actualizers/async.go)
   - fix: reset `a.channelCleanup = nil` after `finit()` in `Run` retry loop, alongside `a.pipeline = nil`, to prevent stale cleanup closure invocation when `init()` returns early before re-acquiring a channel
+  - add rationale comment mirroring the AIR-2302 pipeline comment, referencing AIR-3888 and the `N10nBroker.cleanupChannel` "channel terminated" panic
+- [x] add: [async_test.go](../../../../../pkg/processors/actualizers/async_test.go) — `Test_AsynchronousActualizer_ChannelCleanupPanicReproduction`
+  - drive `asyncActualizer.Run` through the production retry loop with a `flakyAppParts` decorator that fails `WaitForBorrow` #2 (iter 1 `keepReading`) and `AppDef` #2 (iter 2 `init` before `NewChannel`)
+  - assert no panic via `recover()` + `runtime/debug.Stack()`; report the original `N10nBroker.cleanupChannel` stack on failure
+  - test fails (panics) without the fix and passes with it

--- a/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/issue.md
+++ b/uspecs/changes/2605131507-fix-actualizer-channel-cleanup-panic/issue.md
@@ -1,0 +1,45 @@
+# AIR-3888: fix panic on TestVITResetPreservingStorage
+
+- **Type**: Bug
+- **Status**: In Progress
+- **Assignee**: d.gribanov@dev.untill.com
+- **URL**: <https://untill.atlassian.net/browse/AIR-3888>
+
+## Description
+
+Failure observed in CI: <https://github.com/voedger/voedger/actions/runs/25540670722/job/74965652880>
+
+`TestVITResetPreservingStorage` sometimes fails with panic:
+
+```text
+panic: channel terminated
+
+goroutine 37612 [running]:
+github.com/voedger/voedger/pkg/in10nmem.(*N10nBroker).cleanupChannel(0xc00194e630, 0xc001b53c70, {0xc03122f3b0, 0x24}, 0xc03131b390)
+    /home/runner/work/voedger/voedger/pkg/in10nmem/impl.go:265 +0x56a
+github.com/voedger/voedger/pkg/in10nmem.(*N10nBroker).NewChannel.func1()
+    /home/runner/work/voedger/voedger/pkg/in10nmem/impl.go:58 +0x69
+github.com/voedger/voedger/pkg/processors/actualizers.(*asyncActualizer).finit(0xc0019c4a80)
+    /home/runner/work/voedger/voedger/pkg/processors/actualizers/async.go:236 +0xaf
+github.com/voedger/voedger/pkg/processors/actualizers.(*asyncActualizer).Run.func1()
+    /home/runner/work/voedger/voedger/pkg/processors/actualizers/async.go:109 +0x79
+github.com/voedger/voedger/pkg/goutils/retry.RetryNoResult.func1()
+    /home/runner/work/voedger/voedger/pkg/goutils/retry/utils.go:33 +0x2f
+github.com/voedger/voedger/pkg/goutils/retry.Retry[...].func1()
+    /home/runner/work/voedger/voedger/pkg/goutils/retry/utils.go:25 +0x38
+github.com/voedger/voedger/pkg/goutils/retry.(*Retrier).Run(0xc002887c38, {0x17fe8a8, 0xc001003b80}, 0xc002887c60)
+    /home/runner/work/voedger/voedger/pkg/goutils/retry/impl.go:66 +0xa4
+github.com/voedger/voedger/pkg/goutils/retry.Retry[...]({0x17fe8a8, 0xc001003b80}, {0x45ba94, 0x0?, 0xc001c528e0?, 0x91?}, 0xc0023e6cf8?)
+    /home/runner/work/voedger/voedger/pkg/goutils/retry/utils.go:23 +0x205
+github.com/voedger/voedger/pkg/goutils/retry.RetryNoResult({0x17fe8a8, 0xc001003b80}, {0xc0023e6d78?, 0x4dbd45?, 0xc001c528e0?, 0xe0?}, 0xc0023e6d58)
+    /home/runner/work/voedger/voedger/pkg/goutils/retry/utils.go:32 +0xc5
+github.com/voedger/voedger/pkg/processors/actualizers.(*asyncActualizer).Run(0xc0019c4a80, {0x17fe8a8, 0xc001003b80})
+    /home/runner/work/voedger/voedger/pkg/processors/actualizers/async.go:104 +0xd4
+github.com/voedger/voedger/pkg/processors/actualizers.(*actualizers).NewAndRun(0xc0025f6c30, {0x17fe8a8, 0xc001003b80}, {{0x1756380?, 0xbcb7c0?}, {0x175c387?, 0xc6?}}, 0x0, {{0xc0001422b0, 0x8}, ...})
+    /home/runner/work/voedger/voedger/pkg/processors/actualizers/actualizers.go:53 +0x555
+github.com/voedger/voedger/pkg/appparts/internal/actualizers.(*PartitionActualizers).start.func1()
+    /home/runner/work/voedger/voedger/pkg/appparts/internal/actualizers/actualizers.go:76 +0x227
+created by github.com/voedger/voedger/pkg/appparts/internal/actualizers.(*PartitionActualizers).start in goroutine 37496
+    /home/runner/work/voedger/voedger/pkg/appparts/internal/actualizers/actualizers.go:69 +0x345
+FAIL    github.com/voedger/voedger/pkg/sys/it    44.748s
+```


### PR DESCRIPTION
registered_at: 2026-05-13T15:07:03Z
change_id: 2605131507-fix-actualizer-channel-cleanup-panic
baseline: 5b5dd6d7881494fafcc7571ebcdf196acd987d82
issue_url: https://untill.atlassian.net/browse/AIR-3888

# Change request: Fix double channel cleanup panic in async actualizer

## Why

`TestVITResetPreservingStorage` sometimes fails with `panic: channel terminated` originating from `N10nBroker.cleanupChannel` when invoked twice on the same channel via `asyncActualizer.finit`. See [issue.md](issue.md) for details.

## What

Prevent stale `channelCleanup` reuse across retry iterations of `asyncActualizer.Run`:

- Reset `a.channelCleanup` to `nil` after `finit()` in the retry loop, alongside the existing `a.pipeline = nil` reset
