### PR TITLE
docs(apps): Email sending subsystem architecture

### DIFF
--- a/uspecs/changes/archive/2605/2605211447-user-email-sending-arch/change.md
+++ b/uspecs/changes/archive/2605/2605211447-user-email-sending-arch/change.md
@@ -1,0 +1,55 @@
+---
+registered_at: 2026-05-21T14:11:10Z
+change_id: 2605211411-user-email-sending-arch
+type: docs
+scope: apps
+baseline: c27f74d7bd4b234f964a9724a0c2ae54d69aadb4
+archived_at: 2026-05-21T14:47:22Z
+---
+
+# Change request: Email sending subsystem architecture
+
+## Why
+
+Voedger needs a clear subsystem architecture for sending emails so contributors can reason consistently about responsibilities, boundaries, and operational behavior. The architecture should make the email flow understandable before implementation or review decisions depend on scattered local knowledge.
+
+## What
+
+This documentation change delivers subsystem architecture guidance for the email sending area.
+
+- Define the subsystem responsibilities and boundaries for sending emails to users.
+- Describe the architectural flow, integration points, and key design constraints readers need when changing or reviewing this subsystem.
+
+## How
+
+Decisions:
+
+- Add a subsystem architecture document for the email sending area, separate from authentication, because the subsystem is about addressing and delivering messages rather than proving identity or authorizing access.
+- Describe the real processing path: existing commands, queries, projectors, and jobs that need email create `sys.SendMail` state keys in async actualizer or scheduler state.
+- Treat `sys.SendMail` storage as the delivery boundary: it validates required SMTP/message fields, builds `state.EmailMessage`, and delegates delivery to `state.IEmailSender`.
+- Describe current email-producing flows, including invitation emails, email verification codes, and scheduled jobs using `INTENTS(sys.SendMail)`.
+- Include failure and replay/idempotency considerations as architectural constraints based on current projector behavior and `SendMail` storage behavior.
+
+Out of scope:
+
+- Introducing a generic `c.SendEmailToUser` command or `ap.ApplySendEmail` projector.
+- SMTP provider selection, bounce handling, delivery analytics, or user notification preferences.
+- Reworking existing invitation and verification email behavior.
+
+References:
+
+- [product domain overview](../../../../specs/prod/domain.md)
+- [invite email design](../../../../specs/prod/auth/invites--td.md)
+- [system schema email storage](../../../../../pkg/sys/sys.vsql)
+- [user profile schema](../../../../../pkg/sys/userprofile.vsql)
+- [email verification processing](../../../../../pkg/sys/verifier/impl.go)
+- [invitation email processing](../../../../../pkg/sys/invite/impl_applyinviteevents.go)
+- [send mail storage implementation](../../../../../pkg/sys/storages/impl_send_mail_storage.go)
+- [email sender interface](../../../../../pkg/state/types.go)
+- [async actualizer state wiring](../../../../../pkg/state/stateprovide/impl_async_actualizer_state.go)
+- [scheduler state wiring](../../../../../pkg/state/stateprovide/impl_scheduler_state.go)
+
+## Technical design
+
+- [x] create: [arch-user-email-sending.md](../../../../specs/prod/arch-user-email-sending.md)
+  - Domain Subsystem Architecture: real processing path for user email sending through `sys.SendMail`, async actualizers, scheduler jobs, `state.IEmailSender`, SMTP configuration, failure behavior, and replay/idempotency constraints

--- a/uspecs/specs/prod/arch-user-email-sending.md
+++ b/uspecs/specs/prod/arch-user-email-sending.md
@@ -1,0 +1,159 @@
+# Domain subsystem architecture: email sending
+
+## Overview
+
+Email sending is the platform path that turns application-side email side effects into `sys.SendMail` state operations and delegates delivery to the configured email sender.
+
+## Components
+
+- [Email-producing VSQL declarations](../../../pkg/sys/sys.vsql) - declare system commands, projectors, and `STORAGE SendMail`.
+- [User profile email declarations](../../../pkg/sys/userprofile.vsql) - declare email verification command and projector wiring.
+- [Email verification processing](../../../pkg/sys/verifier/impl.go) - initiates verification and emits verification-code email intents.
+- [Invitation email processing](../../../pkg/sys/invite/impl_applyinviteevents.go) - emits invitation and role-update email intents from async invite processing.
+- [Scheduler email job example](../../../pkg/vit/schemaTestApp2WithJobSendMail.vsql) - app jobs that declare `INTENTS(sys.SendMail)` can emit email intents while running in scheduler state.
+- [Async actualizer state](../../../pkg/state/stateprovide/impl_async_actualizer_state.go) - exposes `sys.SendMail` to async projectors with get and insert access.
+- [Scheduler state](../../../pkg/state/stateprovide/impl_scheduler_state.go) - exposes `sys.SendMail` to scheduled jobs with get and insert access.
+- [SendMail storage](../../../pkg/sys/storages/impl_send_mail_storage.go) - validates message and SMTP fields, builds `state.EmailMessage`, and invokes the email sender.
+- [Email sender interface](../../../pkg/state/types.go) - abstracts outbound delivery behind `state.IEmailSender`.
+- [SMTP configuration](../../../pkg/sys/smtp/types.go) - supplies host, port, sender address, username, and password secret name to email-producing code.
+- [App secret storage](../../../pkg/sys/storages/impl_app_secrets_storage.go) - provides the SMTP password secret to projectors and jobs at runtime.
+
+```text
+Email producers
+  |
+  +-- ap.sys.ApplySendEmailVerificationCode
+  +-- ap.sys.ApplyInviteEvents
+  +-- Jobs with INTENTS(sys.SendMail)
+        |
+        v
+
+Execution state
+  |
+  +-- Async actualizer state
+  |     |
+  |     +-- sys.AppSecret storage
+  |     +-- sys.SendMail storage
+  |
+  +-- Scheduler state
+        |
+        +-- sys.AppSecret storage
+        +-- sys.SendMail storage
+              |
+              v
+
+Delivery boundary
+  |
+  +-- sys.SendMail storage
+        |
+        +-- validates SMTP and message fields
+        +-- builds state.EmailMessage
+        +-- invokes state.IEmailSender
+              |
+              v
+
+Transport
+  |
+  +-- state.IEmailSender
+        |
+        v
+
+External system
+  |
+  +-- SMTP server
+```
+
+## Key flows
+
+### Email verification code
+
+```text
+Client
+  |
+  | request verification token/code
+  v
+q.sys.InitiateEmailVerification
+  |
+  | create verification token and code
+  v
+Federation
+  |
+  | call c.sys.SendEmailVerificationCode with system token
+  v
+c.sys.SendEmailVerificationCode
+  |
+  | PLog event
+  v
+ap.sys.ApplySendEmailVerificationCode
+  |
+  | read SMTP password from sys.AppSecret
+  | create sys.SendMail key as intent
+  v
+Async actualizer state
+  |
+  | apply intent
+  v
+sys.SendMail storage
+  |
+  | send EmailMessage
+  v
+state.IEmailSender
+```
+
+The projector skips events older than three days to avoid re-sending verification emails after a projector rename (see voedger/voedger#275).
+
+### Invitation and role-update emails
+
+```text
+Invite command
+  |
+  | PLog event with invite CUD
+  v
+ap.sys.ApplyInviteEvents
+  |
+  | skip pre-refactor or stale events
+  | read invite/workspace state
+  | read SMTP password from sys.AppSecret
+  | create sys.SendMail key as intent
+  v
+Async actualizer state
+  |
+  | apply intent
+  v
+sys.SendMail storage
+  |
+  | send EmailMessage
+  v
+state.IEmailSender
+
+ap.sys.ApplyInviteEvents
+  |
+  | write final invite state
+  v
+Workspace records/views
+```
+
+`ap.sys.ApplyInviteEvents` is responsible for current invite email side effects. It uses a CUD-side `Version` discriminator to avoid re-sending emails from already-processed historical events.
+
+### Scheduler email job
+
+```text
+Scheduler
+  |
+  | invoke due job
+  v
+Job with INTENTS(sys.SendMail)
+  |
+  | create or read sys.SendMail key
+  v
+Scheduler state
+  |
+  | apply/get SendMail operation
+  v
+sys.SendMail storage
+  |
+  | send EmailMessage
+  v
+state.IEmailSender
+```
+
+Scheduler state exposes the same `sys.SendMail` storage as async actualizers so jobs use the same delivery boundary.


### PR DESCRIPTION
```yaml
registered_at: 2026-05-21T14:11:10Z
change_id: 2605211411-user-email-sending-arch
type: docs
scope: apps
baseline: c27f74d7bd4b234f964a9724a0c2ae54d69aadb4
archived_at: 2026-05-21T14:47:22Z
```
## Why

Voedger needs a clear subsystem architecture for sending emails so contributors can reason consistently about responsibilities, boundaries, and operational behavior. The architecture should make the email flow understandable before implementation or review decisions depend on scattered local knowledge.

## What

This documentation change delivers subsystem architecture guidance for the email sending area.

- Define the subsystem responsibilities and boundaries for sending emails to users.
- Describe the architectural flow, integration points, and key design constraints readers need when changing or reviewing this subsystem.


See change.md for details.
