### PR TITLE
[AIR-4029] Return 400 Bad Request for invalid sys.plog and sys.wlog queries

### DIFF
--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -290,6 +290,19 @@ func TestSqlQuery_readLogParams(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.wlog where Offset >= 1 and something >= 5"}}`
 		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("unsupported expression: *sqlparser.AndExpr"))
 	})
+
+	t.Run("Should return error when limit value is not a literal", func(t *testing.T) {
+		body := `{"args":{"Query":"select * from sys.wlog limit sin(5)"}}`
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("unsupported limit value expression:"))
+	})
+	t.Run("Should return error when comparison left side is not a column reference", func(t *testing.T) {
+		body := `{"args":{"Query":"select * from sys.plog where 5 = 1"}}`
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("unsupported column reference expression:"))
+	})
+	t.Run("Should return error when offset value is not a literal", func(t *testing.T) {
+		body := `{"args":{"Query":"select * from sys.plog where Offset >= sin(5)"}}`
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("unsupported offset value expression:"))
+	})
 }
 
 func TestSqlQuery_records(t *testing.T) {

--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -264,31 +264,31 @@ func TestSqlQuery_readLogParams(t *testing.T) {
 
 	t.Run("Should return error when limit value not parsable", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog limit 7.1"}}`
-		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500(`strconv.ParseInt: parsing "7.1": invalid syntax`))
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400(`strconv.ParseInt: parsing "7.1": invalid syntax`))
 	})
 	t.Run("Should return error when limit value invalid", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog limit -3"}}`
-		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("limit must be greater than -2"))
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("limit must be greater than -2"))
 	})
 	t.Run("Should return error when Offset value not parsable", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog where Offset >= 2.1"}}`
-		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500(`strconv.ParseUint: parsing "2.1": invalid syntax`))
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400(`strconv.ParseUint: parsing "2.1": invalid syntax`))
 	})
 	t.Run("Should return error when Offset value invalid", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog where Offset >= 0"}}`
-		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("offset must be greater than zero"))
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("offset must be greater than zero"))
 	})
 	t.Run("Should return error when Offset operation not supported", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog where Offset < 2"}}`
-		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("unsupported operation: <"))
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("unsupported operation: <"))
 	})
 	t.Run("Should return error when column name not supported", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.plog where something >= 1"}}`
-		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("unsupported column name: something"))
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("unsupported column name: something"))
 	})
 	t.Run("Should return error when expression not supported", func(t *testing.T) {
 		body := `{"args":{"Query":"select * from sys.wlog where Offset >= 1 and something >= 5"}}`
-		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect500("unsupported expression: *sqlparser.AndExpr"))
+		vit.PostWS(ws, "q.sys.SqlQuery", body, it.Expect400("unsupported expression: *sqlparser.AndExpr"))
 	})
 }
 

--- a/pkg/sys/sqlquery/impl.go
+++ b/pkg/sys/sqlquery/impl.go
@@ -323,7 +323,11 @@ func lim(limit *sqlparser.Limit) (int, error) {
 	if limit == nil {
 		return DefaultLimit, nil
 	}
-	v, err := strconvu.ParseInt64(string(limit.Rowcount.(*sqlparser.SQLVal).Val))
+	rowCount, ok := limit.Rowcount.(*sqlparser.SQLVal)
+	if !ok {
+		return 0, fmt.Errorf("unsupported limit value expression: %T", limit.Rowcount)
+	}
+	v, err := strconvu.ParseInt64(string(rowCount.Val))
 	if err != nil {
 		return 0, err
 	}
@@ -341,13 +345,21 @@ func offs(expr sqlparser.Expr, simpleOffset istructs.Offset) (istructs.Offset, b
 	eq := false
 	switch r := expr.(type) {
 	case *sqlparser.ComparisonExpr:
-		if r.Left.(*sqlparser.ColName).Name.String() != "offset" {
-			return 0, false, fmt.Errorf("unsupported column name: %s", r.Left.(*sqlparser.ColName).Name.String())
+		colName, ok := r.Left.(*sqlparser.ColName)
+		if !ok {
+			return 0, false, fmt.Errorf("unsupported column reference expression: %T", r.Left)
+		}
+		if colName.Name.String() != "offset" {
+			return 0, false, fmt.Errorf("unsupported column name: %s", colName.Name.String())
 		}
 		if simpleOffset > 0 {
 			return 0, false, errors.New("both .Offset and 'where offset ...' clause can not be provided in one query")
 		}
-		v, e := strconvu.ParseUint64(string(r.Right.(*sqlparser.SQLVal).Val))
+		offsetVal, ok := r.Right.(*sqlparser.SQLVal)
+		if !ok {
+			return 0, false, fmt.Errorf("unsupported offset value expression: %T", r.Right)
+		}
+		v, e := strconvu.ParseUint64(string(offsetVal.Val))
 		if e != nil {
 			return 0, false, e
 		}

--- a/pkg/sys/sqlquery/impl.go
+++ b/pkg/sys/sqlquery/impl.go
@@ -238,7 +238,7 @@ func provideExecQrySQLQuery(federation federation.IFederation, itokens itokens.I
 			}
 			limit, offset, e := params(whereExpr, s.Limit, istructs.Offset(op.EntityID))
 			if e != nil {
-				return e
+				return coreutils.WrapSysError(e, http.StatusBadRequest)
 			}
 			appParts := args.Workpiece.(processors.IProcessorWorkpiece).AppPartitions()
 			if sourceTableName == plog {

--- a/uspecs/changes/archive/2605/2605231235-plog-query-400-bad-request/change.md
+++ b/uspecs/changes/archive/2605/2605231235-plog-query-400-bad-request/change.md
@@ -1,0 +1,25 @@
+---
+registered_at: 2026-05-23T12:13:12Z
+change_id: 2605231213-plog-query-400-bad-request
+baseline: 4344f6ebd11c8a3cdf7509027b56717ce5982fed
+issue_url: https://untill.atlassian.net/browse/AIR-4029
+archived_at: 2026-05-23T12:35:53Z
+---
+
+# Change request: Return 400 Bad Request for invalid sys.plog and sys.wlog queries
+
+## Why
+
+Invalid `select` queries against `sys.plog` and `sys.wlog` (malformed limit, non-positive offset, unsupported operator or column, unsupported expression) currently respond with `500 Internal Server Error`. These are client input errors and must be reported as `400 Bad Request`.
+
+## What
+
+- Map log query parameter validation failures from `500 Internal Server Error` to `400 Bad Request`
+
+## Construction
+
+- [x] update: [it/impl_sqlquery_test.go](../../../../../pkg/sys/it/impl_sqlquery_test.go)
+  - update: `TestSqlQuery_readLogParams` subtests - replace `it.Expect500(...)` with `it.Expect400(...)` for all seven cases
+
+- [x] update: [sqlquery/impl.go](../../../../../pkg/sys/sqlquery/impl.go)
+  - update: `params()` call site in `provideExecQrySQLQuery` - wrap the returned error with `coreutils.WrapSysError(e, http.StatusBadRequest)`

--- a/uspecs/changes/archive/2605/2605231235-plog-query-400-bad-request/change.md
+++ b/uspecs/changes/archive/2605/2605231235-plog-query-400-bad-request/change.md
@@ -15,11 +15,18 @@ Invalid `select` queries against `sys.plog` and `sys.wlog` (malformed limit, non
 ## What
 
 - Map log query parameter validation failures from `500 Internal Server Error` to `400 Bad Request`
+- Replace unchecked type assertions in `lim()` and `offs()` with ok-form checks so invalid expression shapes also return `400 Bad Request` instead of panicking
 
 ## Construction
 
 - [x] update: [it/impl_sqlquery_test.go](../../../../../pkg/sys/it/impl_sqlquery_test.go)
   - update: `TestSqlQuery_readLogParams` subtests - replace `it.Expect500(...)` with `it.Expect400(...)` for all seven cases
+  - add: `TestSqlQuery_readLogParams` subtest - `limit sin(5)` expects 400 and `"unsupported limit value expression:"`
+  - add: `TestSqlQuery_readLogParams` subtest - `where 5 = 1` expects 400 and `"unsupported column reference expression:"`
+  - add: `TestSqlQuery_readLogParams` subtest - `where Offset >= sin(5)` expects 400 and `"unsupported offset value expression:"`
 
 - [x] update: [sqlquery/impl.go](../../../../../pkg/sys/sqlquery/impl.go)
   - update: `params()` call site in `provideExecQrySQLQuery` - wrap the returned error with `coreutils.WrapSysError(e, http.StatusBadRequest)`
+  - update: `lim()` - convert `limit.Rowcount.(*sqlparser.SQLVal)` to ok-form; return `"unsupported limit value expression: %T"` on failure
+  - update: `offs()` - convert `r.Left.(*sqlparser.ColName)` to ok-form; return `"unsupported column reference expression: %T"` on failure
+  - update: `offs()` - convert `r.Right.(*sqlparser.SQLVal)` to ok-form; return `"unsupported offset value expression: %T"` on failure


### PR DESCRIPTION
```yaml
registered_at: 2026-05-23T12:13:12Z
change_id: 2605231213-plog-query-400-bad-request
baseline: 4344f6ebd11c8a3cdf7509027b56717ce5982fed
issue_url: https://untill.atlassian.net/browse/AIR-4029
archived_at: 2026-05-23T12:35:53Z
```

## Why

Invalid `select` queries against `sys.plog` and `sys.wlog` (malformed limit, non-positive offset, unsupported operator or column, unsupported expression) currently respond with `500 Internal Server Error`. These are client input errors and must be reported as `400 Bad Request`.

## What

- Map log query parameter validation failures from `500 Internal Server Error` to `400 Bad Request`
- Replace unchecked type assertions in `lim()` and `offs()` with ok-form checks so invalid expression shapes also return `400 Bad Request` instead of panicking
