### PR TITLE
refactor: Fix perfsprint concat-loop warnings [AIR-4052]

### DIFF
--- a/pkg/appdef/filter/impl_and.go
+++ b/pkg/appdef/filter/impl_and.go
@@ -8,6 +8,7 @@ package filter
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/voedger/voedger/pkg/appdef"
 )
@@ -45,16 +46,13 @@ func (f andFilter) Match(t appdef.IType) bool {
 func (f andFilter) String() string {
 	// QNAMES(…) AND TAGS(…)
 	// (QNAMES(…) OR TYPES(…)) AND NOT TAGS(…)
-	s := ""
+	parts := make([]string, len(f.children))
 	for i, c := range f.children {
 		cStr := fmt.Sprint(c)
 		if (c.Kind() == appdef.FilterKind_Or) || (c.Kind() == appdef.FilterKind_And) {
 			cStr = fmt.Sprintf("(%s)", cStr)
 		}
-		if i > 0 {
-			s += " AND "
-		}
-		s += cStr
+		parts[i] = cStr
 	}
-	return s
+	return strings.Join(parts, " AND ")
 }

--- a/pkg/appdef/filter/impl_or.go
+++ b/pkg/appdef/filter/impl_or.go
@@ -8,6 +8,7 @@ package filter
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/voedger/voedger/pkg/appdef"
 )
@@ -45,16 +46,13 @@ func (f orFilter) Or() []appdef.IFilter { return f.children }
 func (f orFilter) String() string {
 	// QNAMES(…) OR TAGS(…)
 	// (QNAMES(…) AND TYPES(…)) OR NOT TAGS(…)
-	s := ""
+	parts := make([]string, len(f.children))
 	for i, c := range f.children {
 		cStr := fmt.Sprint(c)
 		if (c.Kind() == appdef.FilterKind_Or) || (c.Kind() == appdef.FilterKind_And) {
 			cStr = fmt.Sprintf("(%s)", cStr)
 		}
-		if i > 0 {
-			s += " OR "
-		}
-		s += cStr
+		parts[i] = cStr
 	}
-	return s
+	return strings.Join(parts, " OR ")
 }

--- a/pkg/appdef/filter/impl_qnames.go
+++ b/pkg/appdef/filter/impl_qnames.go
@@ -7,6 +7,7 @@ package filter
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/voedger/voedger/pkg/appdef"
 )
@@ -40,12 +41,9 @@ func (f qNamesFilter) QNames() []appdef.QName {
 
 func (f qNamesFilter) String() string {
 	// QNAMES(…)
-	s := "QNAMES("
+	parts := make([]string, len(f.names))
 	for i, c := range f.names {
-		if i > 0 {
-			s += ", "
-		}
-		s += fmt.Sprint(c)
+		parts[i] = fmt.Sprint(c)
 	}
-	return s + ")"
+	return "QNAMES(" + strings.Join(parts, ", ") + ")"
 }

--- a/pkg/appdef/filter/impl_tags.go
+++ b/pkg/appdef/filter/impl_tags.go
@@ -7,6 +7,7 @@ package filter
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/voedger/voedger/pkg/appdef"
 )
@@ -41,14 +42,11 @@ func (f tagsFilter) Match(t appdef.IType) bool {
 
 func (f tagsFilter) String() string {
 	// TAGS(…)
-	s := "TAGS("
+	parts := make([]string, len(f.tags))
 	for i, c := range f.tags {
-		if i > 0 {
-			s += ", "
-		}
-		s += fmt.Sprint(c)
+		parts[i] = fmt.Sprint(c)
 	}
-	return s + ")"
+	return "TAGS(" + strings.Join(parts, ", ") + ")"
 }
 
 func (f tagsFilter) Tags() []appdef.QName { return f.tags }

--- a/pkg/appdef/filter/impl_types.go
+++ b/pkg/appdef/filter/impl_types.go
@@ -7,6 +7,7 @@ package filter
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/goutils/set"
@@ -44,21 +45,15 @@ func (f typesFilter) Match(t appdef.IType) bool {
 }
 
 func (f typesFilter) String() string {
-	var s string
 	if t, ok := typesStringDecorators[string(f.typeSet.AsBytes())]; ok {
-		s = t
-	} else {
-		// TYPES(…) FROM …)
-		s = "TYPES("
-		for i, t := range f.types {
-			if i > 0 {
-				s += ", "
-			}
-			s += t.TrimString()
-		}
-		s += ")"
+		return t
 	}
-	return s
+	// TYPES(…) FROM …)
+	parts := make([]string, len(f.types))
+	for i, t := range f.types {
+		parts[i] = t.TrimString()
+	}
+	return "TYPES(" + strings.Join(parts, ", ") + ")"
 }
 
 func (f typesFilter) Types() []appdef.TypeKind { return f.types }

--- a/pkg/goutils/logger/impl.go
+++ b/pkg/goutils/logger/impl.go
@@ -59,7 +59,8 @@ func (p *logPrinter) getFormattedMsg(msgType string, funcName string, line int, 
 	if len(args) > 0 {
 		var sb strings.Builder
 		for _, arg := range args {
-			fmt.Fprint(&sb, " ", arg)
+			sb.WriteByte(' ')
+			fmt.Fprint(&sb, arg)
 		}
 		out += sb.String()
 	}

--- a/pkg/goutils/logger/impl.go
+++ b/pkg/goutils/logger/impl.go
@@ -57,11 +57,11 @@ func (p *logPrinter) getFormattedMsg(msgType string, funcName string, line int, 
 	out += ": " + msgType
 	out += fmt.Sprintf(": [%v:%v]:", funcName, line)
 	if len(args) > 0 {
-		var s string
+		var sb strings.Builder
 		for _, arg := range args {
-			s += fmt.Sprint(" ", arg)
+			fmt.Fprint(&sb, " ", arg)
 		}
-		out += s
+		out += sb.String()
 	}
 	return out
 }

--- a/pkg/istructsmem/errors.go
+++ b/pkg/istructsmem/errors.go
@@ -24,10 +24,12 @@ func enrichError(err error, argOrMsg any, args ...any) error {
 	if msg, ok := argOrMsg.(string); ok && len(args) > 0 && strings.Contains(msg, "%") {
 		enrich = fmt.Sprintf(msg, args...)
 	} else {
-		enrich = fmt.Sprint(argOrMsg)
+		var sb strings.Builder
+		fmt.Fprint(&sb, argOrMsg)
 		for i := range args {
-			enrich += " " + fmt.Sprint(args[i])
+			fmt.Fprint(&sb, " ", args[i])
 		}
+		enrich = sb.String()
 	}
 	return fmt.Errorf("%w: %s", err, enrich)
 }

--- a/pkg/istructsmem/errors.go
+++ b/pkg/istructsmem/errors.go
@@ -27,7 +27,8 @@ func enrichError(err error, argOrMsg any, args ...any) error {
 		var sb strings.Builder
 		fmt.Fprint(&sb, argOrMsg)
 		for i := range args {
-			fmt.Fprint(&sb, " ", args[i])
+			sb.WriteByte(' ')
+			fmt.Fprint(&sb, args[i])
 		}
 		enrich = sb.String()
 	}

--- a/pkg/processors/query2/impl_schemas_handler.go
+++ b/pkg/processors/query2/impl_schemas_handler.go
@@ -10,6 +10,7 @@ import (
 	"html"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/bus"
@@ -23,8 +24,9 @@ func schemasHandler() apiPathHandler {
 }
 
 func schemasExec(ctx context.Context, qw *queryWork) (err error) {
-	generatedHTML := fmt.Sprintf("<html><head><title>App %s schema</title></head><body>", qw.msg.AppQName().String())
-	generatedHTML += fmt.Sprintf("<h1>App %s schema</h1>", qw.msg.AppQName().String())
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "<html><head><title>App %s schema</title></head><body>", qw.msg.AppQName().String())
+	fmt.Fprintf(&sb, "<h1>App %s schema</h1>", qw.msg.AppQName().String())
 
 	packages := make(map[string][]appdef.IWorkspace)
 	developer := qw.isDeveloper()
@@ -52,9 +54,9 @@ func schemasExec(ctx context.Context, qw *queryWork) (err error) {
 
 	if len(packages) == 0 {
 		if !developer {
-			generatedHTML += "<p>No workspaces with published roles found</p>"
+			sb.WriteString("<p>No workspaces with published roles found</p>")
 		} else {
-			generatedHTML += "<p>No workspaces found</p>"
+			sb.WriteString("<p>No workspaces found</p>")
 		}
 	} else {
 		// Sort packages alphabetically
@@ -65,8 +67,8 @@ func schemasExec(ctx context.Context, qw *queryWork) (err error) {
 		sort.Strings(pkgNames)
 
 		for _, pkg := range pkgNames {
-			generatedHTML += fmt.Sprintf("<h2>Package %s</h2>", pkg)
-			generatedHTML += "<ul>"
+			fmt.Fprintf(&sb, "<h2>Package %s</h2>", pkg)
+			sb.WriteString("<ul>")
 
 			// Sort workspaces by QName for consistent ordering
 			workspaces := packages[pkg]
@@ -76,12 +78,12 @@ func schemasExec(ctx context.Context, qw *queryWork) (err error) {
 
 			for _, ws := range workspaces {
 				ref := fmt.Sprintf("/api/v2/apps/%s/%s/schemas/%s/roles", qw.msg.AppQName().Owner(), qw.msg.AppQName().Name(), ws.QName().String())
-				generatedHTML += fmt.Sprintf(`<li><a href="%s">%s</a></li>`, html.EscapeString(ref), html.EscapeString(ws.QName().String()))
+				fmt.Fprintf(&sb, `<li><a href="%s">%s</a></li>`, html.EscapeString(ref), html.EscapeString(ws.QName().String()))
 			}
-			generatedHTML += "</ul>"
+			sb.WriteString("</ul>")
 		}
 	}
-	generatedHTML += "</body></html>"
+	sb.WriteString("</body></html>")
 
-	return qw.msg.Responder().Respond(bus.ResponseMeta{ContentType: httpu.ContentType_TextHTML, StatusCode: http.StatusOK}, generatedHTML)
+	return qw.msg.Responder().Respond(bus.ResponseMeta{ContentType: httpu.ContentType_TextHTML, StatusCode: http.StatusOK}, sb.String())
 }

--- a/pkg/processors/query2/impl_schemas_handler.go
+++ b/pkg/processors/query2/impl_schemas_handler.go
@@ -25,8 +25,9 @@ func schemasHandler() apiPathHandler {
 
 func schemasExec(ctx context.Context, qw *queryWork) (err error) {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "<html><head><title>App %s schema</title></head><body>", qw.msg.AppQName().String())
-	fmt.Fprintf(&sb, "<h1>App %s schema</h1>", qw.msg.AppQName().String())
+	appStr := qw.msg.AppQName().String()
+	fmt.Fprintf(&sb, "<html><head><title>App %s schema</title></head><body>", appStr)
+	fmt.Fprintf(&sb, "<h1>App %s schema</h1>", appStr)
 
 	packages := make(map[string][]appdef.IWorkspace)
 	developer := qw.isDeveloper()
@@ -76,8 +77,10 @@ func schemasExec(ctx context.Context, qw *queryWork) (err error) {
 				return workspaces[i].QName().String() < workspaces[j].QName().String()
 			})
 
+			appOwnerStr := qw.msg.AppQName().Owner()
+			appNameStr := qw.msg.AppQName().Name()
 			for _, ws := range workspaces {
-				ref := fmt.Sprintf("/api/v2/apps/%s/%s/schemas/%s/roles", qw.msg.AppQName().Owner(), qw.msg.AppQName().Name(), ws.QName().String())
+				ref := fmt.Sprintf("/api/v2/apps/%s/%s/schemas/%s/roles", appOwnerStr, appNameStr, ws.QName().String())
 				fmt.Fprintf(&sb, `<li><a href="%s">%s</a></li>`, html.EscapeString(ref), html.EscapeString(ws.QName().String()))
 			}
 			sb.WriteString("</ul>")

--- a/pkg/processors/query2/impl_schemas_roles_handler.go
+++ b/pkg/processors/query2/impl_schemas_roles_handler.go
@@ -10,6 +10,7 @@ import (
 	"html"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/bus"
@@ -39,8 +40,9 @@ func schemasRolesExec(ctx context.Context, qw *queryWork) (err error) {
 		rolesTitle = "published roles"
 	}
 
-	generatedHTML := fmt.Sprintf("<html><head><title>App %s: workspace %s %s</title></head><body>", qw.msg.AppQName().String(), wsQname.String(), rolesTitle)
-	generatedHTML += fmt.Sprintf("<h1>App %s</h1><h2>Workspace %s %s</h2>", qw.msg.AppQName().String(), wsQname.String(), rolesTitle)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "<html><head><title>App %s: workspace %s %s</title></head><body>", qw.msg.AppQName().String(), wsQname.String(), rolesTitle)
+	fmt.Fprintf(&sb, "<h1>App %s</h1><h2>Workspace %s %s</h2>", qw.msg.AppQName().String(), wsQname.String(), rolesTitle)
 	packages := make(map[string][]appdef.IRole)
 	for _, typ := range workspace.Types() {
 		if typ.Kind() == appdef.TypeKind_Role {
@@ -58,7 +60,7 @@ func schemasRolesExec(ctx context.Context, qw *queryWork) (err error) {
 	}
 
 	if len(packages) == 0 {
-		generatedHTML += fmt.Sprintf("<p>No %s</p>", rolesTitle)
+		fmt.Fprintf(&sb, "<p>No %s</p>", rolesTitle)
 	} else {
 		// Sort packages alphabetically
 		pkgNames := make([]string, 0, len(packages))
@@ -74,16 +76,16 @@ func schemasRolesExec(ctx context.Context, qw *queryWork) (err error) {
 				return roles[i].QName().String() < roles[j].QName().String()
 			})
 
-			generatedHTML += fmt.Sprintf("<h2>Package %s</h2>", pkg)
-			generatedHTML += "<ul>"
+			fmt.Fprintf(&sb, "<h2>Package %s</h2>", pkg)
+			sb.WriteString("<ul>")
 			for _, role := range roles {
 				ref := fmt.Sprintf("/api/v2/apps/%s/%s/schemas/%s/roles/%s", qw.msg.AppQName().Owner(), qw.msg.AppQName().Name(), workspace.QName().String(), role.QName().String())
-				generatedHTML += fmt.Sprintf(`<li><a href="%s">%s</a></li>`, html.EscapeString(ref), html.EscapeString(role.QName().String()))
+				fmt.Fprintf(&sb, `<li><a href="%s">%s</a></li>`, html.EscapeString(ref), html.EscapeString(role.QName().String()))
 			}
-			generatedHTML += "</ul>"
+			sb.WriteString("</ul>")
 		}
 	}
-	generatedHTML += "</body></html>"
+	sb.WriteString("</body></html>")
 
-	return qw.msg.Responder().Respond(bus.ResponseMeta{ContentType: httpu.ContentType_TextHTML, StatusCode: http.StatusOK}, generatedHTML)
+	return qw.msg.Responder().Respond(bus.ResponseMeta{ContentType: httpu.ContentType_TextHTML, StatusCode: http.StatusOK}, sb.String())
 }

--- a/pkg/processors/query2/impl_schemas_roles_handler.go
+++ b/pkg/processors/query2/impl_schemas_roles_handler.go
@@ -40,9 +40,11 @@ func schemasRolesExec(ctx context.Context, qw *queryWork) (err error) {
 		rolesTitle = "published roles"
 	}
 
+	appStr := qw.msg.AppQName().String()
+	wsStr := wsQname.String()
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "<html><head><title>App %s: workspace %s %s</title></head><body>", qw.msg.AppQName().String(), wsQname.String(), rolesTitle)
-	fmt.Fprintf(&sb, "<h1>App %s</h1><h2>Workspace %s %s</h2>", qw.msg.AppQName().String(), wsQname.String(), rolesTitle)
+	fmt.Fprintf(&sb, "<html><head><title>App %s: workspace %s %s</title></head><body>", appStr, wsStr, rolesTitle)
+	fmt.Fprintf(&sb, "<h1>App %s</h1><h2>Workspace %s %s</h2>", appStr, wsStr, rolesTitle)
 	packages := make(map[string][]appdef.IRole)
 	for _, typ := range workspace.Types() {
 		if typ.Kind() == appdef.TypeKind_Role {
@@ -78,8 +80,10 @@ func schemasRolesExec(ctx context.Context, qw *queryWork) (err error) {
 
 			fmt.Fprintf(&sb, "<h2>Package %s</h2>", pkg)
 			sb.WriteString("<ul>")
+			appOwnerStr := qw.msg.AppQName().Owner()
+			appNameStr := qw.msg.AppQName().Name()
 			for _, role := range roles {
-				ref := fmt.Sprintf("/api/v2/apps/%s/%s/schemas/%s/roles/%s", qw.msg.AppQName().Owner(), qw.msg.AppQName().Name(), workspace.QName().String(), role.QName().String())
+				ref := fmt.Sprintf("/api/v2/apps/%s/%s/schemas/%s/roles/%s", appOwnerStr, appNameStr, workspace.QName().String(), role.QName().String())
 				fmt.Fprintf(&sb, `<li><a href="%s">%s</a></li>`, html.EscapeString(ref), html.EscapeString(role.QName().String()))
 			}
 			sb.WriteString("</ul>")

--- a/uspecs/changes/archive/2605/2605260908-fix-perfsprint-concat-loop/change.md
+++ b/uspecs/changes/archive/2605/2605260908-fix-perfsprint-concat-loop/change.md
@@ -1,0 +1,53 @@
+---
+registered_at: 2026-05-26T08:51:37Z
+change_id: 2605260851-fix-perfsprint-concat-loop
+type: refactor
+baseline: 3f3122a8e3a8dd3b7b6428d0983134b608d69693
+issue_url: https://untill.atlassian.net/browse/AIR-4052
+archived_at: 2026-05-26T09:08:07Z
+---
+
+# Change request: Fix perfsprint concat-loop warnings
+
+## Why
+
+The `perfsprint` linter flagged 9 occurrences of `concat-loop` across the codebase — string concatenation inside `for` loops using `+=`. This pattern runs in O(n²) (every `+=` allocates a fresh string and copies the previous buffer), repeats `if i > 0 { s += sep }` separator boilerplate at every site, and blocks a clean lint baseline.
+
+## What
+
+Replace each in-loop string concatenation with the idiomatic O(n) alternative, without changing observable output:
+
+- "Join values with a separator" patterns: build `[]string` and use `strings.Join`
+- Multi-section text/HTML accumulators: use `strings.Builder` together with `fmt.Fprintf` / `fmt.Fprint` / `WriteString`
+
+## Construction
+
+- [x] update: [appdef/filter/impl_and.go](../../../../../pkg/appdef/filter/impl_and.go)
+  - replace: `s += " AND " + c.String()` loop in `String()` with `strings.Join` over a pre-sized `[]string`
+
+- [x] update: [appdef/filter/impl_or.go](../../../../../pkg/appdef/filter/impl_or.go)
+  - replace: `s += " OR " + c.String()` loop in `String()` with `strings.Join` over a pre-sized `[]string`
+
+- [x] update: [appdef/filter/impl_qnames.go](../../../../../pkg/appdef/filter/impl_qnames.go)
+  - replace: `s += ", "` loop in `String()` with `"QNAMES(" + strings.Join(parts, ", ") + ")"`
+
+- [x] update: [appdef/filter/impl_tags.go](../../../../../pkg/appdef/filter/impl_tags.go)
+  - replace: `s += ", "` loop in `String()` with `"TAGS(" + strings.Join(parts, ", ") + ")"`
+
+- [x] update: [appdef/filter/impl_types.go](../../../../../pkg/appdef/filter/impl_types.go)
+  - replace: `s += ", "` loop in `String()` with `"TYPES(" + strings.Join(parts, ", ") + ")"`
+
+- [x] update: [goutils/logger/impl.go](../../../../../pkg/goutils/logger/impl.go)
+  - replace: `s += fmt.Sprint(" ", arg)` loop in `getFormattedMsg` with `strings.Builder` + `fmt.Fprint`
+
+- [x] update: [istructsmem/errors.go](../../../../../pkg/istructsmem/errors.go)
+  - replace: `enrich += " " + fmt.Sprint(args[i])` loop in `enrichError` with `strings.Builder` + `fmt.Fprint`
+
+- [x] update: [query2/impl_schemas_handler.go](../../../../../pkg/processors/query2/impl_schemas_handler.go)
+  - replace: two `generatedHTML += fmt.Sprintf(...)` loops with `strings.Builder` + `fmt.Fprintf` / `WriteString`
+
+- [x] update: [query2/impl_schemas_roles_handler.go](../../../../../pkg/processors/query2/impl_schemas_roles_handler.go)
+  - replace: two `generatedHTML += fmt.Sprintf(...)` loops with `strings.Builder` + `fmt.Fprintf` / `WriteString`
+
+- [x] verify: `golangci-lint run --default=none --enable perfsprint --max-same-issues 0 --max-issues-per-linter 0 ./...` reports no `concat-loop` issues
+- [x] verify: `go test ./pkg/appdef/filter/... ./pkg/processors/query2/... ./pkg/goutils/logger/... ./pkg/istructsmem/...` is green


### PR DESCRIPTION
```yaml
registered_at: 2026-05-26T08:51:37Z
change_id: 2605260851-fix-perfsprint-concat-loop
type: refactor
baseline: 3f3122a8e3a8dd3b7b6428d0983134b608d69693
issue_url: https://untill.atlassian.net/browse/AIR-4052
archived_at: 2026-05-26T09:08:07Z
```
## Why

The `perfsprint` linter flagged 9 occurrences of `concat-loop` across the codebase — string concatenation inside `for` loops using `+=`. This pattern runs in O(n²) (every `+=` allocates a fresh string and copies the previous buffer), repeats `if i > 0 { s += sep }` separator boilerplate at every site, and blocks a clean lint baseline.

## What

Replace each in-loop string concatenation with the idiomatic O(n) alternative, without changing observable output:

- "Join values with a separator" patterns: build `[]string` and use `strings.Join`
- Multi-section text/HTML accumulators: use `strings.Builder` together with `fmt.Fprintf` / `fmt.Fprint` / `WriteString`

