### PR TITLE
fix: Fix vulnerability GO-2026-5026 in golang.org/x/net [AIR-4036]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	golang.org/x/crypto v0.51.0
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a
 	golang.org/x/mod v0.36.0
-	golang.org/x/net v0.54.0
+	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0
 	golang.org/x/tools v0.45.0
@@ -65,7 +65,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/untillpro/gojay v1.2.17-0.20250325110036-70ad3373aa24 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20201002202402-0a1ea396d57c/go.mod h1:iQL9McJNjoIa5mjH6nYTCTZXUN6RP+XW3eib7Ya3XcI=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -283,8 +283,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.0.0-20180302201248-b7ef84aaf62a/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/uspecs/changes/archive/2605/2605250943-fix-vuln-go-2026-5026/change.md
+++ b/uspecs/changes/archive/2605/2605250943-fix-vuln-go-2026-5026/change.md
@@ -18,3 +18,4 @@ Vulnerability GO-2026-5026 affects `golang.org/x/net@v0.54.0`, currently used by
 Upgrade the affected dependency to a version that contains the patch:
 
 - Bump `golang.org/x/net` to `v0.55.0` or later
+- Bump `golang.org/x/sys` to `v0.45.0` or later

--- a/uspecs/changes/archive/2605/2605250943-fix-vuln-go-2026-5026/change.md
+++ b/uspecs/changes/archive/2605/2605250943-fix-vuln-go-2026-5026/change.md
@@ -1,0 +1,20 @@
+---
+registered_at: 2026-05-25T09:40:36Z
+change_id: 2605250940-fix-vuln-go-2026-5026
+type: fix
+baseline: 4344f6ebd11c8a3cdf7509027b56717ce5982fed
+issue_url: https://untill.atlassian.net/browse/AIR-4036
+archived_at: 2026-05-25T09:43:29Z
+---
+
+# Change request: Fix vulnerability GO-2026-5026 in golang.org/x/net
+
+## Why
+
+Vulnerability GO-2026-5026 affects `golang.org/x/net@v0.54.0`, currently used by the project. The flaw is a failure to reject ASCII-only Punycode-encoded labels in `golang.org/x/net/idna`, reachable from `router.Provide` via `autocert.HostWhitelist` → `idna.Profile.ToASCII`. The fix is available in `golang.org/x/net@v0.55.0`.
+
+## What
+
+Upgrade the affected dependency to a version that contains the patch:
+
+- Bump `golang.org/x/net` to `v0.55.0` or later


### PR DESCRIPTION
```yaml
registered_at: 2026-05-25T09:40:36Z
change_id: 2605250940-fix-vuln-go-2026-5026
type: fix
baseline: 4344f6ebd11c8a3cdf7509027b56717ce5982fed
issue_url: https://untill.atlassian.net/browse/AIR-4036
archived_at: 2026-05-25T09:43:29Z
```
## Why

Vulnerability GO-2026-5026 affects `golang.org/x/net@v0.54.0`, currently used by the project. The flaw is a failure to reject ASCII-only Punycode-encoded labels in `golang.org/x/net/idna`, reachable from `router.Provide` via `autocert.HostWhitelist` → `idna.Profile.ToASCII`. The fix is available in `golang.org/x/net@v0.55.0`.

## What

Upgrade the affected dependency to a version that contains the patch:

- Bump `golang.org/x/net` to `v0.55.0` or later
