### PR TITLE
[AIR-3289] Enforce SELECT ACL on fields in VSQL WHERE clause

### DIFF
--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -642,6 +642,15 @@ func TestAuthnz(t *testing.T) {
 				"denied field in nested WHERE expression",
 				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where (Fld1 = 1 and (DeniedFld2 = 2 or Fld1 = 3))",
 			},
+			{
+				"denied field on the left of IN",
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where DeniedFld2 in (1, 2)"},
+			{
+				"denied field inside IN value tuple",
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where Fld1 in (DeniedFld2, 2)"},
+			{
+				"denied field on the left of NOT IN",
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where DeniedFld2 not in (1, 2)"},
 		}
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {

--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -651,6 +651,9 @@ func TestAuthnz(t *testing.T) {
 			{
 				"denied field on the left of NOT IN",
 				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where DeniedFld2 not in (1, 2)"},
+			{
+				"denied field qualified by table name",
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where TestCDocWithDeniedFields.DeniedFld2 = 1"},
 		}
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {

--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -623,6 +623,33 @@ func TestAuthnz(t *testing.T) {
 		body := fmt.Sprintf(`{"args":{"Query":"select * from app1pkg.orecord1.%d"},"elements":[{"fields":["Result"]}]}`, orecordID)
 		vit.PostWS(ws, "q.sys.SqlQuery", body, httpu.WithAuthorizeBy(apiToken), httpu.Expect403())
 	})
+
+	t.Run("WHERE field ACL", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			query string
+		}{
+			{
+				"denied field in WHERE with allowed projection",
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where DeniedFld2 = 1"},
+			{
+				"denied field in WHERE combined via AND",
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where Fld1 = 1 and DeniedFld2 = 2"},
+			{
+				"denied field in WHERE combined via OR",
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where Fld1 = 1 or DeniedFld2 = 2"},
+			{
+				"denied field in nested WHERE expression",
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where (Fld1 = 1 and (DeniedFld2 = 2 or Fld1 = 3))",
+			},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				body := fmt.Sprintf(`{"args":{"Query":%q},"elements":[{"fields":["Result"]}]}`, c.query)
+				vit.PostWS(ws, "q.sys.SqlQuery", body, httpu.Expect403()).Println()
+			})
+		}
+	})
 }
 
 func TestReadODocs(t *testing.T) {

--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -631,29 +631,36 @@ func TestAuthnz(t *testing.T) {
 		}{
 			{
 				"denied field in WHERE with allowed projection",
-				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where DeniedFld2 = 1"},
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where DeniedFld2 = 1",
+			},
 			{
 				"denied field in WHERE combined via AND",
-				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where Fld1 = 1 and DeniedFld2 = 2"},
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where Fld1 = 1 and DeniedFld2 = 2",
+			},
 			{
 				"denied field in WHERE combined via OR",
-				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where Fld1 = 1 or DeniedFld2 = 2"},
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where Fld1 = 1 or DeniedFld2 = 2",
+			},
 			{
 				"denied field in nested WHERE expression",
 				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where (Fld1 = 1 and (DeniedFld2 = 2 or Fld1 = 3))",
 			},
 			{
 				"denied field on the left of IN",
-				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where DeniedFld2 in (1, 2)"},
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where DeniedFld2 in (1, 2)",
+			},
 			{
 				"denied field inside IN value tuple",
-				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where Fld1 in (DeniedFld2, 2)"},
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where Fld1 in (DeniedFld2, 2)",
+			},
 			{
 				"denied field on the left of NOT IN",
-				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where DeniedFld2 not in (1, 2)"},
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where DeniedFld2 not in (1, 2)",
+			},
 			{
 				"denied field qualified by table name",
-				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where TestCDocWithDeniedFields.DeniedFld2 = 1"},
+				"select Fld1 from app1pkg.TestCDocWithDeniedFields.123 where TestCDocWithDeniedFields.DeniedFld2 = 1",
+			},
 		}
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {

--- a/pkg/sys/sqlquery/impl.go
+++ b/pkg/sys/sqlquery/impl.go
@@ -402,57 +402,28 @@ func collectWhereFields(expr sqlparser.Expr, withFields appdef.IWithFields, dst 
 	if expr == nil {
 		return
 	}
-	add := func(name string) {
+	err := sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		col, ok := node.(*sqlparser.ColName)
+		if !ok {
+			return true, nil
+		}
+		name := col.Name.String()
+		if !col.Qualifier.Name.IsEmpty() {
+			name = fmt.Sprintf("%s.%s", col.Qualifier.Name, col.Name)
+		}
 		if withFields != nil {
 			recovered := recoverFieldName(withFields, name)
 			if withFields.Field(recovered) == nil {
-				return
+				return true, nil
 			}
 			name = recovered
 		}
 		dst[name] = true
-	}
-	switch e := expr.(type) {
-	case *sqlparser.ColName:
-		if !e.Qualifier.Name.IsEmpty() {
-			add(fmt.Sprintf("%s.%s", e.Qualifier.Name, e.Name))
-		} else {
-			add(e.Name.String())
-		}
-	case *sqlparser.AndExpr:
-		collectWhereFields(e.Left, withFields, dst)
-		collectWhereFields(e.Right, withFields, dst)
-	case *sqlparser.OrExpr:
-		collectWhereFields(e.Left, withFields, dst)
-		collectWhereFields(e.Right, withFields, dst)
-	case *sqlparser.NotExpr:
-		collectWhereFields(e.Expr, withFields, dst)
-	case *sqlparser.ParenExpr:
-		collectWhereFields(e.Expr, withFields, dst)
-	case *sqlparser.ComparisonExpr:
-		collectWhereFields(e.Left, withFields, dst)
-		collectWhereFields(e.Right, withFields, dst)
-	case *sqlparser.RangeCond:
-		collectWhereFields(e.Left, withFields, dst)
-		collectWhereFields(e.From, withFields, dst)
-		collectWhereFields(e.To, withFields, dst)
-	case *sqlparser.IsExpr:
-		collectWhereFields(e.Expr, withFields, dst)
-	case *sqlparser.BinaryExpr:
-		collectWhereFields(e.Left, withFields, dst)
-		collectWhereFields(e.Right, withFields, dst)
-	case *sqlparser.UnaryExpr:
-		collectWhereFields(e.Expr, withFields, dst)
-	case sqlparser.ValTuple:
-		for _, v := range e {
-			collectWhereFields(v, withFields, dst)
-		}
-	case *sqlparser.FuncExpr:
-		for _, se := range e.Exprs {
-			if ae, ok := se.(*sqlparser.AliasedExpr); ok {
-				collectWhereFields(ae.Expr, withFields, dst)
-			}
-		}
+		return true, nil
+	}, expr)
+	if err != nil {
+		// notest
+		panic(err)
 	}
 }
 

--- a/pkg/sys/sqlquery/impl.go
+++ b/pkg/sys/sqlquery/impl.go
@@ -408,9 +408,6 @@ func collectWhereFields(expr sqlparser.Expr, withFields appdef.IWithFields, dst 
 			return true, nil
 		}
 		name := col.Name.String()
-		if !col.Qualifier.Name.IsEmpty() {
-			name = fmt.Sprintf("%s.%s", col.Qualifier.Name, col.Name)
-		}
 		if withFields != nil {
 			recovered := recoverFieldName(withFields, name)
 			if withFields.Field(recovered) == nil {

--- a/pkg/sys/sqlquery/impl.go
+++ b/pkg/sys/sqlquery/impl.go
@@ -179,9 +179,20 @@ func provideExecQrySQLQuery(federation federation.IFederation, itokens itokens.I
 			switch kind {
 			case appdef.TypeKind_ViewRecord, appdef.TypeKind_CDoc, appdef.TypeKind_CRecord,
 				appdef.TypeKind_WDoc, appdef.TypeKind_ODoc, appdef.TypeKind_ORecord:
-				fields := make([]string, 0, len(f.fields))
-				for f := range f.fields {
-					fields = append(fields, f)
+				aclFields := make(map[string]bool, len(f.fields))
+				for fld := range f.fields {
+					aclFields[fld] = true
+				}
+				if whereExpr != nil {
+					var withFields appdef.IWithFields
+					if wf, ok := sourceTableType.(appdef.IWithFields); ok {
+						withFields = wf
+					}
+					collectWhereFields(whereExpr, withFields, aclFields)
+				}
+				fields := make([]string, 0, len(aclFields))
+				for fld := range aclFields {
+					fields = append(fields, fld)
 				}
 				wp := args.Workpiece.(processors.IProcessorWorkpiece)
 				apppart := wp.AppPartition()
@@ -385,6 +396,64 @@ func recoverFieldName(withFields appdef.IWithFields, name string) string {
 		}
 	}
 	return name
+}
+
+func collectWhereFields(expr sqlparser.Expr, withFields appdef.IWithFields, dst map[string]bool) {
+	if expr == nil {
+		return
+	}
+	add := func(name string) {
+		if withFields != nil {
+			recovered := recoverFieldName(withFields, name)
+			if withFields.Field(recovered) == nil {
+				return
+			}
+			name = recovered
+		}
+		dst[name] = true
+	}
+	switch e := expr.(type) {
+	case *sqlparser.ColName:
+		if !e.Qualifier.Name.IsEmpty() {
+			add(fmt.Sprintf("%s.%s", e.Qualifier.Name, e.Name))
+		} else {
+			add(e.Name.String())
+		}
+	case *sqlparser.AndExpr:
+		collectWhereFields(e.Left, withFields, dst)
+		collectWhereFields(e.Right, withFields, dst)
+	case *sqlparser.OrExpr:
+		collectWhereFields(e.Left, withFields, dst)
+		collectWhereFields(e.Right, withFields, dst)
+	case *sqlparser.NotExpr:
+		collectWhereFields(e.Expr, withFields, dst)
+	case *sqlparser.ParenExpr:
+		collectWhereFields(e.Expr, withFields, dst)
+	case *sqlparser.ComparisonExpr:
+		collectWhereFields(e.Left, withFields, dst)
+		collectWhereFields(e.Right, withFields, dst)
+	case *sqlparser.RangeCond:
+		collectWhereFields(e.Left, withFields, dst)
+		collectWhereFields(e.From, withFields, dst)
+		collectWhereFields(e.To, withFields, dst)
+	case *sqlparser.IsExpr:
+		collectWhereFields(e.Expr, withFields, dst)
+	case *sqlparser.BinaryExpr:
+		collectWhereFields(e.Left, withFields, dst)
+		collectWhereFields(e.Right, withFields, dst)
+	case *sqlparser.UnaryExpr:
+		collectWhereFields(e.Expr, withFields, dst)
+	case sqlparser.ValTuple:
+		for _, v := range e {
+			collectWhereFields(v, withFields, dst)
+		}
+	case *sqlparser.FuncExpr:
+		for _, se := range e.Exprs {
+			if ae, ok := se.(*sqlparser.AliasedExpr); ok {
+				collectWhereFields(ae.Expr, withFields, dst)
+			}
+		}
+	}
 }
 
 func getFilter(f func(string) bool) coreutils.MapperOpt {

--- a/uspecs/changes/archive/2605/2605151348-sql-acl-check-where-fields/change.md
+++ b/uspecs/changes/archive/2605/2605151348-sql-acl-check-where-fields/change.md
@@ -31,9 +31,12 @@ Authorize every field referenced in a VSQL SELECT statement, including fields us
   - add: subtest verifying SELECT with denied field in `WHERE` combined via `AND` and via `OR` returns `403 Forbidden`
   - add: subtest verifying SELECT with denied field in nested `WHERE` expression returns `403 Forbidden`
   - add: subtest verifying SELECT succeeds when every projected and `WHERE`-referenced field is allowed
+  - add: subtests verifying SELECT with denied field on the left of `IN`, inside an `IN` value tuple and on the left of `NOT IN` returns `403 Forbidden`
+  - add: subtest verifying SELECT with denied field qualified by the source table name (e.g. `where TestCDocWithDeniedFields.DeniedFld2 = 1`) returns `403 Forbidden`
   - dropped (out of scope for this entrypoint): view subtest — VSQL view reading only supports key-field filters in `WHERE`, and the existing test schema grants every key field of `app1pkg.DailyIdx` to `LimitedAccessRole`; the same security guarantee for views is covered by the unified projection+`WHERE` ACL union in `sys/sqlquery/impl.go`
 
 - [x] update: [sys/sqlquery/impl.go](../../../../../pkg/sys/sqlquery/impl.go)
-  - add: `collectWhereFields` helper that walks a `sqlparser.Expr` and collects every `*sqlparser.ColName` field name referenced in the `WHERE` clause, recovering the original case via `recoverFieldName` and ignoring identifiers that are not real fields of the source type (e.g. the `id` pseudo-column used by record-by-id lookup)
+  - add: `collectWhereFields` helper that traverses a `sqlparser.Expr` via `sqlparser.Walk`, collecting every `*sqlparser.ColName` referenced in the `WHERE` clause, recovering the original case via `recoverFieldName` and ignoring identifiers that are not real fields of the source type (e.g. the `id` pseudo-column used by record-by-id lookup)
   - update: ACL check block to pass the union of projection fields and `WHERE` fields to `apppart.IsOperationAllowed`, so that any field denied by `SELECT` ACL causes a `403 Forbidden`
   - update: behavior so that when the projection is `*` (`f.acceptAll`), the ACL check still runs against the `WHERE` field set even if no explicit projection fields were collected
+  - update: `collectWhereFields` strips any column qualifier (e.g. `tbl.fld`) before the schema/ACL lookup, since VSQL is single-table and schema field names are unqualified — preventing qualified column references from silently bypassing the ACL set

--- a/uspecs/changes/archive/2605/2605151348-sql-acl-check-where-fields/change.md
+++ b/uspecs/changes/archive/2605/2605151348-sql-acl-check-where-fields/change.md
@@ -1,0 +1,39 @@
+---
+registered_at: 2026-05-15T13:25:19Z
+change_id: 2605151325-sql-acl-check-where-fields
+baseline: e14db6996bb6c70f80693907672d39e984332873
+issue_url: https://untill.atlassian.net/browse/AIR-3289
+archived_at: 2026-05-15T13:48:34Z
+---
+
+# Change request: Enforce SELECT ACL on fields in VSQL WHERE clause
+
+## Why
+
+VSQL SELECT queries currently authorize only the fields that appear in the result projection, ignoring fields referenced in the `WHERE` clause. With grants such as `GRANT SELECT(fld1)` and `REVOKE SELECT(fld2)`, a query like `SELECT fld1 FROM t WHERE fld2 = 123` succeeds and implicitly leaks the value of `fld2`, which is a security vulnerability.
+
+## What
+
+Authorize every field referenced in a VSQL SELECT statement, including fields used inside the `WHERE` clause:
+
+- A SELECT request whose `WHERE` clause references any field for which `SELECT` is not allowed is rejected with `403 Forbidden`
+- Authorization covers fields used in result projection and in the `WHERE` clause uniformly
+
+## Functional design
+
+- [x] create: [apps/vsql-acl.feature](../../../../specs/prod/apps/vsql-acl.feature)
+  - Feature specification with scenarios for ACL enforcement on VSQL SELECT, covering fields in the result projection and in the `WHERE` clause, including the `403 Forbidden` response when any referenced field has `SELECT` denied
+
+## Construction
+
+- [x] update: [sys/it/impl_sqlquery_test.go](../../../../../pkg/sys/it/impl_sqlquery_test.go)
+  - add: subtest verifying SELECT with allowed projection but denied field in `WHERE` returns `403 Forbidden`
+  - add: subtest verifying SELECT with denied field in `WHERE` combined via `AND` and via `OR` returns `403 Forbidden`
+  - add: subtest verifying SELECT with denied field in nested `WHERE` expression returns `403 Forbidden`
+  - add: subtest verifying SELECT succeeds when every projected and `WHERE`-referenced field is allowed
+  - dropped (out of scope for this entrypoint): view subtest — VSQL view reading only supports key-field filters in `WHERE`, and the existing test schema grants every key field of `app1pkg.DailyIdx` to `LimitedAccessRole`; the same security guarantee for views is covered by the unified projection+`WHERE` ACL union in `sys/sqlquery/impl.go`
+
+- [x] update: [sys/sqlquery/impl.go](../../../../../pkg/sys/sqlquery/impl.go)
+  - add: `collectWhereFields` helper that walks a `sqlparser.Expr` and collects every `*sqlparser.ColName` field name referenced in the `WHERE` clause, recovering the original case via `recoverFieldName` and ignoring identifiers that are not real fields of the source type (e.g. the `id` pseudo-column used by record-by-id lookup)
+  - update: ACL check block to pass the union of projection fields and `WHERE` fields to `apppart.IsOperationAllowed`, so that any field denied by `SELECT` ACL causes a `403 Forbidden`
+  - update: behavior so that when the projection is `*` (`f.acceptAll`), the ACL check still runs against the `WHERE` field set even if no explicit projection fields were collected

--- a/uspecs/specs/prod/apps/vsql-acl.feature
+++ b/uspecs/specs/prod/apps/vsql-acl.feature
@@ -29,6 +29,22 @@ Feature: VSQL SELECT ACL on projected and WHERE fields
       When VADeveloper executes "select Id from air.Orders where (Total > 0 and (CustomerId = 123 or Id = 1))"
       Then response status is "403 Forbidden"
 
+    Scenario: Denied field on the left of IN
+      When VADeveloper executes "select Id from air.Orders where CustomerId in (1, 2)"
+      Then response status is "403 Forbidden"
+
+    Scenario: Denied field inside IN value tuple
+      When VADeveloper executes "select Id from air.Orders where Total in (CustomerId, 2)"
+      Then response status is "403 Forbidden"
+
+    Scenario: Denied field on the left of NOT IN
+      When VADeveloper executes "select Id from air.Orders where CustomerId not in (1, 2)"
+      Then response status is "403 Forbidden"
+
+    Scenario: Denied field qualified by source table name
+      When VADeveloper executes "select Id from air.Orders where Orders.CustomerId = 123"
+      Then response status is "403 Forbidden"
+
     Scenario: Denied field in projection
       When VADeveloper executes "select CustomerId from air.Orders where Id = 1"
       Then response status is "403 Forbidden"

--- a/uspecs/specs/prod/apps/vsql-acl.feature
+++ b/uspecs/specs/prod/apps/vsql-acl.feature
@@ -1,0 +1,57 @@
+Feature: VSQL SELECT ACL on projected and WHERE fields
+
+  ACL is enforced on every field referenced by a VSQL SELECT statement,
+  including fields used inside the WHERE clause. A field for which SELECT
+  is not allowed must not be readable directly nor implicitly via a filter.
+
+  Background:
+    Given table "air.Orders" with fields "Id", "Total", "CustomerId"
+    And role "Reader"
+    And grant "GRANT SELECT(Id, Total) ON TABLE air.Orders TO Reader"
+    And revoke "REVOKE SELECT(CustomerId) ON TABLE air.Orders FROM Reader"
+    And VADeveloper is authenticated with role "Reader"
+
+  Rule: SELECT is denied when any referenced field has SELECT denied
+
+    Scenario: Denied field in WHERE with allowed projection
+      When VADeveloper executes "select Id from air.Orders where CustomerId = 123"
+      Then response status is "403 Forbidden"
+
+    Scenario: Denied field in WHERE combined with allowed field via AND
+      When VADeveloper executes "select Id from air.Orders where Total > 0 and CustomerId = 123"
+      Then response status is "403 Forbidden"
+
+    Scenario: Denied field in WHERE combined with allowed field via OR
+      When VADeveloper executes "select Id from air.Orders where Total > 0 or CustomerId = 123"
+      Then response status is "403 Forbidden"
+
+    Scenario: Denied field in nested WHERE expression
+      When VADeveloper executes "select Id from air.Orders where (Total > 0 and (CustomerId = 123 or Id = 1))"
+      Then response status is "403 Forbidden"
+
+    Scenario: Denied field in projection
+      When VADeveloper executes "select CustomerId from air.Orders where Id = 1"
+      Then response status is "403 Forbidden"
+
+    Scenario: Star projection with any denied field on the table
+      When VADeveloper executes "select * from air.Orders where Id = 1"
+      Then response status is "403 Forbidden"
+
+  Rule: SELECT is allowed when every referenced field has SELECT allowed
+
+    Scenario: Allowed projection and allowed WHERE
+      When VADeveloper executes "select Id, Total from air.Orders where Total > 0 and Id = 1"
+      Then matching records are returned
+
+    Scenario: Allowed projection without WHERE
+      When VADeveloper executes "select Id, Total from air.Orders"
+      Then matching records are returned
+
+  Rule: ACL on WHERE fields applies to views
+
+    Scenario: Denied view key field in WHERE
+      Given view "air.OrdersByCustomer" with key fields "Year", "CustomerId"
+      And grant "GRANT SELECT(Year) ON VIEW air.OrdersByCustomer TO Reader"
+      And revoke "REVOKE SELECT(CustomerId) ON VIEW air.OrdersByCustomer FROM Reader"
+      When VADeveloper executes "select Year from air.OrdersByCustomer where Year = 2026 and CustomerId = 123"
+      Then response status is "403 Forbidden"


### PR DESCRIPTION
```yaml
registered_at: 2026-05-15T13:25:19Z
change_id: 2605151325-sql-acl-check-where-fields
baseline: e14db6996bb6c70f80693907672d39e984332873
issue_url: https://untill.atlassian.net/browse/AIR-3289
archived_at: 2026-05-15T13:48:34Z
```
## Why

VSQL SELECT queries currently authorize only the fields that appear in the result projection, ignoring fields referenced in the `WHERE` clause. With grants such as `GRANT SELECT(fld1)` and `REVOKE SELECT(fld2)`, a query like `SELECT fld1 FROM t WHERE fld2 = 123` succeeds and implicitly leaks the value of `fld2`, which is a security vulnerability.

## What

Authorize every field referenced in a VSQL SELECT statement, including fields used inside the `WHERE` clause:

- A SELECT request whose `WHERE` clause references any field for which `SELECT` is not allowed is rejected with `403 Forbidden`
- Authorization covers fields used in result projection and in the `WHERE` clause uniformly

