### PR TITLE
refactor(apps): Refactor actualizer context usage [AIR-3972]

### DIFF
--- a/pkg/processors/actualizers/async.go
+++ b/pkg/processors/actualizers/async.go
@@ -93,7 +93,7 @@ func (a *asyncActualizer) Prepare(vvmCtx context.Context) {
 				return true, nil
 			}
 		}
-		logger.ErrorCtx(a.readCtx.vvmCtx, a.name, opErr)
+		logger.ErrorCtx(vvmCtx, a.name, opErr)
 		return true, nil
 	}
 }
@@ -124,17 +124,15 @@ func (a *asyncActualizer) Run(vvmCtx context.Context) {
 	}
 }
 
-func (a *asyncActualizer) cancelChannel(e error) {
+func (a *asyncActualizer) cancelChannel(ctx context.Context, e error) {
 	a.readCtx.cancelWithError(e)
-	a.conf.Broker.WatchChannel(a.readCtx.vvmCtx, a.conf.channel, func(projection in10n.ProjectionKey, offset istructs.Offset) {})
+	a.conf.Broker.WatchChannel(ctx, a.conf.channel, func(projection in10n.ProjectionKey, offset istructs.Offset) {})
 }
 
 func (a *asyncActualizer) init(vvmCtx context.Context) (err error) {
 	a.plogBatch = make(plogBatch, 0, plogReadBatchSize)
 
 	a.readCtx = &asyncActualizerContextState{}
-
-	a.readCtx.vvmCtx, a.readCtx.cancel = context.WithCancel(vvmCtx)
 
 	appDef, err := a.appParts.AppDef(a.conf.AppQName)
 	if err != nil {
@@ -183,7 +181,7 @@ func (a *asyncActualizer) init(vvmCtx context.Context) (err error) {
 
 	a.name = fmt.Sprintf("%v [%d]", p.name, a.conf.PartitionID)
 
-	err = a.readOffset(p.name)
+	err = a.readOffset(vvmCtx, p.name)
 	if err != nil {
 		return err
 	}
@@ -244,14 +242,18 @@ func (a *asyncActualizer) finit() {
 }
 
 func (a *asyncActualizer) keepReading(ctx context.Context) (err error) {
+	watchCtx, cancelWatch := context.WithCancel(ctx)
+	a.readCtx.setCancelWatch(cancelWatch)
+	defer cancelWatch()
+
 	err = a.readPlogToTheEnd(ctx)
 	if err != nil {
-		a.cancelChannel(err)
+		a.cancelChannel(watchCtx, err)
 		return
 	}
-	a.conf.Broker.WatchChannel(a.readCtx.vvmCtx, a.conf.channel, func(projection in10n.ProjectionKey, offset istructs.Offset) {
+	a.conf.Broker.WatchChannel(watchCtx, a.conf.channel, func(projection in10n.ProjectionKey, offset istructs.Offset) {
 		if a.offset < offset {
-			err = a.readPlogToOffset(a.readCtx.vvmCtx, offset)
+			err = a.readPlogToOffset(ctx, offset)
 			if err != nil {
 				a.readCtx.cancelWithError(err)
 			}
@@ -278,7 +280,7 @@ func (a *asyncActualizer) handleEvent(ctx context.Context, pLogOffset istructs.O
 }
 
 func (a *asyncActualizer) readPlogByBatches(ctx context.Context, readBatch readPLogBatch) error {
-	for a.readCtx.vvmCtx.Err() == nil {
+	for ctx.Err() == nil && a.readCtx.error() == nil {
 		if err := readBatch(&a.plogBatch); err != nil {
 			return err
 		}
@@ -289,7 +291,7 @@ func (a *asyncActualizer) readPlogByBatches(ctx context.Context, readBatch readP
 			if err := a.handleEvent(ctx, e.Offset, e.IPLogEvent); err != nil {
 				return err
 			}
-			if a.readCtx.vvmCtx.Err() != nil {
+			if ctx.Err() != nil || a.readCtx.error() != nil {
 				return nil // canceled
 			}
 		}
@@ -305,14 +307,14 @@ func (a *asyncActualizer) readPlogToTheEnd(ctx context.Context) error {
 	return a.readPlogByBatches(ctx, func(batch *plogBatch) (err error) {
 		*batch = (*batch)[:0]
 
-		ap, err := a.borrowAppPart(a.readCtx.vvmCtx)
+		ap, err := a.borrowAppPart(ctx)
 		if err != nil {
 			return err
 		}
 
 		defer ap.Release()
 
-		err = ap.AppStructs().Events().ReadPLog(a.readCtx.vvmCtx, a.conf.PartitionID, a.offset+1, istructs.ReadToTheEnd,
+		err = ap.AppStructs().Events().ReadPLog(ctx, a.conf.PartitionID, a.offset+1, istructs.ReadToTheEnd,
 			func(ofs istructs.Offset, event istructs.IPLogEvent) error {
 				if *batch = append(*batch, plogEvent{ofs, event}); len(*batch) == cap(*batch) {
 					return errBatchFull
@@ -340,7 +342,7 @@ func (a *asyncActualizer) readPlogToOffset(ctx context.Context, tillOffset istru
 
 		plog := ap.AppStructs().Events()
 		for readOffset := a.offset + 1; readOffset <= tillOffset; readOffset++ {
-			if err = plog.ReadPLog(a.readCtx.vvmCtx, a.conf.PartitionID, readOffset, 1,
+			if err = plog.ReadPLog(ctx, a.conf.PartitionID, readOffset, 1,
 				func(ofs istructs.Offset, event istructs.IPLogEvent) error {
 					if *batch = append(*batch, plogEvent{ofs, event}); len(*batch) == cap(*batch) {
 						return errBatchFull
@@ -358,8 +360,8 @@ func (a *asyncActualizer) readPlogToOffset(ctx context.Context, tillOffset istru
 	})
 }
 
-func (a *asyncActualizer) readOffset(projectorName appdef.QName) error {
-	ap, err := a.borrowAppPart(a.readCtx.vvmCtx)
+func (a *asyncActualizer) readOffset(ctx context.Context, projectorName appdef.QName) error {
+	ap, err := a.borrowAppPart(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/processors/actualizers/async_test.go
+++ b/pkg/processors/actualizers/async_test.go
@@ -1239,6 +1239,47 @@ func Test_AsynchronousActualizer_ChannelCleanupPanicReproduction(t *testing.T) {
 	}
 }
 
+func Test_AsynchronousActualizer_CancelWithErrorBreaksLocalWatchChannelContext(t *testing.T) {
+	require := require.New(t)
+
+	broker, cleanup := in10nmem.NewN10nBroker(in10n.Quotas{
+		Channels: 1, ChannelsPerSubject: 1, Subscriptions: 1, SubscriptionsPerSubject: 1,
+	}, timeu.NewITime())
+	defer cleanup()
+
+	channelID, channelCleanup, err := broker.NewChannel("test", time.Minute)
+	require.NoError(err)
+	defer channelCleanup()
+
+	parentCtx, parentCancel := context.WithCancel(context.Background())
+	defer parentCancel()
+	watchCtx, cancelWatch := context.WithCancel(parentCtx)
+
+	readCtx := &asyncActualizerContextState{}
+	readCtx.setCancelWatch(cancelWatch)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		broker.WatchChannel(watchCtx, channelID, func(in10n.ProjectionKey, istructs.Offset) {})
+	}()
+
+	expectedErr := errors.New("test watch break")
+	readCtx.cancelWithError(expectedErr)
+
+	require.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+	require.ErrorIs(readCtx.error(), expectedErr)
+	require.ErrorIs(watchCtx.Err(), context.Canceled)
+	require.NoError(parentCtx.Err())
+}
+
 type flakyAppParts struct {
 	appparts.IAppPartitions
 	appDefCalls        atomic.Int32

--- a/pkg/processors/actualizers/types.go
+++ b/pkg/processors/actualizers/types.go
@@ -7,7 +7,6 @@
 package actualizers
 
 import (
-	"context"
 	"sync"
 
 	"github.com/voedger/voedger/pkg/appdef"
@@ -15,17 +14,24 @@ import (
 )
 
 type asyncActualizerContextState struct {
-	lock   sync.Mutex
-	err    error
-	vvmCtx context.Context
-	cancel func()
+	lock        sync.Mutex
+	err         error
+	cancelWatch func()
 }
 
 func (s *asyncActualizerContextState) cancelWithError(err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.err = err
-	s.cancel()
+	if s.cancelWatch != nil {
+		s.cancelWatch()
+	}
+}
+
+func (s *asyncActualizerContextState) setCancelWatch(cancel func()) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.cancelWatch = cancel
 }
 
 // @ConcurrentAccess

--- a/uspecs/changes/archive/2605/2605202127-actualizer-context-watchchannel/change.md
+++ b/uspecs/changes/archive/2605/2605202127-actualizer-context-watchchannel/change.md
@@ -1,0 +1,62 @@
+---
+registered_at: 2026-05-20T21:16:29Z
+change_id: 2605202116-actualizer-context-watchchannel
+type: refactor
+scope: apps
+baseline: c27f74d7bd4b234f964a9724a0c2ae54d69aadb4
+issue_url: https://untill.atlassian.net/browse/AIR-3972
+archived_at: 2026-05-20T21:27:38Z
+---
+
+# Change request: Refactor actualizer context usage
+
+## Why
+
+`asyncActualizerContextState.vvmCtx` is used across the actualizer context but is only needed to break `WatchChannel`. Keeping it in the broad context state exposes an implementation detail to code paths that should not depend on it.
+
+## What
+
+Deliver an internal refactor with no behavior change: actualizer processing must preserve the existing `WatchChannel` lifecycle and cancellation behavior while narrowing the scope of the context value used to break it.
+
+- Remove `vvmCtx` from the broad async actualizer context state.
+
+- Introduce a thin-scoped mechanism dedicated to breaking `WatchChannel`.
+
+## How
+
+Decisions:
+
+- Keep `asyncActualizerContextState` responsible for synchronized error capture and cancellation signaling, but remove direct ownership of the VVM-derived context from that shared state.
+
+- Create a local `watchCtx` in the async actualizer read flow and pass it only to `IN10nBroker.WatchChannel`, so the cancellable context exists only where it is needed to unblock waiting.
+
+- Keep PLog reads, app partition borrowing, state factory creation, pipeline construction, and logging on the parent actualizer context.
+
+- Preserve existing async actualizer retry, PLog reading, pipeline error handling, channel cleanup, and offset persistence behavior.
+
+Out of scope:
+
+- Changing `IN10nBroker.WatchChannel` API semantics.
+- Changing async projector execution, batching, or flush policy.
+
+References:
+
+- [async actualizer context state](../../../../../pkg/processors/actualizers/types.go)
+- [async actualizer processing flow](../../../../../pkg/processors/actualizers/async.go)
+- [notification broker contract](../../../../../pkg/in10n/interface.go)
+- [async actualizer tests](../../../../../pkg/processors/actualizers/async_test.go)
+
+## Construction
+
+- [x] update: [actualizers/async_test.go](../../../../../pkg/processors/actualizers/async_test.go)
+  - add or update regression coverage proving WatchChannel can be unblocked through the local watch context without storing the VVM-derived context in `asyncActualizerContextState`
+  - verify async actualizer error and retry behavior still preserves PLog reading, channel cleanup, and offset persistence behavior
+
+- [x] update: [actualizers/types.go](../../../../../pkg/processors/actualizers/types.go)
+  - remove `vvmCtx` from `asyncActualizerContextState`
+  - keep synchronized error storage and cancellation signaling needed by the async error handler
+
+- [x] update: [actualizers/async.go](../../../../../pkg/processors/actualizers/async.go)
+  - create the local `watchCtx` in the async actualizer read flow and pass it only to `IN10nBroker.WatchChannel`
+  - route PLog reads, app partition borrowing, state factory creation, pipeline construction, and logging through the parent actualizer context
+  - ensure error paths that currently call `cancelWithError` still unblock `WatchChannel` and return the captured error to the retry loop

--- a/uspecs/changes/archive/2605/2605202127-actualizer-context-watchchannel/decisions.md
+++ b/uspecs/changes/archive/2605/2605202127-actualizer-context-watchchannel/decisions.md
@@ -1,0 +1,39 @@
+# Decisions
+
+## Uncertainty: where should the new thin-scoped WatchChannel breaker live?
+
+Decision: Local `watchCtx` in async actualizer read flow
+
+- Pros: smallest refactor; keeps the context scoped to `WatchChannel`; avoids adding new shared state
+- Cons: cancellation has to be threaded carefully from error paths that currently call `readCtx.cancelWithError`
+- Confidence: high
+
+Alternatives:
+
+1. Dedicated small struct owned by `asyncActualizer`
+   - Pros: makes the breaker explicit and reusable across `keepReading` and `cancelChannel`
+   - Cons: adds another lifecycle object that must be reset during retry/finit
+   - Confidence: medium
+2. Extend `asyncActualizerContextState` with a narrower cancel-only field
+   - Pros: minimal call-site churn; keeps existing error-handler wiring mostly intact
+   - Cons: only partially solves the broad-state coupling because WatchChannel control still lives in shared read state
+   - Confidence: low
+
+## Uncertainty: which operations should keep using the parent actualizer context instead of the local `watchCtx`?
+
+Decision: Only `WatchChannel` uses `watchCtx`; PLog reads, app partition borrowing, state factory, pipeline, and logging keep using the parent actualizer context
+
+- Pros: preserves existing cancellation/logging behavior everywhere except the dedicated WatchChannel breaker; smallest behavior risk
+- Cons: implementation must audit every current `a.readCtx.vvmCtx` usage and replace it deliberately
+- Confidence: high
+
+Alternatives:
+
+1. Use `watchCtx` for `WatchChannel` and callback-triggered PLog reads
+   - Pros: aligns reads triggered by notifications with the watch lifecycle
+   - Cons: may cancel PLog reads earlier than the current behavior and blur the narrow scope goal
+   - Confidence: low
+2. Replace most `a.readCtx.vvmCtx` usages with `watchCtx`
+   - Pros: simple mechanical replacement in the current read loop
+   - Cons: changes broader actualizer cancellation behavior and contradicts the "thin-scoped" requirement
+   - Confidence: low


### PR DESCRIPTION
```yaml
registered_at: 2026-05-20T21:16:29Z
change_id: 2605202116-actualizer-context-watchchannel
type: refactor
scope: apps
baseline: c27f74d7bd4b234f964a9724a0c2ae54d69aadb4
issue_url: https://untill.atlassian.net/browse/AIR-3972
archived_at: 2026-05-20T21:27:38Z
```
## Why

`asyncActualizerContextState.vvmCtx` is used across the actualizer context but is only needed to break `WatchChannel`. Keeping it in the broad context state exposes an implementation detail to code paths that should not depend on it.

## What

Deliver an internal refactor with no behavior change: actualizer processing must preserve the existing `WatchChannel` lifecycle and cancellation behavior while narrowing the scope of the context value used to break it.

- Remove `vvmCtx` from the broad async actualizer context state.

- Introduce a thin-scoped mechanism dedicated to breaking `WatchChannel`.

