### PR TITLE
test: respect `usetesting` linter across the project [AIR-4017]

### DIFF
--- a/.augment/rules/ar-golang.md
+++ b/.augment/rules/ar-golang.md
@@ -9,7 +9,13 @@ if you you are writting a program on golang then follow these rules:
 - in unit tests use require := require.New(t) and then use e.g. require.Equal(1, 1) instead of require.Equal(t, 1, 1)
 - in unit tests avoid constructions like if a != b { t.Fatal() }. Use require.Equal(a,b) instead
 - in unit tests if you are modifying any global state then save the initial state, then modify, then revert changes using defer func
-- in unit tests if the test consists of few parts that do not impact on others then implement subtests with t.Run(description, func(t *testing.T){}) instead of setting description as a comment
+- in unit tests if the test consists of few parts that do not impact on others then implement subtests with t.Run(description, func(t \*testing.T){}) instead of setting description as a comment
+- in unit tests prefer `*testing.T` helpers over their `os` equivalents (respect the `usetesting` linter):
+  - use `t.Setenv(key, value)` instead of `os.Setenv` + `defer os.Unsetenv`; drop the surrounding `require.NoError` since `t.Setenv` fails the test on error
+  - use `t.TempDir()` instead of `os.MkdirTemp` + `defer os.RemoveAll`
+  - use `t.Chdir(dir)` instead of capturing `initialWD, _ := os.Getwd()` + `os.Chdir(dir)` + `defer os.Chdir(initialWD)`
+  - when a helper called from a test needs one of the above, refactor it to accept `*testing.T` (and call `t.Helper()`) rather than `*require.Assertions`
+  - if the call must stay (e.g. intentionally preserving a temp dir for post-mortem inspection in a verbose-mode branch), annotate it with `//nolint:usetesting` and an inline rationale
 - write as short a code as possible
 - avoid comments. Produce the code so that it is clear without comments what it does
 - never assign a Go error to `_` (no `res, _ := json.Marshal(x)`). Always bind it: `res, err := json.Marshal(x); if err != nil { ... }`. For calls infallible by construction (e.g. `json.Marshal` over a fully-controlled struct, `bytes.Buffer.Write`), use `// notest` on the error branch and either `panic(err)` or `return err`. In all other cases, use `return err` to propagate.

--- a/.augment/rules/ar-golang.md
+++ b/.augment/rules/ar-golang.md
@@ -9,11 +9,11 @@ if you you are writting a program on golang then follow these rules:
 - in unit tests use require := require.New(t) and then use e.g. require.Equal(1, 1) instead of require.Equal(t, 1, 1)
 - in unit tests avoid constructions like if a != b { t.Fatal() }. Use require.Equal(a,b) instead
 - in unit tests if you are modifying any global state then save the initial state, then modify, then revert changes using defer func
-- in unit tests if the test consists of few parts that do not impact on others then implement subtests with `t.Run(description, func(t *testing.T){})` instead of setting description as a comment
+- in unit tests if the test consists of few parts that do not impact on others then implement subtests with `t.Run(description, func(t *testing.T) {})` instead of setting description as a comment
 - in unit tests prefer `*testing.T` helpers over their `os` equivalents (respect the `usetesting` linter):
   - use `t.Setenv(key, value)` instead of `os.Setenv` + `defer os.Unsetenv`; drop the surrounding `require.NoError` since `t.Setenv` fails the test on error
   - use `t.TempDir()` instead of `os.MkdirTemp` + `defer os.RemoveAll`
-  - use `t.Chdir(dir)` instead of capturing `initialWD, _ := os.Getwd()` + `os.Chdir(dir)` + `defer os.Chdir(initialWD)`
+  - use `t.Chdir(dir)` instead of capturing `initialWD, err := os.Getwd(); if err != nil { ... }` + `os.Chdir(dir)` + `defer os.Chdir(initialWD)`
   - when a helper called from a test needs one of the above, refactor it to accept `*testing.T` (and call `t.Helper()`) rather than `*require.Assertions`
   - if the call must stay (e.g. intentionally preserving a temp dir for post-mortem inspection in a verbose-mode branch), annotate it with `//nolint:usetesting` and an inline rationale
 - write as short a code as possible

--- a/.augment/rules/ar-golang.md
+++ b/.augment/rules/ar-golang.md
@@ -9,7 +9,7 @@ if you you are writting a program on golang then follow these rules:
 - in unit tests use require := require.New(t) and then use e.g. require.Equal(1, 1) instead of require.Equal(t, 1, 1)
 - in unit tests avoid constructions like if a != b { t.Fatal() }. Use require.Equal(a,b) instead
 - in unit tests if you are modifying any global state then save the initial state, then modify, then revert changes using defer func
-- in unit tests if the test consists of few parts that do not impact on others then implement subtests with t.Run(description, func(t \*testing.T){}) instead of setting description as a comment
+- in unit tests if the test consists of few parts that do not impact on others then implement subtests with `t.Run(description, func(t *testing.T){})` instead of setting description as a comment
 - in unit tests prefer `*testing.T` helpers over their `os` equivalents (respect the `usetesting` linter):
   - use `t.Setenv(key, value)` instead of `os.Setenv` + `defer os.Unsetenv`; drop the surrounding `require.NoError` since `t.Setenv` fails the test on error
   - use `t.TempDir()` instead of `os.MkdirTemp` + `defer os.RemoveAll`

--- a/cmd/ctool/main_test.go
+++ b/cmd/ctool/main_test.go
@@ -209,8 +209,7 @@ func TestEnvSshKey(t *testing.T) {
 	err := execRootCmd([]string{"./ctool", "init", "n5", "10.0.0.21", "10.0.0.22", "10.0.0.23", "10.0.0.24", "10.0.0.25", "--dry-run", "--acme-domain", "domain1,domain2,domain3"}, version)
 	require.Error(err)
 
-	err = os.Setenv(envVoedgerSSHKey, "key")
-	require.NoError(err)
+	t.Setenv(envVoedgerSSHKey, "key")
 
 	// now the option --ssh-key can be omitted
 	err = execRootCmd([]string{"./ctool", "init", "n5", "10.0.0.21", "10.0.0.22", "10.0.0.23", "10.0.0.24", "10.0.0.25", "--dry-run", "--acme-domain", "domain1,domain2,domain3"}, version)
@@ -343,14 +342,12 @@ fi
 	err = os.WriteFile(filepath.Join(scriptsTempDir, "test-script.sh"), []byte(script), filesu.FileMode_DefaultForFile)
 	require.NoError(err)
 
-	err = os.Setenv("TEST_VAR", "test_value")
-	require.NoError(err)
+	t.Setenv("TEST_VAR", "test_value")
 
 	err = newScriptExecuter("", "").run("test-script.sh")
 	require.NoError(err)
 
-	err = os.Setenv("TEST_VAR", "new_test_value")
-	require.NoError(err)
+	t.Setenv("TEST_VAR", "new_test_value")
 
 	err = newScriptExecuter("", "").run("test-script.sh")
 	require.Error(err)

--- a/cmd/vpm/main_test.go
+++ b/cmd/vpm/main_test.go
@@ -186,7 +186,7 @@ func TestCompileErrors(t *testing.T) {
 	var tempDir string
 	if logger.IsVerbose() {
 		var err error
-		tempDir, err = os.MkdirTemp("", "test_compile")
+		tempDir, err = os.MkdirTemp("", "test_compile") //nolint:usetesting // verbose mode keeps the dir for post-test inspection; t.TempDir() auto-removes
 		require.NoError(err)
 	} else {
 		tempDir = t.TempDir()
@@ -250,15 +250,10 @@ func TestPkgRegistryCompile(t *testing.T) {
 	require := require.New(t)
 
 	wd, err := os.Getwd()
+	require.NoError(err)
 	pkgDirLocalPath := wd[:strings.LastIndex(wd, filepath.FromSlash("/cmd/vpm"))] + filepath.FromSlash("/wasm")
 
-	require.NoError(err)
-	defer func() {
-		_ = os.Chdir(wd)
-	}()
-
-	err = os.Chdir(pkgDirLocalPath)
-	require.NoError(err)
+	t.Chdir(pkgDirLocalPath)
 
 	err = execRootCmd([]string{"vpm", "compile", "-C", "registry"}, "1.0.0")
 	require.NoError(err)
@@ -278,7 +273,7 @@ func TestOrmBasicUsage(t *testing.T) {
 	var err error
 	var tempDir string
 	if logger.IsVerbose() {
-		tempDir, err = os.MkdirTemp("", "test_genorm")
+		tempDir, err = os.MkdirTemp("", "test_genorm") //nolint:usetesting // verbose mode keeps the dir for post-test inspection; t.TempDir() auto-removes
 		require.NoError(err)
 	} else {
 		tempDir = t.TempDir()
@@ -395,7 +390,7 @@ func TestTidyBasicUsage(t *testing.T) {
 	var err error
 	var tempDir string
 	if logger.IsVerbose() {
-		tempDir, err = os.MkdirTemp("", "test_genorm")
+		tempDir, err = os.MkdirTemp("", "test_genorm") //nolint:usetesting // verbose mode keeps the dir for post-test inspection; t.TempDir() auto-removes
 		require.NoError(err)
 	} else {
 		tempDir = t.TempDir()
@@ -446,7 +441,7 @@ func TestBuildBasicUsage(t *testing.T) {
 	var tempDir string
 	if logger.IsVerbose() {
 		var err error
-		tempDir, err = os.MkdirTemp("", "test_build")
+		tempDir, err = os.MkdirTemp("", "test_build") //nolint:usetesting // verbose mode keeps the dir for post-test inspection; t.TempDir() auto-removes
 		require.NoError(err)
 	} else {
 		tempDir = t.TempDir()
@@ -526,7 +521,7 @@ func TestGenOrmTestItAndBuildApp(t *testing.T) {
 	var tempDir string
 	if logger.IsVerbose() {
 		var err error
-		tempDir, err = os.MkdirTemp("", "test_build")
+		tempDir, err = os.MkdirTemp("", "test_build") //nolint:usetesting // verbose mode keeps the dir for post-test inspection; t.TempDir() auto-removes
 		require.NoError(err)
 	} else {
 		tempDir = t.TempDir()

--- a/pkg/goutils/exec/exec_test.go
+++ b/pkg/goutils/exec/exec_test.go
@@ -24,7 +24,7 @@ import (
 func Test_PassEnvironmentVariable(t *testing.T) {
 
 	// set MYVAR=MYVALUE
-	os.Setenv("MYVAR", "MYVALUE")
+	t.Setenv("MYVAR", "MYVALUE")
 
 	stdout, stderr, err := new(exec.PipedExec).
 		Command("sh", "-c", "echo $MYVAR").

--- a/pkg/goutils/filesu/impl_test.go
+++ b/pkg/goutils/filesu/impl_test.go
@@ -80,13 +80,8 @@ func TestCopy_BasicUsage(t *testing.T) {
 
 	t.Run("CopyFile src file without path", func(t *testing.T) {
 		tempDirDst := t.TempDir()
-		initialWD, err := os.Getwd()
-		require.NoError(err)
 		file1SrcPath, file1SrcName := filepath.Split(file1)
-		require.NoError(os.Chdir(file1SrcPath))
-		defer func() {
-			require.NoError(os.Chdir(initialWD))
-		}()
+		t.Chdir(file1SrcPath)
 
 		require.NoError(CopyFile(file1SrcName, tempDirDst))
 		file1Dst := filepath.Join(tempDirDst, file1SrcName)

--- a/pkg/ihttpimpl/impl_test.go
+++ b/pkg/ihttpimpl/impl_test.go
@@ -49,8 +49,7 @@ func TestBasicUsage_HTTPProcessor(t *testing.T) {
 			"dir2/content",
 		}
 		for _, res := range resources {
-			dir, fileName := makeTmpContent(require, res)
-			defer os.RemoveAll(dir)
+			dir, fileName := makeTmpContent(t, res)
 			dirFS := os.DirFS(dir)
 			testApp.processor.DeployStaticContent(res, dirFS)
 
@@ -471,15 +470,11 @@ func (ta *testApp) post(resource string, contentType string, requestText string,
 	return body
 }
 
-func makeTmpContent(require *require.Assertions, pattern string) (dir string, fileName string) {
-	dir, err := os.MkdirTemp("", "."+filepath.Base(pattern))
-	require.NoError(err)
-
+func makeTmpContent(t *testing.T, pattern string) (dir string, fileName string) {
+	t.Helper()
+	dir = t.TempDir()
 	fileName = "tmpcontext.txt"
-
-	err = os.WriteFile(filepath.Join(dir, fileName), []byte(filepath.Base(pattern)), filesu.FileMode_DefaultForFile)
-	require.NoError(err)
-
+	require.NoError(t, os.WriteFile(filepath.Join(dir, fileName), []byte(filepath.Base(pattern)), filesu.FileMode_DefaultForFile))
 	return dir, fileName
 }
 

--- a/pkg/isecretsimpl/impl_test.go
+++ b/pkg/isecretsimpl/impl_test.go
@@ -16,13 +16,8 @@ import (
 
 func TestBasicUsage(t *testing.T) {
 	require := require.New(t)
-	dir, err := os.MkdirTemp("", "isecretsimpl")
-	require.NoError(err)
-	require.NoError(os.Setenv(SecretRootEnv, dir))
-	defer func() {
-		require.NoError(os.RemoveAll(dir))
-		require.NoError(os.Unsetenv(SecretRootEnv))
-	}()
+	dir := t.TempDir()
+	t.Setenv(SecretRootEnv, dir)
 	secret := "secret.json"
 	require.NoError(os.WriteFile(filepath.Join(dir, secret), []byte(`{"secret":"key"}`), fs.ModePerm))
 	sr := ProvideSecretReader()

--- a/uspecs/changes/archive/2605/2605221344-respect-usetesting-linter/change.md
+++ b/uspecs/changes/archive/2605/2605221344-respect-usetesting-linter/change.md
@@ -1,0 +1,74 @@
+---
+registered_at: 2026-05-22T13:31:43Z
+change_id: 2605221331-respect-usetesting-linter
+type: test
+baseline: 4344f6ebd11c8a3cdf7509027b56717ce5982fed
+issue_url: https://untill.atlassian.net/browse/AIR-4017
+archived_at: 2026-05-22T13:44:28Z
+---
+
+# Change request: respect `usetesting` linter across the project
+
+## Why
+
+The `usetesting` linter (enabled via `default: all` in `.golangci.yml`) flags `os` package calls inside `*testing.T` functions that have safer testing equivalents introduced in Go 1.17+ and Go 1.24:
+
+- `os.Setenv` / `os.Unsetenv` — manual `defer os.Unsetenv(...)` is error-prone, leaks state on early `t.Fatal`, and is not parallel-safe across subtests; `t.Setenv` auto-restores the prior value and fails fast when `t.Parallel()` is set
+- `os.MkdirTemp` / `os.CreateTemp` — manual `defer os.RemoveAll(dir)` is verbose, repeated at every call site, and runs even on `require.FailNow`; `t.TempDir()` ties cleanup to the test lifetime with proper Windows retry semantics and a unique per-test name
+- `os.Chdir` (Go 1.24+) — manual `defer os.Chdir(initialWD)` requires capturing the working directory before every call and unwinding in reverse order; `t.Chdir` does this automatically and is goroutine-safe with respect to the test framework
+
+Aligning with `usetesting` keeps the test suite consistent across all five modules registered in `go.work`, removes boilerplate (manual `Getwd` / `Unsetenv` / `RemoveAll` defers), and prevents future regressions because the linter runs in CI.
+
+## What
+
+Replace flagged `os.*` calls in test functions with their `*testing.T` equivalents and drop the now-redundant cleanup defers and error checks:
+
+- `os.Setenv` → `t.Setenv`
+- `os.MkdirTemp` → `t.TempDir`
+- `os.Chdir` → `t.Chdir`
+
+Retain `os.MkdirTemp` in `cmd/vpm/main_test.go` for the verbose-mode branches that deliberately preserve the temp directory for post-test inspection; annotate each retained site with `//nolint:usetesting` and an inline rationale.
+
+Verify by running `golangci-lint run --enable-only=usetesting ./...` in each `go.work` module and confirming `0 issues`.
+
+## Construction
+
+### Rules
+
+- [x] update: [ar-golang.md](../../../../../.augment/rules/ar-golang.md)
+  - add: a new bullet under the existing unit-test rules describing the `usetesting` preferences
+  - cover: `t.Setenv` over `os.Setenv` + `defer os.Unsetenv` (with note that `t.Setenv` already fails the test on error, so the surrounding `require.NoError` is to be dropped)
+  - cover: `t.TempDir()` over `os.MkdirTemp` + `defer os.RemoveAll`
+  - cover: `t.Chdir(dir)` over `initialWD, _ := os.Getwd()` + `os.Chdir(dir)` + `defer os.Chdir(initialWD)`
+  - cover: when a helper called from a test needs one of the above, refactor it to accept `*testing.T` (with `t.Helper()`) rather than `*require.Assertions`
+  - cover: escape hatch — annotate intentional retentions with `//nolint:usetesting` and an inline rationale (e.g. preserving a temp dir for post-mortem inspection in a verbose-mode branch)
+
+### Tests
+
+- [x] update: [impl_test.go](../../../../../pkg/isecretsimpl/impl_test.go)
+  - replace: `os.MkdirTemp` → `t.TempDir()`
+  - replace: `os.Setenv` → `t.Setenv`
+  - drop: `defer` cleanup block (`os.RemoveAll` + `os.Unsetenv`)
+
+- [x] update: [exec_test.go](../../../../../pkg/goutils/exec/exec_test.go)
+  - replace: `os.Setenv("MYVAR", ...)` → `t.Setenv("MYVAR", ...)` in `Test_PassEnvironmentVariable`
+
+- [x] update: [impl_test.go](../../../../../pkg/goutils/filesu/impl_test.go)
+  - replace in `TestCopy_BasicUsage/"CopyFile src file without path"`: `os.Getwd` capture + `os.Chdir` + `defer os.Chdir` → `t.Chdir`
+
+- [x] update: [impl_test.go](../../../../../pkg/ihttpimpl/impl_test.go)
+  - refactor: `makeTmpContent(require *require.Assertions, ...)` → `makeTmpContent(t *testing.T, ...)` using `t.TempDir()` and `t.Helper()`
+  - drop: `defer os.RemoveAll(dir)` at the call site in `TestBasicUsage_HTTPProcessor`
+
+- [x] update: [main_test.go](../../../../../cmd/vpm/main_test.go)
+  - replace in `TestPkgRegistryCompile`: `os.Getwd` capture + `os.Chdir` + `defer os.Chdir` → `t.Chdir`
+  - annotate the 5 verbose-mode `os.MkdirTemp` sites (`TestCompileBasicUsage_Errors`, `TestOrmBasicUsage`, `TestTidyBasicUsage`, `TestBuildBasicUsage`, `TestGenOrmTestItAndBuildApp`) with `//nolint:usetesting` plus an inline rationale (verbose mode keeps the dir for post-test inspection; `t.TempDir()` auto-removes)
+
+- [x] update: [main_test.go](../../../../../cmd/ctool/main_test.go)
+  - replace 3 `os.Setenv` sites (`TestEnvSshKey`, `TestVariableEnvironment` ×2) → `t.Setenv`; drop the paired `require.NoError(err)` checks
+
+### Verification
+
+- [x] run: `golangci-lint run --enable-only=usetesting ./...` in each `go.work` module (`.`, `./cmd/ctool`, `./cmd/edger`, `./pkg/iextengine/wazero/_testdata`, `./pkg/sys/it/testdata/apps/test2.app1/src`) — each must report `0 issues`
+- [x] run: `go build ./...` in root, `./cmd/ctool`, `./cmd/edger` — must succeed
+- [x] run: tests of affected packages (`pkg/isecretsimpl`, `pkg/goutils/exec`, `pkg/goutils/filesu`, `pkg/ihttpimpl`, `cmd/vpm`) — must pass


### PR DESCRIPTION
```yaml
registered_at: 2026-05-22T13:31:43Z
change_id: 2605221331-respect-usetesting-linter
type: test
baseline: 4344f6ebd11c8a3cdf7509027b56717ce5982fed
issue_url: https://untill.atlassian.net/browse/AIR-4017
archived_at: 2026-05-22T13:44:28Z
```
## Why

The `usetesting` linter (enabled via `default: all` in `.golangci.yml`) flags `os` package calls inside `*testing.T` functions that have safer testing equivalents introduced in Go 1.17+ and Go 1.24:

- `os.Setenv` / `os.Unsetenv` — manual `defer os.Unsetenv(...)` is error-prone, leaks state on early `t.Fatal`, and is not parallel-safe across subtests; `t.Setenv` auto-restores the prior value and fails fast when `t.Parallel()` is set
- `os.MkdirTemp` / `os.CreateTemp` — manual `defer os.RemoveAll(dir)` is verbose, repeated at every call site, and runs even on `require.FailNow`; `t.TempDir()` ties cleanup to the test lifetime with proper Windows retry semantics and a unique per-test name
- `os.Chdir` (Go 1.24+) — manual `defer os.Chdir(initialWD)` requires capturing the working directory before every call and unwinding in reverse order; `t.Chdir` does this automatically and is goroutine-safe with respect to the test framework

Aligning with `usetesting` keeps the test suite consistent across all five modules registered in `go.work`, removes boilerplate (manual `Getwd` / `Unsetenv` / `RemoveAll` defers), and prevents future regressions because the linter runs in CI.

## What

Replace flagged `os.*` calls in test functions with their `*testing.T` equivalents and drop the now-redundant cleanup defers and error checks:

- `os.Setenv` → `t.Setenv`
- `os.MkdirTemp` → `t.TempDir`
- `os.Chdir` → `t.Chdir`

Retain `os.MkdirTemp` in `cmd/vpm/main_test.go` for the verbose-mode branches that deliberately preserve the temp directory for post-test inspection; annotate each retained site with `//nolint:usetesting` and an inline rationale.

Verify by running `golangci-lint run --enable-only=usetesting ./...` in each `go.work` module and confirming `0 issues`.

