### PR TITLE
[AIR-3910] Fix wrong struct field assignment in SwitchOperator

### DIFF
--- a/pkg/pipeline/core-pipeline-design.archimate
+++ b/pkg/pipeline/core-pipeline-design.archimate
@@ -28,7 +28,6 @@
 }</documentation>
         </element>
         <element xsi:type="archimate:TechnologyProcess" name="Prepare()" id="id-4add19a34e4842628fe304a679012f81"/>
-        <element xsi:type="archimate:Artifact" name="currentBranchName" id="id-33726952f34b42578b3b1c05b8e61066"/>
         <element xsi:type="archimate:TechnologyProcess" name="DoSync()" id="id-a27fb3fea5334503a8f599034f5ba086"/>
       </folder>
       <folder name="fork" id="id-df95a09936e642cfbd944f727f7c09da">
@@ -513,10 +512,8 @@ type ISyncOperator interface {&#xD;
     <element xsi:type="archimate:AggregationRelationship" id="id-935d53635b02454e8c33d822097307f7" source="id-c065de82b62a42fea6fe782adcf23dd5" target="id-50692ee038334ea081580219316fc0a5"/>
     <element xsi:type="archimate:CompositionRelationship" id="id-369fa78d98704721859aecf9775d76ff" source="id-c065de82b62a42fea6fe782adcf23dd5" target="id-4add19a34e4842628fe304a679012f81"/>
     <element xsi:type="archimate:ServingRelationship" name="work -> Branch name" id="id-5f1c0460302648e79fd18a2bb3c9bb8d" source="id-a963419bce3f4f5ab4bfcf321a9be7ba" target="id-4add19a34e4842628fe304a679012f81"/>
-    <element xsi:type="archimate:AccessRelationship" id="id-06300c39cf314c12939f967059cdfccb" source="id-4add19a34e4842628fe304a679012f81" target="id-33726952f34b42578b3b1c05b8e61066"/>
     <element xsi:type="archimate:CompositionRelationship" id="id-3f8284e91b5f44feb7a4be15404bdd53" source="id-c065de82b62a42fea6fe782adcf23dd5" target="id-a27fb3fea5334503a8f599034f5ba086"/>
     <element xsi:type="archimate:TriggeringRelationship" id="id-e7cdc7f3a1c74e729b74cae4acef6a90" source="id-a27fb3fea5334503a8f599034f5ba086" target="id-c6c917aa2fa24c00aff064bfa7b91d43"/>
-    <element xsi:type="archimate:AccessRelationship" id="id-57f12511bb8a47678576c72b43bf4c6a" source="id-a27fb3fea5334503a8f599034f5ba086" target="id-33726952f34b42578b3b1c05b8e61066" accessType="1"/>
     <element xsi:type="archimate:TriggeringRelationship" id="id-af42794c311a41639951961b725b1094" source="id-b0152cdac9744a0d887e735557b03be3" target="id-73f004a40e6b49f687798331d57e5c0d"/>
     <element xsi:type="archimate:CompositionRelationship" id="id-f1db45648ff34fb5858fd243db3e3bfb" source="id-89f7bfd15d12483db60e498a3f3250e5" target="id-b0152cdac9744a0d887e735557b03be3"/>
     <element xsi:type="archimate:RealizationRelationship" id="id-ef803c07caee4230ba539ef6a12775f5" source="id-811e0b8652e94bd0be63b6727aaab984" target="id-a3ea51c35b5941bda12ad89b592cc86a"/>
@@ -560,15 +557,10 @@ type ISyncOperator interface {&#xD;
         </child>
         <child xsi:type="archimate:DiagramObject" id="id-20b5dfb50b9046e7ac4dac7c037ecd99" targetConnections="id-0c986e511adf41b8b2d18c2441a079e2 id-9f1e979f3dd54f079e875aae03ecbf26" archimateElement="id-4add19a34e4842628fe304a679012f81">
           <bounds x="720" y="276" width="157" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="id-84468e0be1c047519b7e1907459959ab" source="id-20b5dfb50b9046e7ac4dac7c037ecd99" target="id-7526c79a684c43599346ba1436339486" archimateRelationship="id-06300c39cf314c12939f967059cdfccb"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="id-7526c79a684c43599346ba1436339486" targetConnections="id-84468e0be1c047519b7e1907459959ab id-1110ff6c31c543b1a5b4468e389115f5" archimateElement="id-33726952f34b42578b3b1c05b8e61066">
-          <bounds x="720" y="420" width="157" height="55"/>
         </child>
         <child xsi:type="archimate:DiagramObject" id="id-14c30f44c3374d55b779e3f6b7f1314c" targetConnections="id-36e1ce130b7c4321a2e37575e6f0c5e0" archimateElement="id-a27fb3fea5334503a8f599034f5ba086">
           <bounds x="504" y="276" width="145" height="55"/>
           <sourceConnection xsi:type="archimate:Connection" id="id-ccaeed325ffb4e369fe1457a25052ce0" source="id-14c30f44c3374d55b779e3f6b7f1314c" target="id-a0cde9c79b924e39a90a08ce720cb254" archimateRelationship="id-e7cdc7f3a1c74e729b74cae4acef6a90"/>
-          <sourceConnection xsi:type="archimate:Connection" id="id-1110ff6c31c543b1a5b4468e389115f5" source="id-14c30f44c3374d55b779e3f6b7f1314c" target="id-7526c79a684c43599346ba1436339486" archimateRelationship="id-57f12511bb8a47678576c72b43bf4c6a"/>
         </child>
       </element>
       <element xsi:type="archimate:ArchimateDiagramModel" name="ForkOperator" id="id-94589d88f8e74625bf09e859a5324cb8">

--- a/pkg/pipeline/switch-operator-impl.go
+++ b/pkg/pipeline/switch-operator-impl.go
@@ -7,9 +7,8 @@ package pipeline
 import "context"
 
 type switchOperator struct {
-	switchLogic       ISwitch
-	branches          map[string]ISyncOperator
-	currentBranchName string
+	switchLogic ISwitch
+	branches    map[string]ISyncOperator
 }
 
 func (s switchOperator) Close() {
@@ -19,11 +18,11 @@ func (s switchOperator) Close() {
 }
 
 func (s switchOperator) DoSync(ctx context.Context, work IWorkpiece) (err error) {
-	s.currentBranchName, err = s.switchLogic.Switch(work)
+	branchName, err := s.switchLogic.Switch(work)
 	if err != nil {
 		return err
 	}
-	return s.branches[s.currentBranchName].DoSync(ctx, work)
+	return s.branches[branchName].DoSync(ctx, work)
 }
 
 type SwitchOperatorOptionFunc func(*switchOperator)

--- a/uspecs/changes/archive/2605/2605140834-fix-switch-op-field-assignment/change.md
+++ b/uspecs/changes/archive/2605/2605140834-fix-switch-op-field-assignment/change.md
@@ -1,0 +1,21 @@
+---
+registered_at: 2026-05-14T08:26:18Z
+change_id: 2605140826-fix-switch-op-field-assignment
+baseline: 816987454e5ee9cd6c094bb07fd41cdffe850db9
+issue_url: https://untill.atlassian.net/browse/AIR-3910
+archived_at: 2026-05-14T08:34:53Z
+---
+
+# Change request: Fix wrong struct field assignment in switchOperator
+
+## Why
+
+In `pkg/pipeline/switch-operator-impl.go`, `switchOperator.DoSync` has a value receiver yet assigns to `s.currentBranchName`. The mutation is silently lost outside the call, the field is never read elsewhere, and the pattern is misleading and unsafe under concurrent calls. See [issue.md](issue.md) for details.
+
+## What
+
+Fix the misuse of the struct field in `switchOperator`:
+
+- Replace the use of `s.currentBranchName` in `DoSync` with a local variable.
+- Remove the now-unused `currentBranchName` field from the `switchOperator` struct.
+- Update `pkg/pipeline/core-pipeline-design.archimate` to drop the `currentBranchName` artifact reference.

--- a/uspecs/changes/archive/2605/2605140834-fix-switch-op-field-assignment/impl.md
+++ b/uspecs/changes/archive/2605/2605140834-fix-switch-op-field-assignment/impl.md
@@ -1,0 +1,9 @@
+# Implementation plan: Fix wrong struct field assignment in switchOperator
+
+## Construction
+
+- [x] update: [pkg/pipeline/switch-operator-impl.go](../../../../../pkg/pipeline/switch-operator-impl.go)
+  - remove: `currentBranchName` field from `switchOperator` struct
+  - update: `DoSync` to use a local variable instead of `s.currentBranchName`
+- [x] update: [pkg/pipeline/core-pipeline-design.archimate](../../../../../pkg/pipeline/core-pipeline-design.archimate)
+  - remove: `currentBranchName` Artifact element and its inbound AccessRelationships and DiagramObject references

--- a/uspecs/changes/archive/2605/2605140834-fix-switch-op-field-assignment/issue.md
+++ b/uspecs/changes/archive/2605/2605140834-fix-switch-op-field-assignment/issue.md
@@ -1,0 +1,25 @@
+# AIR-3910: pipeline: SwitchOperator: fix wrong struct field assignment in func with non-pointer receiver
+
+- **Key:** AIR-3910
+- **Type:** Sub-task
+- **Status:** In Progress
+- **Assignee:** d.gribanov@dev.untill.com
+- **URL:** https://untill.atlassian.net/browse/AIR-3910
+
+## Why
+
+[pkg/pipeline/switch-operator-impl.go#L21](https://github.com/voedger/voedger/blob/816987454e5ee9cd6c094bb07fd41cdffe850db9/pkg/pipeline/switch-operator-impl.go#L21):
+
+```go
+func (s switchOperator) DoSync(ctx context.Context, work IWorkpiece) (err error) {
+    s.currentBranchName, err = s.switchLogic.Switch(work) // <-- error here, switchOperator.currentBranchName accessed wrong
+    if err != nil {
+        return err
+    }
+    return s.branches[s.currentBranchName].DoSync(ctx, work)
+}
+```
+
+## What
+
+Use a local var instead of the `currentBranchName` field.


### PR DESCRIPTION
registered_at: 2026-05-14T08:26:18Z
change_id: 2605140826-fix-switch-op-field-assignment
baseline: 816987454e5ee9cd6c094bb07fd41cdffe850db9
issue_url: https://untill.atlassian.net/browse/AIR-3910
archived_at: 2026-05-14T08:34:53Z

# Change request: Fix wrong struct field assignment in switchOperator

## Why

In `pkg/pipeline/switch-operator-impl.go`, `switchOperator.DoSync` has a value receiver yet assigns to `s.currentBranchName`. The mutation is silently lost outside the call, the field is never read elsewhere, and the pattern is misleading and unsafe under concurrent calls. See [issue.md](issue.md) for details.

## What

Fix the misuse of the struct field in `switchOperator`:

- Replace the use of `s.currentBranchName` in `DoSync` with a local variable.
- Remove the now-unused `currentBranchName` field from the `switchOperator` struct.
- Update `pkg/pipeline/core-pipeline-design.archimate` to drop the `currentBranchName` artifact reference.
