### PR TITLE
fix(registry): Escape hyphen in login validation regexp [AIR-3992]

### DIFF
--- a/pkg/registry/consts.go
+++ b/pkg/registry/consts.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	validLoginRegexp                                  = regexp.MustCompile(`^[a-z0-9!#$%&'*+-\/=?^_{|}~@]+$`) // https://dev.untill.com/projects/#!537026
+	validLoginRegexp                                  = regexp.MustCompile(`^[a-z0-9!#$%&'*+\-\/=.?^_{|}~@]+$`) // https://dev.untill.com/projects/#!537026
 	QNameViewLoginIdx                                 = appdef.NewQName(RegistryPackage, "LoginIdx")
 	qNameCmdChangePassword                            = appdef.NewQName(RegistryPackage, "ChangePassword")
 	QNameProjectorLoginIdx                            = appdef.NewQName(RegistryPackage, "ProjectorLoginIdx")

--- a/pkg/sys/it/impl_signupin_test.go
+++ b/pkg/sys/it/impl_signupin_test.go
@@ -173,6 +173,18 @@ func TestCreateLoginErrors(t *testing.T) {
 				it.Expect400("incorrect login format"))
 		}
 	})
+
+	t.Run("allowed special chars in login", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip()
+		}
+		allowedSpecialChars := []string{"!", "#", "$", "%", "&", "'", "*", "+", "-", "/", "=", ".", "?", "^", "_", "{", "|", "}", "~", "@"}
+		for _, c := range allowedSpecialChars {
+			goodLogin := vit.NextName() + c + "x"
+			login := vit.SignUp(goodLogin, "1", istructs.AppQName_test1_app1)
+			vit.SignIn(login)
+		}
+	})
 }
 
 func TestSignInErrors(t *testing.T) {

--- a/pkg/sys/it/impl_signupin_test.go
+++ b/pkg/sys/it/impl_signupin_test.go
@@ -162,6 +162,8 @@ func TestCreateLoginErrors(t *testing.T) {
 			"-test@test.com",
 			"-test@test.com-",
 			"sys.test@test.com",
+			",",
+			"test,foo@test.com",
 		}
 		for _, wrongLogin := range wrongLogins {
 			pseudoWSID := coreutils.GetPseudoWSID(istructs.NullWSID, wrongLogin, istructs.CurrentClusterID())

--- a/uspecs/changes/archive/2605/2605210658-escape-hyphen-in-login-regexp/change.md
+++ b/uspecs/changes/archive/2605/2605210658-escape-hyphen-in-login-regexp/change.md
@@ -1,0 +1,43 @@
+---
+registered_at: 2026-05-20T14:22:47Z
+change_id: 2605201422-escape-hyphen-in-login-regexp
+type: fix
+baseline: e50729e8f343aceebe4189c5848147088e711df6
+issue_url: https://untill.atlassian.net/browse/AIR-3992
+scope: registry
+archived_at: 2026-05-21T06:58:15Z
+---
+
+# Change request: Escape hyphen in login validation regexp
+
+## Why
+
+`validLoginRegexp` in `pkg/registry/consts.go` was intended to allow `+`, `-`, and `/` as literal characters in a login, but the hyphen sits between `+` and `\/` inside the character class, so the regexp engine interprets it as a range (`+` .. `/`) instead of a literal `-`. The range `[+-\/]` therefore matches 5 characters instead of the 3 originally intended:
+
+| Code point | Char | Originally intended | Allowed after fix |
+| ---------- | ---- | ------------------- | ----------------- |
+| U+002B     | `+`  | yes                 | yes               |
+| U+002C     | `,`  | no                  | no                |
+| U+002D     | `-`  | yes                 | yes               |
+| U+002E     | `.`  | no                  | yes               |
+| U+002F     | `/`  | yes                 | yes               |
+
+`,` and `.` are currently accepted by accident. The fix removes `,` from the allowed set and explicitly adds `.` (kept allowed on purpose, since existing logins may already contain it in non-leading/trailing/double positions).
+
+## What
+
+Fix the regexp so the hyphen is treated as a literal character, and align tests with the resulting allowed character set:
+
+- Escape the `-` in `validLoginRegexp` (or move it to a position where it is unambiguously literal)
+- Explicitly add `.` to the allowed character set
+- Add/adjust unit tests to cover `,` char is not allowed for logins
+
+## Construction
+
+- [x] update: [it/impl_signupin_test.go](../../../../../pkg/sys/it/impl_signupin_test.go)
+  - add: `","` (and `"test,foo@test.com"`) to the `wrongLogins` list in `TestSignUpErrors/subject name constraint violation` to assert `,` is rejected after the fix
+  - add: positive sub-test verifying logins containing `+`, `-`, `/` (e.g. `a+b@x.com`, `a-b@x.com`, `a/b@x.com`) succeed via `vit.SignUp`
+
+- [x] update: [registry/consts.go](../../../../../pkg/registry/consts.go)
+  - fix: escape `-` in `validLoginRegexp` (`+-\/` -> `+\-\/`) so the hyphen is a literal character instead of forming a range with `+` and `/`
+  - add: `.` to the `validLoginRegexp` character class (preserves backward compatibility with existing logins that contain `.` in non-leading/trailing/double positions)

--- a/uspecs/changes/archive/2605/2605210658-escape-hyphen-in-login-regexp/change.md
+++ b/uspecs/changes/archive/2605/2605210658-escape-hyphen-in-login-regexp/change.md
@@ -36,7 +36,6 @@ Fix the regexp so the hyphen is treated as a literal character, and align tests 
 
 - [x] update: [it/impl_signupin_test.go](../../../../../pkg/sys/it/impl_signupin_test.go)
   - add: `","` (and `"test,foo@test.com"`) to the `wrongLogins` list in `TestSignUpErrors/subject name constraint violation` to assert `,` is rejected after the fix
-  - add: positive sub-test verifying logins containing `+`, `-`, `/` (e.g. `a+b@x.com`, `a-b@x.com`, `a/b@x.com`) succeed via `vit.SignUp`
 
 - [x] update: [registry/consts.go](../../../../../pkg/registry/consts.go)
   - fix: escape `-` in `validLoginRegexp` (`+-\/` -> `+\-\/`) so the hyphen is a literal character instead of forming a range with `+` and `/`


### PR DESCRIPTION
```yaml
registered_at: 2026-05-20T14:22:47Z
change_id: 2605201422-escape-hyphen-in-login-regexp
type: fix
baseline: e50729e8f343aceebe4189c5848147088e711df6
issue_url: https://untill.atlassian.net/browse/AIR-3992
scope: registry
archived_at: 2026-05-21T06:58:15Z
```
## Why

`validLoginRegexp` in `pkg/registry/consts.go` was intended to allow `+`, `-`, and `/` as literal characters in a login, but the hyphen sits between `+` and `\/` inside the character class, so the regexp engine interprets it as a range (`+` .. `/`) instead of a literal `-`. The range `[+-\/]` therefore matches 5 characters instead of the 3 originally intended:

| Code point | Char | Originally intended | Allowed after fix |
| ---------- | ---- | ------------------- | ----------------- |
| U+002B     | `+`  | yes                 | yes               |
| U+002C     | `,`  | no                  | no                |
| U+002D     | `-`  | yes                 | yes               |
| U+002E     | `.`  | no                  | yes               |
| U+002F     | `/`  | yes                 | yes               |

`,` and `.` are currently accepted by accident. The fix removes `,` from the allowed set and explicitly adds `.` (kept allowed on purpose, since existing logins may already contain it in non-leading/trailing/double positions).

## What

Fix the regexp so the hyphen is treated as a literal character, and align tests with the resulting allowed character set:

- Escape the `-` in `validLoginRegexp` (or move it to a position where it is unambiguously literal)
- Explicitly add `.` to the allowed character set
- Add/adjust unit tests to cover `,` char is not allowed for logins

