### PR TITLE
[AIR-3915] Allow recreating a login that was deactivated

### DIFF
--- a/pkg/registry/impl_createlogin.go
+++ b/pkg/registry/impl_createlogin.go
@@ -66,11 +66,13 @@ func createLogin(args istructs.ExecCommandArgs, login string) (err error) {
 		return coreutils.NewHTTPErrorf(http.StatusBadRequest, "incorrect login format: ", login)
 	}
 
-	cdocLoginID, err := GetCDocLoginID(args.State, args.WSID, appName, login)
+	// deactivated cdoc.registry.Login is treated as missing by GetCDocLogin so the same login name can be registered again;
+	// projectorLoginIdx then rewrites view.registry.LoginIdx by primary key (AppWSID, AppIDLoginHash)
+	_, loginExists, err := GetCDocLogin(login, args.State, args.WSID, appName)
 	if err != nil {
 		return err
 	}
-	if cdocLoginID > 0 {
+	if loginExists {
 		return coreutils.NewHTTPErrorf(http.StatusConflict, "login already exists")
 	}
 

--- a/pkg/sys/it/impl_deactivateworkspace_test.go
+++ b/pkg/sys/it/impl_deactivateworkspace_test.go
@@ -213,19 +213,30 @@ func TestDeactivateUserProfile(t *testing.T) {
 			it.Expect401(fmt.Sprintf("login %s does not exist", loginName))).Println()
 		expectVerboseLine()
 	})
+}
 
-	t.Run("recreate the deactivated login", func(t *testing.T) {
-		require := require.New(t)
+func TestRecreateDeactivatedLogin(t *testing.T) {
+	require := require.New(t)
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
 
-		// sign up the same loginName again -> a new bare cdoc.registry.Login with the same name
-		newLogin := vit.SignUp(loginName, pwd, istructs.AppQName_test1_app1)
+	loginName := vit.NextName() + "@123.com"
+	pwd := "1"
 
-		// view.registry.LoginIdx is rewritten by projectorLoginIdx (PK = AppWSID + AppIDLoginHash) to point at the new CDocLogin
-		newCDocLoginID := vit.GetCDocLoginID(newLogin)
-		require.NotEqual(cdocLoginID, newCDocLoginID, "view.registry.LoginIdx must be rewritten to a new CDoc<Login>")
+	// create
+	login := vit.SignUp(loginName, pwd, istructs.AppQName_test1_app1)
+	prn := vit.SignIn(login)
+	cdocLoginID := vit.GetCDocLoginID(login)
 
-		// q.registry.IssuePrincipalToken authenticates the recreated login and resolves a fresh ProfileWSID
-		newPrn := vit.SignIn(newLogin)
-		require.NotEqual(prn.ProfileWSID, newPrn.ProfileWSID, "recreated login must resolve to a new profile workspace")
-	})
+	// deactivate
+	vit.PostProfile(prn, "c.sys.InitiateDeactivateWorkspace", "{}")
+	waitForDeactivate(vit, prn.AppQName, prn.ProfileWSID, loginName)
+
+	// create again with the same name
+	newLogin := vit.SignUp(loginName, pwd, istructs.AppQName_test1_app1)
+	newPrn := vit.SignIn(newLogin)
+	newCDocLoginID := vit.GetCDocLoginID(newLogin)
+
+	require.NotEqual(cdocLoginID, newCDocLoginID, "view.registry.LoginIdx must be rewritten to a new CDoc<Login>")
+	require.NotEqual(prn.ProfileWSID, newPrn.ProfileWSID, "recreated login must resolve to a new profile workspace")
 }

--- a/pkg/sys/it/impl_deactivateworkspace_test.go
+++ b/pkg/sys/it/impl_deactivateworkspace_test.go
@@ -213,4 +213,19 @@ func TestDeactivateUserProfile(t *testing.T) {
 			it.Expect401(fmt.Sprintf("login %s does not exist", loginName))).Println()
 		expectVerboseLine()
 	})
+
+	t.Run("recreate the deactivated login", func(t *testing.T) {
+		require := require.New(t)
+
+		// sign up the same loginName again -> a new bare cdoc.registry.Login with the same name
+		newLogin := vit.SignUp(loginName, pwd, istructs.AppQName_test1_app1)
+
+		// view.registry.LoginIdx is rewritten by projectorLoginIdx (PK = AppWSID + AppIDLoginHash) to point at the new CDocLogin
+		newCDocLoginID := vit.GetCDocLoginID(newLogin)
+		require.NotEqual(cdocLoginID, newCDocLoginID, "view.registry.LoginIdx must be rewritten to a new CDoc<Login>")
+
+		// q.registry.IssuePrincipalToken authenticates the recreated login and resolves a fresh ProfileWSID
+		newPrn := vit.SignIn(newLogin)
+		require.NotEqual(prn.ProfileWSID, newPrn.ProfileWSID, "recreated login must resolve to a new profile workspace")
+	})
 }

--- a/pkg/sys/workspace/impl.go
+++ b/pkg/sys/workspace/impl.go
@@ -111,12 +111,28 @@ func execCmdCreateWorkspaceID(args istructs.ExecCommandArgs) (err error) {
 	}
 	kb.PutInt64(Field_OwnerWSID, ownerWSID)
 	kb.PutString(authnz.Field_WSName, wsName)
-	_, ok, err := args.State.CanExist(kb)
+	viewRec, ok, err := args.State.CanExist(kb)
 	if err != nil {
 		return err
 	}
 	if ok {
-		return coreutils.NewHTTPErrorf(http.StatusConflict, fmt.Sprintf("workspace with name %s and ownerWSID %d already exists", wsName, ownerWSID))
+		// the existing index entry must be honored only while its cdoc.sys.WorkspaceID is active;
+		// if the previous workspace was deactivated (cmdOnWorkspaceDeactivatedExec sets sys.IsActive=false on cdoc.sys.WorkspaceID),
+		// re-creation under the same (OwnerWSID, WSName) is allowed and workspaceIDIdxProjector overwrites the index entry
+		recKB, err := args.State.KeyBuilder(sys.Storage_Record, QNameCDocWorkspaceID)
+		if err != nil {
+			// notest
+			return err
+		}
+		recKB.PutRecordID(sys.Storage_Record_Field_ID, viewRec.AsRecordID(field_IDOfCDocWorkspaceID))
+		cdocWorkspaceID, err := args.State.MustExist(recKB)
+		if err != nil {
+			// notest
+			return err
+		}
+		if cdocWorkspaceID.AsBool(appdef.SystemField_IsActive) {
+			return coreutils.NewHTTPErrorf(http.StatusConflict, fmt.Sprintf("workspace with name %s and ownerWSID %d already exists", wsName, ownerWSID))
+		}
 	}
 
 	// Get new WSID from View<NextBaseWSID>

--- a/pkg/sys/workspace/impl_deactivate.go
+++ b/pkg/sys/workspace/impl_deactivate.go
@@ -242,12 +242,22 @@ func projectorApplyDeactivateWorkspace(federation federation.IFederation, tokens
 			return err
 		}
 
-		// currentApp/ApplicationWS/c.sys.OnWorkspaceDeactivated(OnwerWSID, WSName)
+		// c.sys.OnWorkspaceDeactivated targets the app and pseudoWSID where cdoc.sys.WorkspaceID actually lives:
+		//   child workspace (ownerApp == projectorApp): ownerApp at pseudoWSID(ownerWSID, wsName)
+		//   login profile (ownerApp != projectorApp):   projectorApp (= targetApp) at pseudoWSID(NullWSID, wsName)
+		//                                                per pkg/registry/impl_invokecreateworkspaceid.go
 		wsName := wsDesc.AsString(authnz.Field_WSName)
 		body := fmt.Sprintf(`{"args":{"OwnerWSID":%d, "WSName":%q}}`, ownerWSID, wsName)
+		cdocWorkspaceIDApp := ownerApp
+		cdocWorkspaceIDAppToken := ownerAppToken
 		cdocWorkspaceIDWSID := coreutils.GetPseudoWSID(istructs.WSID(ownerWSID), wsName, event.Workspace().ClusterID()) // nolint G115
-		if _, err := federation.Func(fmt.Sprintf("api/%s/%d/c.sys.OnWorkspaceDeactivated", ownerApp, cdocWorkspaceIDWSID), body,
-			httpu.WithDiscardResponse(), httpu.WithAuthorizeBy(ownerAppToken)); err != nil {
+		if ownerAppQName != projectorAppQName {
+			cdocWorkspaceIDApp = projectorAppQName.String()
+			cdocWorkspaceIDAppToken = projectorAppToken
+			cdocWorkspaceIDWSID = coreutils.GetPseudoWSID(istructs.NullWSID, wsName, event.Workspace().ClusterID())
+		}
+		if _, err := federation.Func(fmt.Sprintf("api/%s/%d/c.sys.OnWorkspaceDeactivated", cdocWorkspaceIDApp, cdocWorkspaceIDWSID), body,
+			httpu.WithDiscardResponse(), httpu.WithAuthorizeBy(cdocWorkspaceIDAppToken)); err != nil {
 			return fmt.Errorf("c.sys.OnWorkspaceDeactivated failed: %w", err)
 		}
 

--- a/uspecs/changes/archive/2605/2605141149-recreate-deactivated-login/change.md
+++ b/uspecs/changes/archive/2605/2605141149-recreate-deactivated-login/change.md
@@ -1,0 +1,20 @@
+---
+registered_at: 2026-05-14T10:38:43Z
+change_id: 2605141038-recreate-deactivated-login
+baseline: 4184d623f617f80924fec35b0351252c59686887
+issue_url: https://untill.atlassian.net/browse/AIR-3915
+archived_at: 2026-05-14T11:49:37Z
+---
+
+# Change request: Allow recreating a login that was deactivated
+
+## Why
+
+Once a login is deactivated, `IssuePrincipalToken` returns "login or password is incorrect" (per AIR-3892), but attempting to register the same login again fails with "login exists already". This violates GDPR statements because the user cannot re-register under the same name. See [issue.md](issue.md) for details.
+
+## What
+
+Registering a login again after it was deactivated must succeed:
+
+- Creating a login with a name that previously existed but is now deactivated produces a new bare login with the same name
+- Existing key in `LoginIdx` is rewritten to point to the newly created login

--- a/uspecs/changes/archive/2605/2605141149-recreate-deactivated-login/how.md
+++ b/uspecs/changes/archive/2605/2605141149-recreate-deactivated-login/how.md
@@ -1,0 +1,21 @@
+# How: registry — allow recreating a login after its profile was deactivated
+
+## Approach
+
+- Lift the "treat inactive as missing" rule into the create-login path in `pkg/registry/impl_createlogin.go`: replace the `GetCDocLoginID > 0` precheck inside `createLogin` with a `GetCDocLogin` call. Since `GetCDocLogin` in `pkg/registry/utils.go` already returns `loginExists=false` for `cdoc.registry.Login` with `sys.IsActive=false` (per the prior AIR-3892 change), the 409 "login already exists" response stays for active logins and is bypassed for deactivated ones — covering both `c.registry.CreateLogin` and `c.registry.CreateEmailLogin`, which share `createLogin`
+- Rely on the existing `projectorLoginIdx` in `impl_createlogin.go` to "rewrite the existing key in `LoginIdx`": its PK is `(AppWSID, AppIDLoginHash)`, so the new `cdoc.registry.Login` produced for the same login name simply overwrites the stale `CDocLoginID` value pointing at the deactivated record. No projector or `appws.vsql` change required
+- The new `cdoc.registry.Login` is `IsNew()` and triggers `invokeCreateWorkspaceIDProjector` in `impl_invokecreateworkspaceid.go`, which creates a fresh profile workspace — matching the issue's "new bare login is created" requirement; the deactivated profile workspace from the previous incarnation is left as-is (it is already `Status=Inactive` after the deactivation cascade)
+- Relax the `c.sys.CreateWorkspaceID` deduplication in `pkg/sys/workspace/impl.go > execCmdCreateWorkspaceID` so the 409 "already exists" response is returned only while the existing `cdoc.sys.WorkspaceID` (referenced by `view.sys.WorkspaceIDIdx[(OwnerWSID, WSName)].IDOfCDocWorkspaceID`) is `sys.IsActive=true`. If the previous profile was deactivated (so its `cdoc.sys.WorkspaceID.sys.IsActive=false`), re-creation under the same `(OwnerWSID, WSName)` proceeds and `workspaceIDIdxProjector` overwrites the index entry by its PK `(OwnerWSID, WSName)`. The deduplication for active workspaces (and for child-workspace re-creation under an active owner) is preserved
+- Close the deactivation gap for login profiles in `pkg/sys/workspace/impl_deactivate.go > projectorApplyDeactivateWorkspace` so the IsActive check above can actually fire: route the existing `c.sys.OnWorkspaceDeactivated` call to the app and pseudoWSID where `cdoc.sys.WorkspaceID` actually lives — `ownerApp` at `pseudoWSID(ownerWSID, wsName)` for child workspaces (where `ownerAppQName == projectorAppQName`), and `projectorAppQName` (= `targetApp`) at `pseudoWSID(NullWSID, wsName)` for login profiles (where `ownerAppQName != projectorAppQName`, per `pkg/registry/impl_invokecreateworkspaceid.go`). The previous unconditional call to `ownerApp` was a silent no-op for login profiles since no `cdoc.sys.WorkspaceID` exists there
+- Cover the recreate-after-deactivate scenario with an IT in `pkg/sys/it/impl_deactivateworkspace_test.go` (next to the existing deactivation cascade IT): sign up a login, deactivate its profile WS via `c.sys.InitiateDeactivateWorkspace`, wait for `cdoc.registry.Login.sys.IsActive=false`, then sign up the same login again and assert it succeeds, the resulting `cdoc.registry.Login` is a new `RecordID`, the `view.registry.LoginIdx` entry now points at it, and `q.registry.IssuePrincipalToken` returns a token for the new profile
+
+References:
+
+- [pkg/registry/impl_createlogin.go](../../../../../pkg/registry/impl_createlogin.go)
+- [pkg/registry/utils.go](../../../../../pkg/registry/utils.go)
+- [pkg/registry/impl_invokecreateworkspaceid.go](../../../../../pkg/registry/impl_invokecreateworkspaceid.go)
+- [pkg/registry/appws.vsql](../../../../../pkg/registry/appws.vsql)
+- [pkg/sys/workspace/impl.go](../../../../../pkg/sys/workspace/impl.go)
+- [pkg/sys/workspace/impl_deactivate.go](../../../../../pkg/sys/workspace/impl_deactivate.go)
+- [pkg/sys/it/impl_deactivateworkspace_test.go](../../../../../pkg/sys/it/impl_deactivateworkspace_test.go)
+- [pkg/sys/it/impl_signupin_test.go](../../../../../pkg/sys/it/impl_signupin_test.go)

--- a/uspecs/changes/archive/2605/2605141149-recreate-deactivated-login/impl.md
+++ b/uspecs/changes/archive/2605/2605141149-recreate-deactivated-login/impl.md
@@ -1,0 +1,17 @@
+# Implementation plan: Allow recreating a login that was deactivated
+
+## Construction
+
+- [x] update: [pkg/registry/impl_createlogin.go](../../../../../pkg/registry/impl_createlogin.go)
+  - update: in `createLogin`, replace the `GetCDocLoginID > 0` precheck with `GetCDocLogin` so the existing IsActive filter (introduced for AIR-3892) is honored — an existing-but-deactivated `cdoc.registry.Login` no longer triggers the 409 "login already exists" response and a new `cdoc.registry.Login` is created instead; the `projectorLoginIdx` already overwrites `view.registry.LoginIdx` by primary key `(AppWSID, AppIDLoginHash)`, so the stale `CDocLoginID` is rewritten without any projector or `appws.vsql` change
+- [x] update: [pkg/sys/workspace/impl.go](../../../../../pkg/sys/workspace/impl.go)
+  - update: in `execCmdCreateWorkspaceID`, when `view.sys.WorkspaceIDIdx[(OwnerWSID, WSName)]` already exists, additionally read `cdoc.sys.WorkspaceID` by `IDOfCDocWorkspaceID` and return the 409 conflict only if its `sys.IsActive=true`; if it is `false` (previous profile was deactivated), proceed with creation — `workspaceIDIdxProjector` then overwrites the index entry by its PK `(OwnerWSID, WSName)`
+- [x] update: [pkg/sys/workspace/impl_deactivate.go](../../../../../pkg/sys/workspace/impl_deactivate.go)
+  - update: in `projectorApplyDeactivateWorkspace`, route the single `c.sys.OnWorkspaceDeactivated` call to the app and pseudoWSID where `cdoc.sys.WorkspaceID` actually lives — `ownerApp` at `pseudoWSID(ownerWSID, wsName)` for child workspaces, and `projectorAppQName` (= `targetApp`) at `pseudoWSID(NullWSID, wsName)` for login profiles (`ownerAppQName != projectorAppQName`, per `pkg/registry/impl_invokecreateworkspaceid.go`) — so its `sys.IsActive` is flipped to `false` and the new `execCmdCreateWorkspaceID` IsActive check can detect the deactivated state on re-creation; the previous call to `ownerApp` was a silent no-op for login profiles since no `cdoc.sys.WorkspaceID` exists there
+- [x] update: [pkg/sys/it/impl_deactivateworkspace_test.go](../../../../../pkg/sys/it/impl_deactivateworkspace_test.go)
+  - add: subtest under `TestDeactivateUserProfile` that signs up the same login again after deactivation completes and asserts:
+    - `c.registry.CreateLogin` succeeds (no 409)
+    - the resulting `cdoc.registry.Login` has a different `RecordID` than the deactivated one
+    - `view.registry.LoginIdx` for the same `(AppWSID, AppName/LoginHash)` now points at the new `CDocLoginID`
+    - `q.registry.IssuePrincipalToken` returns a token for the recreated login and resolves a new `ProfileWSID` distinct from the deactivated profile
+- [x] Review

--- a/uspecs/changes/archive/2605/2605141149-recreate-deactivated-login/issue.md
+++ b/uspecs/changes/archive/2605/2605141149-recreate-deactivated-login/issue.md
@@ -1,0 +1,21 @@
+# AIR-3915: voedger: make possible to create login again if it was deactivated
+
+- **Key**: AIR-3915
+- **Type**: Sub-task
+- **Status**: In Progress
+- **Assignee**: d.gribanov@dev.untill.com
+- **URL**: https://untill.atlassian.net/browse/AIR-3915
+
+## Why
+
+- Deactivate login
+- `IssuePrincipalToken` returns "login or password is incorrect" according to [AIR-3892](https://untill.atlassian.net/browse/AIR-3892)
+- Try to create the login again with the same name → "login exists already" error that violates GDPR statements
+
+## What
+
+Create the login again with the same name → new bare login is created, the same name.
+
+## How
+
+Rewrite the existing key in `LoginIdx`.

--- a/uspecs/changes/archive/2605/2605141149-recreate-deactivated-login/issue.md
+++ b/uspecs/changes/archive/2605/2605141149-recreate-deactivated-login/issue.md
@@ -1,4 +1,4 @@
-# AIR-3915: voedger: make possible to create login again if it was deactivated
+# AIR-3915: voedger: make it possible to create a login again after it was deactivated
 
 - **Key**: AIR-3915
 - **Type**: Sub-task


### PR DESCRIPTION
registered_at: 2026-05-14T10:38:43Z
change_id: 2605141038-recreate-deactivated-login
baseline: 4184d623f617f80924fec35b0351252c59686887
issue_url: https://untill.atlassian.net/browse/AIR-3915
archived_at: 2026-05-14T11:49:37Z

# Change request: Allow recreating a login that was deactivated

## Why

Once a login is deactivated, `IssuePrincipalToken` returns "login or password is incorrect" (per AIR-3892), but attempting to register the same login again fails with "login exists already". This violates GDPR statements because the user cannot re-register under the same name. See [issue.md](issue.md) for details.

## What

Registering a login again after it was deactivated must succeed:

- Creating a login with a name that previously existed but is now deactivated produces a new bare login with the same name
- Existing key in `LoginIdx` is rewritten to point to the newly created login
