### PR TITLE
refactor(actualizers): Refactor async actualizer context usage [AIR-3972]

### DIFF
--- a/pkg/processors/actualizers/async.go
+++ b/pkg/processors/actualizers/async.go
@@ -251,10 +251,14 @@ func (a *asyncActualizer) keepReading(ctx context.Context) error {
 			}
 		}
 	})
-	if ctx.Err() != nil {
-		return nil
+	// returns n10nWatchCtxCause of cancellation injected via cancelN10NWatchChannelCtx;
+	// suppresses parent-propagated cancellation so graceful shutdown doesn't
+	// trigger retrier.OnError logging
+	n10nWatchCtxCause := context.Cause(a.n10nWatchChannelCtx)
+	if !errors.Is(n10nWatchCtxCause, context.Cause(ctx)) {
+		return n10nWatchCtxCause
 	}
-	return context.Cause(a.n10nWatchChannelCtx)
+	return nil
 }
 
 func (a *asyncActualizer) handleEvent(ctx context.Context, pLogOffset istructs.Offset, event istructs.IPLogEvent) (err error) {

--- a/pkg/processors/actualizers/async.go
+++ b/pkg/processors/actualizers/async.go
@@ -56,17 +56,18 @@ type (
 
 // 1 asyncActualizer per each projector per each partition
 type asyncActualizer struct {
-	conf           AsyncActualizerConf
-	projectorQName appdef.QName
-	pipeline       pipeline.IAsyncPipeline
-	offset         istructs.Offset
-	name           string
-	readCtx        *asyncActualizerContextState
-	projErrState   int32 // 0 - no error, 1 - error
-	plogBatch            // [50]plogEvent
-	appParts       appparts.IAppPartitions
-	retrierCfg     retrier.Config
-	channelCleanup func()
+	conf                      AsyncActualizerConf
+	projectorQName            appdef.QName
+	pipeline                  pipeline.IAsyncPipeline
+	offset                    istructs.Offset
+	name                      string
+	n10nWatchChannelCtx       context.Context
+	cancelN10NWatchChannelCtx context.CancelCauseFunc
+	projErrState              int32 // 0 - no error, 1 - error
+	plogBatch                       // [50]plogEvent
+	appParts                  appparts.IAppPartitions
+	retrierCfg                retrier.Config
+	channelCleanup            func()
 }
 
 func (a *asyncActualizer) Prepare(vvmCtx context.Context) {
@@ -93,7 +94,7 @@ func (a *asyncActualizer) Prepare(vvmCtx context.Context) {
 				return true, nil
 			}
 		}
-		logger.ErrorCtx(a.readCtx.vvmCtx, a.name, opErr)
+		logger.ErrorCtx(vvmCtx, a.name, opErr)
 		return true, nil
 	}
 }
@@ -124,17 +125,10 @@ func (a *asyncActualizer) Run(vvmCtx context.Context) {
 	}
 }
 
-func (a *asyncActualizer) cancelChannel(e error) {
-	a.readCtx.cancelWithError(e)
-	a.conf.Broker.WatchChannel(a.readCtx.vvmCtx, a.conf.channel, func(projection in10n.ProjectionKey, offset istructs.Offset) {})
-}
-
 func (a *asyncActualizer) init(vvmCtx context.Context) (err error) {
 	a.plogBatch = make(plogBatch, 0, plogReadBatchSize)
 
-	a.readCtx = &asyncActualizerContextState{}
-
-	a.readCtx.vvmCtx, a.readCtx.cancel = context.WithCancel(vvmCtx)
+	a.n10nWatchChannelCtx, a.cancelN10NWatchChannelCtx = context.WithCancelCause(vvmCtx)
 
 	appDef, err := a.appParts.AppDef(a.conf.AppQName)
 	if err != nil {
@@ -183,7 +177,7 @@ func (a *asyncActualizer) init(vvmCtx context.Context) (err error) {
 
 	a.name = fmt.Sprintf("%v [%d]", p.name, a.conf.PartitionID)
 
-	err = a.readOffset(p.name)
+	err = a.readOffset(vvmCtx, p.name)
 	if err != nil {
 		return err
 	}
@@ -214,11 +208,11 @@ func (a *asyncActualizer) init(vvmCtx context.Context) (err error) {
 	projectorOp := pipeline.WireAsyncOperator("Projector", p, a.conf.FlushInterval)
 
 	errHandler := &asyncErrorHandler{
-		readCtx:      a.readCtx,
-		projErrState: &a.projErrState,
-		metrics:      a.conf.Metrics,
-		vvmName:      a.conf.VvmName,
-		appQName:     a.conf.AppQName,
+		cancelN10NWatchChannelCtx: a.cancelN10NWatchChannelCtx,
+		projErrState:              &a.projErrState,
+		metrics:                   a.conf.Metrics,
+		vvmName:                   a.conf.VvmName,
+		appQName:                  a.conf.AppQName,
 	}
 	errorHandlerOp := pipeline.WireAsyncOperator("ErrorHandler", errHandler)
 
@@ -241,23 +235,26 @@ func (a *asyncActualizer) finit() {
 	if a.channelCleanup != nil {
 		a.channelCleanup()
 	}
+	if a.cancelN10NWatchChannelCtx != nil {
+		a.cancelN10NWatchChannelCtx(nil)
+	}
 }
 
-func (a *asyncActualizer) keepReading(ctx context.Context) (err error) {
-	err = a.readPlogToTheEnd(ctx)
-	if err != nil {
-		a.cancelChannel(err)
-		return
+func (a *asyncActualizer) keepReading(ctx context.Context) error {
+	if err := a.readPlogToTheEnd(ctx); err != nil {
+		return err
 	}
-	a.conf.Broker.WatchChannel(a.readCtx.vvmCtx, a.conf.channel, func(projection in10n.ProjectionKey, offset istructs.Offset) {
+	a.conf.Broker.WatchChannel(a.n10nWatchChannelCtx, a.conf.channel, func(projection in10n.ProjectionKey, offset istructs.Offset) {
 		if a.offset < offset {
-			err = a.readPlogToOffset(a.readCtx.vvmCtx, offset)
-			if err != nil {
-				a.readCtx.cancelWithError(err)
+			if err := a.readPlogToOffset(a.n10nWatchChannelCtx, offset); err != nil {
+				a.cancelN10NWatchChannelCtx(err)
 			}
 		}
 	})
-	return a.readCtx.error()
+	if ctx.Err() != nil {
+		return nil
+	}
+	return context.Cause(a.n10nWatchChannelCtx)
 }
 
 func (a *asyncActualizer) handleEvent(ctx context.Context, pLogOffset istructs.Offset, event istructs.IPLogEvent) (err error) {
@@ -278,7 +275,7 @@ func (a *asyncActualizer) handleEvent(ctx context.Context, pLogOffset istructs.O
 }
 
 func (a *asyncActualizer) readPlogByBatches(ctx context.Context, readBatch readPLogBatch) error {
-	for a.readCtx.vvmCtx.Err() == nil {
+	for ctx.Err() == nil {
 		if err := readBatch(&a.plogBatch); err != nil {
 			return err
 		}
@@ -289,7 +286,7 @@ func (a *asyncActualizer) readPlogByBatches(ctx context.Context, readBatch readP
 			if err := a.handleEvent(ctx, e.Offset, e.IPLogEvent); err != nil {
 				return err
 			}
-			if a.readCtx.vvmCtx.Err() != nil {
+			if ctx.Err() != nil {
 				return nil // canceled
 			}
 		}
@@ -305,14 +302,14 @@ func (a *asyncActualizer) readPlogToTheEnd(ctx context.Context) error {
 	return a.readPlogByBatches(ctx, func(batch *plogBatch) (err error) {
 		*batch = (*batch)[:0]
 
-		ap, err := a.borrowAppPart(a.readCtx.vvmCtx)
+		ap, err := a.borrowAppPart(ctx)
 		if err != nil {
 			return err
 		}
 
 		defer ap.Release()
 
-		err = ap.AppStructs().Events().ReadPLog(a.readCtx.vvmCtx, a.conf.PartitionID, a.offset+1, istructs.ReadToTheEnd,
+		err = ap.AppStructs().Events().ReadPLog(ctx, a.conf.PartitionID, a.offset+1, istructs.ReadToTheEnd,
 			func(ofs istructs.Offset, event istructs.IPLogEvent) error {
 				if *batch = append(*batch, plogEvent{ofs, event}); len(*batch) == cap(*batch) {
 					return errBatchFull
@@ -340,7 +337,7 @@ func (a *asyncActualizer) readPlogToOffset(ctx context.Context, tillOffset istru
 
 		plog := ap.AppStructs().Events()
 		for readOffset := a.offset + 1; readOffset <= tillOffset; readOffset++ {
-			if err = plog.ReadPLog(a.readCtx.vvmCtx, a.conf.PartitionID, readOffset, 1,
+			if err = plog.ReadPLog(ctx, a.conf.PartitionID, readOffset, 1,
 				func(ofs istructs.Offset, event istructs.IPLogEvent) error {
 					if *batch = append(*batch, plogEvent{ofs, event}); len(*batch) == cap(*batch) {
 						return errBatchFull
@@ -358,8 +355,8 @@ func (a *asyncActualizer) readPlogToOffset(ctx context.Context, tillOffset istru
 	})
 }
 
-func (a *asyncActualizer) readOffset(projectorName appdef.QName) error {
-	ap, err := a.borrowAppPart(a.readCtx.vvmCtx)
+func (a *asyncActualizer) readOffset(ctx context.Context, projectorName appdef.QName) error {
+	ap, err := a.borrowAppPart(ctx)
 	if err != nil {
 		return err
 	}
@@ -582,11 +579,11 @@ func (p *asyncProjector) flush() (err error) {
 
 type asyncErrorHandler struct {
 	pipeline.AsyncNOOP
-	readCtx      *asyncActualizerContextState
-	metrics      imetrics.IMetrics
-	vvmName      string
-	appQName     appdef.AppQName
-	projErrState *int32
+	cancelN10NWatchChannelCtx context.CancelCauseFunc
+	metrics                   imetrics.IMetrics
+	vvmName                   string
+	appQName                  appdef.AppQName
+	projErrState              *int32
 }
 
 func (h *asyncErrorHandler) OnError(_ context.Context, err error) {
@@ -595,7 +592,7 @@ func (h *asyncErrorHandler) OnError(_ context.Context, err error) {
 			h.metrics.IncreaseApp(ProjectorsInError, h.vvmName, h.appQName, 1)
 		}
 	}
-	h.readCtx.cancelWithError(err)
+	h.cancelN10NWatchChannelCtx(err)
 }
 
 func ActualizerOffset(appStructs istructs.IAppStructs, partition istructs.PartitionID, projectorName appdef.QName) (offset istructs.Offset, err error) {

--- a/pkg/processors/actualizers/async_test.go
+++ b/pkg/processors/actualizers/async_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1255,6 +1256,103 @@ func (f *flakyAppParts) AppDef(name appdef.AppQName) (appdef.IAppDef, error) {
 func (f *flakyAppParts) WaitForBorrow(ctx context.Context, app appdef.AppQName, partID istructs.PartitionID, kind appparts.ProcessorKind) (appparts.IAppPartition, error) {
 	if f.waitForBorrowCalls.Add(1) == 2 {
 		return nil, errors.New("flaky WaitForBorrow failure")
+	}
+	return f.IAppPartitions.WaitForBorrow(ctx, app, partID, kind)
+}
+
+// Verifies that when WatchChannel's notify callback triggers a readPlogToOffset that fails,
+// the error is recorded as the cause of n10nWatchChannelCtx and surfaced verbatim by keepReading.
+func Test_AsynchronousActualizer_KeepReadingPropagatesReadPLogErrorAsCause(t *testing.T) {
+	require := require.New(t)
+	appName, partitionNr := istructs.AppQName_test1_app1, istructs.PartitionID(1)
+
+	broker, bCleanup := in10nmem.NewN10nBroker(in10n.Quotas{
+		Channels: 10, ChannelsPerSubject: 10, Subscriptions: 10, SubscriptionsPerSubject: 10,
+	}, timeu.NewITime())
+	defer bCleanup()
+
+	actCfg := &BasicAsyncActualizerConfig{Broker: broker}
+	appParts, _, stop := deployTestApp(appName, 1, false, testWorkspace, testWorkspaceDescriptor,
+		func(wsb appdef.IWorkspaceBuilder) {
+			ProvideViewDef(wsb, incProjectionView, buildProjectionView)
+			wsb.AddCommand(testQName)
+			wsb.AddProjector(incrementorName).Events().Add(
+				[]appdef.OperationKind{appdef.OperationKind_Execute}, filter.QNames(testQName))
+		},
+		func(cfg *istructsmem.AppConfigType) {
+			cfg.Resources.Add(istructsmem.NewCommandFunction(testQName, istructsmem.NullCommandExec))
+			cfg.AddAsyncProjectors(testIncrementor)
+		},
+		actCfg)
+	defer stop()
+	appParts.DeployAppPartitions(appName, []istructs.PartitionID{partitionNr})
+
+	injectedErr := errors.New("injected readPlogToOffset failure")
+	flaky := &ctxFailingAppParts{IAppPartitions: appParts, failErr: injectedErr}
+
+	act := &asyncActualizer{
+		projectorQName: incrementorName,
+		conf: AsyncActualizerConf{
+			BasicAsyncActualizerConfig: *actCfg, AppQName: appName, PartitionID: partitionNr,
+		},
+		appParts:   flaky,
+		retrierCfg: retrier.NewConfig(time.Millisecond, 5*time.Millisecond),
+	}
+	vvmCtx, vvmCancel := context.WithCancel(context.Background())
+	defer vvmCancel()
+
+	act.Prepare(vvmCtx)
+	require.NoError(act.init(vvmCtx))
+	defer act.finit()
+
+	flaky.setFailOnCtx(act.n10nWatchChannelCtx)
+
+	stopNotifier := make(chan struct{})
+	notifierDone := make(chan struct{})
+	go func() {
+		defer close(notifierDone)
+		ticker := time.NewTicker(5 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopNotifier:
+				return
+			case <-ticker.C:
+				broker.Update(in10n.ProjectionKey{
+					App: appName, Projection: PLogUpdatesQName, WS: istructs.WSID(partitionNr),
+				}, istructs.Offset(100))
+			}
+		}
+	}()
+
+	err := act.keepReading(vvmCtx)
+	close(stopNotifier)
+	<-notifierDone
+
+	require.ErrorIs(err, injectedErr)
+	require.Same(injectedErr, context.Cause(act.n10nWatchChannelCtx))
+	require.Same(err, context.Cause(act.n10nWatchChannelCtx))
+}
+
+type ctxFailingAppParts struct {
+	appparts.IAppPartitions
+	mu        sync.Mutex
+	failOnCtx context.Context
+	failErr   error
+}
+
+func (f *ctxFailingAppParts) setFailOnCtx(ctx context.Context) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failOnCtx = ctx
+}
+
+func (f *ctxFailingAppParts) WaitForBorrow(ctx context.Context, app appdef.AppQName, partID istructs.PartitionID, kind appparts.ProcessorKind) (appparts.IAppPartition, error) {
+	f.mu.Lock()
+	failOnCtx := f.failOnCtx
+	f.mu.Unlock()
+	if failOnCtx != nil && ctx == failOnCtx {
+		return nil, f.failErr
 	}
 	return f.IAppPartitions.WaitForBorrow(ctx, app, partID, kind)
 }

--- a/pkg/processors/actualizers/types.go
+++ b/pkg/processors/actualizers/types.go
@@ -7,33 +7,9 @@
 package actualizers
 
 import (
-	"context"
-	"sync"
-
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/istructs"
 )
-
-type asyncActualizerContextState struct {
-	lock   sync.Mutex
-	err    error
-	vvmCtx context.Context
-	cancel func()
-}
-
-func (s *asyncActualizerContextState) cancelWithError(err error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	s.err = err
-	s.cancel()
-}
-
-// @ConcurrentAccess
-func (s *asyncActualizerContextState) error() error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	return s.err
-}
 
 // Returns is projector triggered by event
 func ProjectorEvent(prj appdef.IProjector, event istructs.IPLogEvent) (triggeredBy appdef.QName) {

--- a/uspecs/changes/2605191458-actualizer-context-refactor/change.md
+++ b/uspecs/changes/2605191458-actualizer-context-refactor/change.md
@@ -1,0 +1,44 @@
+---
+registered_at: 2026-05-19T14:58:25Z
+change_id: 2605191458-actualizer-context-refactor
+type: refactor
+scope: actualizers
+baseline: e50729e8f343aceebe4189c5848147088e711df6
+issue_url: https://untill.atlassian.net/browse/AIR-3972
+---
+
+# Change request: Refactor async actualizer context usage
+
+## Why
+
+`asyncActualizerContextState.vvmCtx` (a per-run cancellable context derived from the VVM context) is currently propagated into every place inside `asyncActualizer` that needs a `context.Context` — PLog reads, partition borrows, structured logging, pipeline error handling — while its only real responsibility is to be the cancel handle that breaks `IN10nBroker.WatchChannel`. The misleading field name and broad reuse obscure intent and tangle lifecycle: callers can't easily tell which paths need to abort with the run-scoped cancel and which should simply follow the surrounding `vvmCtx`/operation context.
+
+## What
+
+Narrow the surface so the actualizer only stores what is needed to break `WatchChannel` and remember the cancellation cause; let every other call site use the context already in scope. Use `context.WithCancelCause`/`context.Cause` instead of a hand-rolled struct with a mutex, and drop the vestigial `WatchChannel` invocation inside `cancelChannel` (no longer needed since AIR-1855 moved channel cleanup to `NewChannel`'s returned `channelCleanup`).
+
+- Delete the `asyncActualizerContextState` struct (lock + err + vvmCtx + cancel + `cancelWithError`/`error()` methods) — replaced by `context.WithCancelCause`
+- On `asyncActualizer`, store `n10nWatchChannelCtx context.Context` and its `cancelN10NWatchChannelCtx context.CancelCauseFunc` directly; on `asyncErrorHandler`, store only the `cancelN10NWatchChannelCtx context.CancelCauseFunc`
+- Replace every `a.readCtx.cancelWithError(err)` with `a.cancelN10NWatchChannelCtx(err)`; replace `a.readCtx.error()` with `context.Cause(a.n10nWatchChannelCtx)` (filtered when the parent ctx is the one that ended the loop)
+- Remove `cancelChannel(e)` entirely; the early `readPlogToTheEnd` failure path just returns the error and lets `finit`/`channelCleanup` tear down the n10n channel
+- Replace every other `a.readCtx.vvmCtx` reference with the in-scope `ctx`/`vvmCtx` (`readPlogByBatches` loop, `readPlogToTheEnd`/`readPlogToOffset`'s `borrowAppPart`/`ReadPLog`, `readOffset`, `Prepare`'s retrier `OnError` logger)
+- Ensure `finit` calls `cancelN10NWatchChannelCtx(nil)` so the per-run cause-context is released on every retrier iteration
+
+## Construction
+
+- [x] update: [actualizers/types.go](../../../pkg/processors/actualizers/types.go)
+  - remove: struct `asyncActualizerContextState` and its methods `cancelWithError`/`error()`
+  - remove: unused `context` and `sync` imports
+
+- [x] update: [actualizers/async.go](../../../pkg/processors/actualizers/async.go)
+  - replace on `asyncActualizer`: field `readCtx *asyncActualizerContextState` → `n10nWatchChannelCtx context.Context` + `cancelN10NWatchChannelCtx context.CancelCauseFunc`
+  - replace on `asyncErrorHandler`: field `readCtx *asyncActualizerContextState` → `cancelN10NWatchChannelCtx context.CancelCauseFunc`; update the `init` initializer accordingly
+  - `init(vvmCtx)`: `a.n10nWatchChannelCtx, a.cancelN10NWatchChannelCtx = context.WithCancelCause(vvmCtx)`; pass `vvmCtx` to `readOffset`
+  - `finit()`: append `if a.cancelN10NWatchChannelCtx != nil { a.cancelN10NWatchChannelCtx(nil) }` so the cause-context is released even when the WatchChannel path was never reached
+  - remove: method `cancelChannel(e error)` — the inner `WatchChannel` call is vestigial post-AIR-1855; channel cleanup is owned by `finit`/`channelCleanup`
+  - `keepReading(ctx)`: on `readPlogToTheEnd` failure return the error directly; in the WatchChannel callback call `a.cancelN10NWatchChannelCtx(err)`; after WatchChannel returns, return `nil` when `ctx.Err() != nil` (parent shutdown) else `context.Cause(a.n10nWatchChannelCtx)`
+  - `readPlogByBatches`/`readPlogToTheEnd`/`readPlogToOffset`/`readOffset`: replace every `a.readCtx.vvmCtx` with the in-scope `ctx`; change `readOffset` signature to `readOffset(ctx context.Context, projectorName appdef.QName)`
+  - `Prepare`'s `retrierCfg.OnError`: replace `logger.ErrorCtx(a.readCtx.vvmCtx, …)` with the `vvmCtx` captured from `Prepare`'s parameter
+  - `OnError`: replace `h.readCtx.cancelWithError(err)` with `h.cancelN10NWatchChannelCtx(err)`
+
+- [x] Review

--- a/uspecs/changes/2605191458-actualizer-context-refactor/change.md
+++ b/uspecs/changes/2605191458-actualizer-context-refactor/change.md
@@ -36,9 +36,14 @@ Narrow the surface so the actualizer only stores what is needed to break `WatchC
   - `init(vvmCtx)`: `a.n10nWatchChannelCtx, a.cancelN10NWatchChannelCtx = context.WithCancelCause(vvmCtx)`; pass `vvmCtx` to `readOffset`
   - `finit()`: append `if a.cancelN10NWatchChannelCtx != nil { a.cancelN10NWatchChannelCtx(nil) }` so the cause-context is released even when the WatchChannel path was never reached
   - remove: method `cancelChannel(e error)` — the inner `WatchChannel` call is vestigial post-AIR-1855; channel cleanup is owned by `finit`/`channelCleanup`
-  - `keepReading(ctx)`: on `readPlogToTheEnd` failure return the error directly; in the WatchChannel callback call `a.cancelN10NWatchChannelCtx(err)`; after WatchChannel returns, return `nil` when `ctx.Err() != nil` (parent shutdown) else `context.Cause(a.n10nWatchChannelCtx)`
+  - `keepReading(ctx)`: on `readPlogToTheEnd` failure return the error directly; in the WatchChannel callback call `a.cancelN10NWatchChannelCtx(err)`; after WatchChannel returns, compute `n10nWatchCtxCause := context.Cause(a.n10nWatchChannelCtx)` and return `n10nWatchCtxCause` only when `!errors.Is(n10nWatchCtxCause, context.Cause(ctx))` (otherwise return `nil`) so parent-propagated cancellation is suppressed and does not trigger retrier `OnError` logging
   - `readPlogByBatches`/`readPlogToTheEnd`/`readPlogToOffset`/`readOffset`: replace every `a.readCtx.vvmCtx` with the in-scope `ctx`; change `readOffset` signature to `readOffset(ctx context.Context, projectorName appdef.QName)`
   - `Prepare`'s `retrierCfg.OnError`: replace `logger.ErrorCtx(a.readCtx.vvmCtx, …)` with the `vvmCtx` captured from `Prepare`'s parameter
   - `OnError`: replace `h.readCtx.cancelWithError(err)` with `h.cancelN10NWatchChannelCtx(err)`
+
+- [x] update: [actualizers/async_test.go](../../../pkg/processors/actualizers/async_test.go)
+  - add: `Test_AsynchronousActualizer_KeepReadingPropagatesReadPLogErrorAsCause` covering the path where `WatchChannel`'s notify callback triggers `readPlogToOffset`, the failure is recorded as the cause of `n10nWatchChannelCtx`, and `keepReading` returns the same error verbatim (`require.Same` between returned error and `context.Cause(act.n10nWatchChannelCtx)`)
+  - add: `ctxFailingAppParts` test helper (decorator over `IAppPartitions`) that fails `WaitForBorrow` only when the incoming `ctx` is identity-equal to a configured `failOnCtx` (mutex-protected), keying off `n10nWatchChannelCtx` to avoid races with the pipeline's background `Flush`-driven borrows
+  - add: `sync` import
 
 - [x] Review

--- a/uspecs/changes/2605191458-actualizer-context-refactor/decisions.md
+++ b/uspecs/changes/2605191458-actualizer-context-refactor/decisions.md
@@ -1,0 +1,54 @@
+# Decisions
+
+## Uncertainty: shape of the read-cancel state
+
+Decision: drop the dedicated struct entirely and use `context.WithCancelCause`/`context.Cause` on `n10nWatchChannelCtx`; store only the `context.CancelCauseFunc` on `asyncActualizer` and `asyncErrorHandler`
+
+- Pros: removes the manual `sync.Mutex` + `err` field; first-cause-wins semantics are guaranteed by the standard library; no awkward `a.readCtx.cancelWithError(err)` / `a.readCtx.error()` call sites; aligns with Go 1.20+ idiom
+- Cons: callers must filter `context.Cause` against `ctx.Err()` to preserve the existing "return nil on parent shutdown" behavior of `asyncActualizerContextState.error()`; `finit` must call `cancelN10NWatchChannelCtx(nil)` so the per-run cause-context registered on `vvmCtx` is released on every retrier iteration
+- Field naming: `n10nWatchChannelCtx context.Context` + `cancelN10NWatchChannelCtx context.CancelCauseFunc` (paired names make the cancel-handle's target explicit at every call site)
+- Confidence: high
+- Supersedes: the earlier `onReadError` rename decision (the struct is now removed)
+
+## Uncertainty: keep `cancelChannel`'s inner `WatchChannel` call?
+
+Decision: remove `cancelChannel` entirely; the early `readPlogToTheEnd` failure path returns the error directly and `finit`/`channelCleanup` tears down the n10n channel
+
+- Pros: the inner `WatchChannel` call with an already-cancelled ctx has been dead code since AIR-1855 (c9625f6a1) moved cleanup from `WatchChannel`'s defer into the `channelCleanup` func returned by `NewChannel`; today it only toggles `channel.watching` from false→true→false via the deferred `Store(false)` and does no useful work
+- Cons: any future change that puts channel-side effects back into `WatchChannel` would need to re-add an explicit cleanup invocation; mitigated by the fact that `channelCleanup` is the single, explicit cleanup path
+- Confidence: high
+
+## Uncertainty: better name for `asyncActualizerContextState` (superseded)
+
+Decision (superseded): `onReadError` — kept as historical record; the struct itself was later removed in favor of `context.WithCancelCause`
+
+- Pros: named the struct after the event it handled
+- Cons: noun-as-handler naming; method names read awkwardly at call sites
+- Confidence: user-provided
+
+Alternatives:
+
+1. `readCancel`
+   - Pros: minimal change to surrounding code; mirrors current `readCtx` naming so call sites stay readable
+   - Cons: "Cancel" alone doesn't convey the stored cause; still feels like a context-ish thing
+   - Confidence: medium
+2. `readLoopTerminator`
+   - Pros: states exactly what it does (terminates the read loop, which includes breaking `WatchChannel`); matches the file's existing vocabulary (`readPlogToTheEnd`, `keepReading`)
+   - Cons: "terminator" sounds heavy; ties name to "loop" while the struct only stores cancel+err
+   - Confidence: high
+3. `runCanceller`
+   - Pros: scopes intent to one actualizer run; pairs naturally with the existing `cancelWithError`/`cancel`/`error()` methods
+   - Cons: generic; doesn't hint that the cause is preserved
+   - Confidence: high
+4. `watchChannelBreaker`
+   - Pros: matches the issue wording literally; obvious why the struct exists
+   - Cons: under-sells responsibility — it also tears down PLog reads and the pipeline indirectly via the cancel; ties name to one downstream consumer
+   - Confidence: medium
+5. `abortSignal`
+   - Pros: short; reads naturally at call sites (`a.abort.cancelWithError(err)`)
+   - Cons: "signal" overlaps with OS signal handling vocabulary used elsewhere in the codebase
+   - Confidence: medium
+6. `cancelCause`
+   - Pros: aligns with Go 1.20+ `context.WithCancelCause` vocabulary
+   - Cons: invites confusion with the std-lib helper even though the struct doesn't wrap it; risks future refactor pressure to actually use `context.WithCancelCause`
+   - Confidence: low


### PR DESCRIPTION
```yaml
registered_at: 2026-05-19T14:58:25Z
change_id: 2605191458-actualizer-context-refactor
type: refactor
scope: actualizers
baseline: e50729e8f343aceebe4189c5848147088e711df6
issue_url: https://untill.atlassian.net/browse/AIR-3972
```
## Why

`asyncActualizerContextState.vvmCtx` (a per-run cancellable context derived from the VVM context) is currently propagated into every place inside `asyncActualizer` that needs a `context.Context` — PLog reads, partition borrows, structured logging, pipeline error handling — while its only real responsibility is to be the cancel handle that breaks `IN10nBroker.WatchChannel`. The misleading field name and broad reuse obscure intent and tangle lifecycle: callers can't easily tell which paths need to abort with the run-scoped cancel and which should simply follow the surrounding `vvmCtx`/operation context.

## What

Narrow the surface so the actualizer only stores what is needed to break `WatchChannel` and remember the cancellation cause; let every other call site use the context already in scope. Use `context.WithCancelCause`/`context.Cause` instead of a hand-rolled struct with a mutex, and drop the vestigial `WatchChannel` invocation inside `cancelChannel` (no longer needed since AIR-1855 moved channel cleanup to `NewChannel`'s returned `channelCleanup`).

- Delete the `asyncActualizerContextState` struct (lock + err + vvmCtx + cancel + `cancelWithError`/`error()` methods) — replaced by `context.WithCancelCause`
- On `asyncActualizer`, store `n10nWatchChannelCtx context.Context` and its `cancelN10NWatchChannelCtx context.CancelCauseFunc` directly; on `asyncErrorHandler`, store only the `cancelN10NWatchChannelCtx context.CancelCauseFunc`
- Replace every `a.readCtx.cancelWithError(err)` with `a.cancelN10NWatchChannelCtx(err)`; replace `a.readCtx.error()` with `context.Cause(a.n10nWatchChannelCtx)` (filtered when the parent ctx is the one that ended the loop)
- Remove `cancelChannel(e)` entirely; the early `readPlogToTheEnd` failure path just returns the error and lets `finit`/`channelCleanup` tear down the n10n channel
- Replace every other `a.readCtx.vvmCtx` reference with the in-scope `ctx`/`vvmCtx` (`readPlogByBatches` loop, `readPlogToTheEnd`/`readPlogToOffset`'s `borrowAppPart`/`ReadPLog`, `readOffset`, `Prepare`'s retrier `OnError` logger)
- Ensure `finit` calls `cancelN10NWatchChannelCtx(nil)` so the per-run cause-context is released on every retrier iteration

