### PR TITLE
fix(istructsmem): Clarify error when verification token for a verified field is invalid [AIR-3973]

### DIFF
--- a/pkg/istructsmem/types.go
+++ b/pkg/istructsmem/types.go
@@ -503,7 +503,7 @@ func (row *rowType) verifyToken(fld appdef.IField, token string) (value any, err
 	payload := payloads.VerifiedValuePayload{}
 	tokens := row.appCfg.app.AppTokens()
 	if _, err = tokens.ValidateToken(token, &payload); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("verification token for %s.%s is invalid: %w", row.QName(), fld.Name(), err)
 	}
 
 	// if payload.AppQName != row.appCfg.Name { … } // redundant check, must be check by IAppToken.ValidateToken()

--- a/pkg/istructsmem/validation_test.go
+++ b/pkg/istructsmem/validation_test.go
@@ -858,6 +858,16 @@ func Test_VerifiedFields(t *testing.T) {
 			require.ErrorIs(err, itokens.ErrInvalidToken)
 		})
 
+		t.Run("error if malformed token clarifies entity and field", func(t *testing.T) {
+
+			row := makeObject(cfg, objName, nil)
+			row.PutInt32("int32", 1)
+			row.PutString("email", "this-is-not-a-jwt")
+
+			_, err := row.Build()
+			require.Error(err, require.Is(itokens.ErrInvalidToken), require.HasAll(objName, "email", "verification token"))
+		})
+
 		t.Run("error if unexpected token kind", func(t *testing.T) {
 			ukToken := func() string {
 				p := payloads.VerifiedValuePayload{

--- a/uspecs/changes/archive/2605/2605191454-clarify-verified-field-token-error/change.md
+++ b/uspecs/changes/archive/2605/2605191454-clarify-verified-field-token-error/change.md
@@ -1,0 +1,35 @@
+---
+registered_at: 2026-05-19T14:42:39Z
+change_id: 2605191442-clarify-verified-field-token-error
+type: fix
+scope: istructsmem
+baseline: e50729e8f343aceebe4189c5848147088e711df6
+issue_url: https://untill.atlassian.net/browse/AIR-3973
+archived_at: 2026-05-19T14:54:42Z
+---
+
+# Change request: Clarify error when verification token for a verified field is invalid
+
+## Why
+
+When a CUD on a verified field is submitted with an invalid verification-value token (e.g. `update untill.airs-bp.%d.air.UserProfile.%d set EMail='<bad-token>'`), the response surfaces a bare JWT error such as `token is malformed: token contains an invalid number of segments. invalid token`. The message is indistinguishable from a failure of the request's principal/authorization token, so the caller debugs the wrong token and the verified-field flow looks broken.
+
+## What
+
+Make every failure of a verified-field value-token explicit about its origin so the caller can immediately tell it apart from a principal-token failure:
+
+- Wrap the underlying `IAppTokens.ValidateToken` error with the row's QName and the verified field's name (e.g. `verification token for field «<entity>.<field>» is invalid: <underlying error>`)
+- Wrong-payload errors raised after successful token parsing (verification kind mismatch, wrong entity, wrong field, value clarification failure) follow the same prefix so all verified-field token failures share one recognizable shape
+- Underlying error is preserved (wrapped with `%w`) so callers can still match the original sentinel
+
+## Construction
+
+- [x] update: [istructsmem/types.go](../../../../../pkg/istructsmem/types.go) — `verifyToken`
+  - update: wrap the `AppTokens().ValidateToken` error with the row's QName and the verified field's name (e.g. `verification token for %v.%s is invalid: <underlying>`) using `%w` so the original sentinel stays matchable
+  - keep: the post-parse errors (`ErrInvalidVerificationKind`, wrong-entity, wrong-field, `clarifyJSONValue` failure) already mention the row and field — verify their messages also clearly identify the verified-field token origin and align wording with the new prefix
+
+- [x] update: [istructsmem/validation_test.go](../../../../../pkg/istructsmem/validation_test.go)
+  - add: subtest in the verified-field block asserting that a malformed token (e.g. arbitrary non-JWT string) returns an error containing both the entity QName and the verified field name, and unwraps to the underlying token-parse error
+  - keep: existing `ErrInvalidVerificationKindError`, wrong-entity, and wrong-field subtests — adjust their expected-message assertions if the prefix wording changes
+
+- [x] Review


### PR DESCRIPTION
```yaml
registered_at: 2026-05-19T14:42:39Z
change_id: 2605191442-clarify-verified-field-token-error
type: fix
scope: istructsmem
baseline: e50729e8f343aceebe4189c5848147088e711df6
issue_url: https://untill.atlassian.net/browse/AIR-3973
archived_at: 2026-05-19T14:54:42Z
```
## Why

When a CUD on a verified field is submitted with an invalid verification-value token (e.g. `update untill.airs-bp.%d.air.UserProfile.%d set EMail='<bad-token>'`), the response surfaces a bare JWT error such as `token is malformed: token contains an invalid number of segments. invalid token`. The message is indistinguishable from a failure of the request's principal/authorization token, so the caller debugs the wrong token and the verified-field flow looks broken.

## What

Make every failure of a verified-field value-token explicit about its origin so the caller can immediately tell it apart from a principal-token failure:

- Wrap the underlying `IAppTokens.ValidateToken` error with the row's QName and the verified field's name (e.g. `verification token for field «<entity>.<field>» is invalid: <underlying error>`)
- Wrong-payload errors raised after successful token parsing (verification kind mismatch, wrong entity, wrong field, value clarification failure) follow the same prefix so all verified-field token failures share one recognizable shape
- Underlying error is preserved (wrapped with `%w`) so callers can still match the original sentinel

