### PR TITLE
[AIR-3953] VIT: get rid of confusing unexported results of exported optional funcs

### DIFF
--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -51,7 +51,7 @@ import (
 // caches schemas for apps that are not test apps (i.e., not test1_app1, test1_app2, test2_app1, or test2_app2)
 var nonTestAppsSchemasCache = &implISchemasCache_nonTestApps{schemas: map[appdef.AppQName]*parser.AppSchemaAST{}}
 
-func NewVIT(t testing.TB, vitCfg *VITConfig, opts ...vitOptFunc) (vit *VIT) {
+func NewVIT(t testing.TB, vitCfg *VITConfig, opts ...IVITOpt) (vit *VIT) {
 	useCas := coreutils.IsCassandraStorage()
 	if !vitCfg.isShared {
 		vit = newVit(t, vitCfg, useCas, false)
@@ -69,7 +69,7 @@ func NewVIT(t testing.TB, vitCfg *VITConfig, opts ...vitOptFunc) (vit *VIT) {
 	}
 
 	for _, opt := range opts {
-		opt(vit)
+		opt.applyVITOpt(vit)
 	}
 
 	vit.emailCaptor.checkEmpty(t)
@@ -298,10 +298,10 @@ func createSubjects(vit *VIT, token string, subjects []subject, appQName appdef.
 	}
 }
 
-func NewVITLocalCassandra(tb testing.TB, vitCfg *VITConfig, opts ...vitOptFunc) (vit *VIT) {
+func NewVITLocalCassandra(tb testing.TB, vitCfg *VITConfig, opts ...IVITOpt) (vit *VIT) {
 	vit = newVit(tb, vitCfg, true, false)
 	for _, opt := range opts {
-		opt(vit)
+		opt.applyVITOpt(vit)
 	}
 
 	return vit

--- a/pkg/vit/types.go
+++ b/pkg/vit/types.go
@@ -58,10 +58,19 @@ type vitPreConfig struct {
 
 type VITConfigOptFunc func(*vitPreConfig)
 type AppOptFunc func(app *app, cfg *vvm.VVMConfig)
+type PostConstructFunc func(intf interface{})
+
+type IVITOpt interface{ applyVITOpt(vit *VIT) }
+type ISignInOpt interface{ applySignInOpt(opts *signInOpts) }
+type ISignUpOpt interface{ applySignUpOpt(opts *signUpOpts) }
+
 type vitOptFunc func(vit *VIT)
 type signInOptFunc func(opts *signInOpts)
 type signUpOptFunc func(opts *signUpOpts)
-type PostConstructFunc func(intf interface{})
+
+func (f vitOptFunc) applyVITOpt(vit *VIT)            { f(vit) }
+func (f signInOptFunc) applySignInOpt(o *signInOpts) { f(o) }
+func (f signUpOptFunc) applySignUpOpt(o *signUpOpts) { f(o) }
 
 type Login struct {
 	Name, Pwd         string

--- a/pkg/vit/types.go
+++ b/pkg/vit/types.go
@@ -64,11 +64,9 @@ type IVITOpt interface{ applyVITOpt(vit *VIT) }
 type ISignInOpt interface{ applySignInOpt(opts *signInOpts) }
 type ISignUpOpt interface{ applySignUpOpt(opts *signUpOpts) }
 
-type vitOptFunc func(vit *VIT)
 type signInOptFunc func(opts *signInOpts)
 type signUpOptFunc func(opts *signUpOpts)
 
-func (f vitOptFunc) applyVITOpt(vit *VIT)            { f(vit) }
 func (f signInOptFunc) applySignInOpt(o *signInOpts) { f(o) }
 func (f signUpOptFunc) applySignUpOpt(o *signUpOpts) { f(o) }
 

--- a/pkg/vit/utils.go
+++ b/pkg/vit/utils.go
@@ -286,12 +286,12 @@ func DoNotFailOnTimeout() ISignInOpt {
 	})
 }
 
-func (vit *VIT) SignIn(login Login, optFuncs ...ISignInOpt) (prn *Principal) {
+func (vit *VIT) SignIn(login Login, options ...ISignInOpt) (prn *Principal) {
 	vit.T.Helper()
 	opts := &signInOpts{
 		failOnTimeout: true,
 	}
-	for _, opt := range optFuncs {
+	for _, opt := range options {
 		opt.applySignInOpt(opts)
 	}
 	deadline := time.Now().Add(getWorkspaceInitAwaitTimeout())

--- a/pkg/vit/utils.go
+++ b/pkg/vit/utils.go
@@ -72,19 +72,19 @@ func (vit *VIT) signUp(login Login, opts ...httpu.ReqOptFunc) {
 	vit.Func(fmt.Sprintf("api/v2/apps/%s/%s/users", login.AppQName.Owner(), login.AppQName.Name()), string(bodyBytes), opts...)
 }
 
-func WithClusterID(clusterID istructs.ClusterID) signUpOptFunc {
-	return func(opts *signUpOpts) {
+func WithClusterID(clusterID istructs.ClusterID) ISignUpOpt {
+	return signUpOptFunc(func(opts *signUpOpts) {
 		opts.profileClusterID = clusterID
-	}
+	})
 }
 
-func WithReqOpt(reqOpt httpu.ReqOptFunc) signUpOptFunc {
-	return func(opts *signUpOpts) {
+func WithReqOpt(reqOpt httpu.ReqOptFunc) ISignUpOpt {
+	return signUpOptFunc(func(opts *signUpOpts) {
 		opts.reqOpts = append(opts.reqOpts, reqOpt)
-	}
+	})
 }
 
-func (vit *VIT) SignUp(loginName, pwd string, appQName appdef.AppQName, opts ...signUpOptFunc) Login {
+func (vit *VIT) SignUp(loginName, pwd string, appQName appdef.AppQName, opts ...ISignUpOpt) Login {
 	vit.T.Helper()
 	signUpOpts := getSignUpOpts(opts)
 	login := NewLogin(loginName, pwd, appQName, istructs.SubjectKind_User, signUpOpts.profileClusterID)
@@ -92,17 +92,17 @@ func (vit *VIT) SignUp(loginName, pwd string, appQName appdef.AppQName, opts ...
 	return login
 }
 
-func getSignUpOpts(opts []signUpOptFunc) *signUpOpts {
+func getSignUpOpts(opts []ISignUpOpt) *signUpOpts {
 	res := &signUpOpts{
 		profileClusterID: istructs.CurrentClusterID(),
 	}
 	for _, opt := range opts {
-		opt(res)
+		opt.applySignUpOpt(res)
 	}
 	return res
 }
 
-func (vit *VIT) SignUpDevice(appQName appdef.AppQName, opts ...signUpOptFunc) Login {
+func (vit *VIT) SignUpDevice(appQName appdef.AppQName, opts ...ISignUpOpt) Login {
 	vit.T.Helper()
 	signUpOpts := getSignUpOpts(opts)
 	resp := vit.Func(fmt.Sprintf("api/v2/apps/%s/%s/devices", appQName.Owner(), appQName.Name()), "", signUpOpts.reqOpts...)
@@ -280,19 +280,19 @@ func (vit *VIT) WaitForChildWorkspace(parentWS *AppWorkspace, wsName string, opt
 	})
 }
 
-func DoNotFailOnTimeout() signInOptFunc {
-	return func(opts *signInOpts) {
+func DoNotFailOnTimeout() ISignInOpt {
+	return signInOptFunc(func(opts *signInOpts) {
 		opts.failOnTimeout = false
-	}
+	})
 }
 
-func (vit *VIT) SignIn(login Login, optFuncs ...signInOptFunc) (prn *Principal) {
+func (vit *VIT) SignIn(login Login, optFuncs ...ISignInOpt) (prn *Principal) {
 	vit.T.Helper()
 	opts := &signInOpts{
 		failOnTimeout: true,
 	}
 	for _, opt := range optFuncs {
-		opt(opts)
+		opt.applySignInOpt(opts)
 	}
 	deadline := time.Now().Add(getWorkspaceInitAwaitTimeout())
 	for time.Now().Before(deadline) {

--- a/uspecs/changes/archive/2605/2605171258-vit-seal-option-types/change.md
+++ b/uspecs/changes/archive/2605/2605171258-vit-seal-option-types/change.md
@@ -1,0 +1,37 @@
+---
+registered_at: 2026-05-17T12:34:13Z
+change_id: 2605171234-vit-seal-option-types
+baseline: 59247f436a281fd98e8d1cde3265b2fda7063bc9
+issue_url: https://untill.atlassian.net/browse/AIR-3953
+archived_at: 2026-05-17T12:58:39Z
+---
+
+# Change request: VIT — seal functional-option types to silence revive unexported-return
+
+## Why
+
+Exported option constructors in `pkg/vit` (e.g. `DoNotFailOnTimeout`, `WithClusterID`, `WithReqOpt`) return unexported function types such as `signInOptFunc` and `signUpOptFunc`. `revive`'s `unexported-return` rule flags every such function, producing persistent linter noise, and consumers in other packages cannot name the return type to store it in a variable. We do not want to suppress the warning (hides the smell) or to export the underlying `signInOpts` / `signUpOpts` structs (would leak internal fields and freeze them as public API).
+
+## What
+
+Adopt the canonical sealed functional-options pattern in `pkg/vit`:
+
+- Introduce an exported interface per option family (`ISignInOpt`, `ISignUpOpt`, `IVITOpt`) with a single unexported `apply` method
+- Keep the underlying option structs (`signInOpts`, `signUpOpts`) and the func types (`signInOptFunc`, `signUpOptFunc`, `vitOptFunc`) unexported; have the func types implement the sealed interfaces
+- Change exported option constructors to return the new interface types
+- Update the consuming methods/constructors (`(*VIT).SignIn`, `(*VIT).SignUp`, `(*VIT).SignUpDevice`, `NewVIT`, `NewVITLocalCassandra`) to accept the interfaces as variadic arguments
+
+## Construction
+
+- [x] update: [vit/types.go](../../../../../pkg/vit/types.go)
+  - add: exported sealed interfaces `ISignInOpt`, `ISignUpOpt`, `IVITOpt`, each with a single unexported `apply…` method
+  - update: keep `signInOptFunc`, `signUpOptFunc`, `vitOptFunc` unexported; add `apply…` methods so they implement the corresponding sealed interface
+
+- [x] update: [vit/utils.go](../../../../../pkg/vit/utils.go)
+  - update: `DoNotFailOnTimeout` to return `ISignInOpt`
+  - update: `WithClusterID`, `WithReqOpt` to return `ISignUpOpt`
+  - update: `(*VIT).SignIn` to accept `...ISignInOpt` and invoke the sealed apply method
+  - update: `(*VIT).SignUp`, `(*VIT).SignUpDevice`, `getSignUpOpts` to accept `...ISignUpOpt` and invoke the sealed apply method
+
+- [x] update: [vit/impl.go](../../../../../pkg/vit/impl.go)
+  - update: `NewVIT`, `NewVITLocalCassandra` to accept `...IVITOpt` and invoke the sealed apply method

--- a/uspecs/changes/archive/2605/2605171258-vit-seal-option-types/change.md
+++ b/uspecs/changes/archive/2605/2605171258-vit-seal-option-types/change.md
@@ -17,7 +17,7 @@ Exported option constructors in `pkg/vit` (e.g. `DoNotFailOnTimeout`, `WithClust
 Adopt the canonical sealed functional-options pattern in `pkg/vit`:
 
 - Introduce an exported interface per option family (`ISignInOpt`, `ISignUpOpt`, `IVITOpt`) with a single unexported `apply` method
-- Keep the underlying option structs (`signInOpts`, `signUpOpts`) and the func types (`signInOptFunc`, `signUpOptFunc`, `vitOptFunc`) unexported; have the func types implement the sealed interfaces
+- Keep the underlying option structs (`signInOpts`, `signUpOpts`) and the func carriers (`signInOptFunc`, `signUpOptFunc`) unexported; have the func types implement the sealed interfaces
 - Change exported option constructors to return the new interface types
 - Update the consuming methods/constructors (`(*VIT).SignIn`, `(*VIT).SignUp`, `(*VIT).SignUpDevice`, `NewVIT`, `NewVITLocalCassandra`) to accept the interfaces as variadic arguments
 
@@ -25,7 +25,8 @@ Adopt the canonical sealed functional-options pattern in `pkg/vit`:
 
 - [x] update: [vit/types.go](../../../../../pkg/vit/types.go)
   - add: exported sealed interfaces `ISignInOpt`, `ISignUpOpt`, `IVITOpt`, each with a single unexported `apply…` method
-  - update: keep `signInOptFunc`, `signUpOptFunc`, `vitOptFunc` unexported; add `apply…` methods so they implement the corresponding sealed interface
+  - update: keep `signInOptFunc`, `signUpOptFunc` unexported; add `apply…` methods so they implement the corresponding sealed interface
+  - remove: unused `vitOptFunc` func type (no constructor produces it; future `IVITOpt` carriers can reintroduce a typed func when needed)
 
 - [x] update: [vit/utils.go](../../../../../pkg/vit/utils.go)
   - update: `DoNotFailOnTimeout` to return `ISignInOpt`


### PR DESCRIPTION
```yaml
registered_at: 2026-05-17T12:34:13Z
change_id: 2605171234-vit-seal-option-types
baseline: 59247f436a281fd98e8d1cde3265b2fda7063bc9
issue_url: https://untill.atlassian.net/browse/AIR-3953
archived_at: 2026-05-17T12:58:39Z
```
## Why

Exported option constructors in `pkg/vit` (e.g. `DoNotFailOnTimeout`, `WithClusterID`, `WithReqOpt`) return unexported function types such as `signInOptFunc` and `signUpOptFunc`. `revive`'s `unexported-return` rule flags every such function, producing persistent linter noise, and consumers in other packages cannot name the return type to store it in a variable. We do not want to suppress the warning (hides the smell) or to export the underlying `signInOpts` / `signUpOpts` structs (would leak internal fields and freeze them as public API).

## What

Adopt the canonical sealed functional-options pattern in `pkg/vit`:

- Introduce an exported interface per option family (`ISignInOpt`, `ISignUpOpt`, `IVITOpt`) with a single unexported `apply` method
- Keep the underlying option structs (`signInOpts`, `signUpOpts`) and the func types (`signInOptFunc`, `signUpOptFunc`, `vitOptFunc`) unexported; have the func types implement the sealed interfaces
- Change exported option constructors to return the new interface types
- Update the consuming methods/constructors (`(*VIT).SignIn`, `(*VIT).SignUp`, `(*VIT).SignUpDevice`, `NewVIT`, `NewVITLocalCassandra`) to accept the interfaces as variadic arguments

