### PR TITLE
fix: Spread msgAndArgs in require wrapper forwarding sites [AIR-4058]

### DIFF
--- a/pkg/goutils/testingu/require/constraint.go
+++ b/pkg/goutils/testingu/require/constraint.go
@@ -153,7 +153,7 @@ func ErrorWith(t assert.TestingT, e error, c ...Constraint) bool {
 
 func errorWith(t assert.TestingT, e error, c []Constraint, msgAndArgs ...interface{}) bool {
 	if e == nil {
-		return assert.Fail(t, "error expected", msgAndArgs)
+		return assert.Fail(t, "error expected", msgAndArgs...)
 	}
 
 	for _, constraint := range c {

--- a/pkg/goutils/testingu/require/constraint_test.go
+++ b/pkg/goutils/testingu/require/constraint_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -169,5 +170,54 @@ func TestErrorWith(t *testing.T) {
 				t.Errorf("ErrorWith() returns %v, want %v", r, tt.want)
 			}
 		})
+	}
+}
+
+// Demonstrates that msgAndArgs are passed correctly when ErrorWith fails on a
+// nil error. Two bug sites stack on the (*Require).Error path:
+//   - constraint.go:156 — assert.Fail(t, "error expected", msgAndArgs) wraps
+//     msgAndArgs once (variadic boxing).
+//   - require.go:135 — errorWith(r.t, err, cc, msgAndArgs) wraps it a second
+//     time before constraint.go:156 wraps it a third.
+// See https://untill.atlassian.net/browse/AIR-4058
+func TestErrorWith_NilErrorMsgAndArgs_FormatsCorrectly(t *testing.T) {
+	t.Run("errorWith direct (single wrap site)", func(t *testing.T) {
+		mockT := &captureT{}
+		_ = errorWith(mockT, nil, []Constraint{}, "ctx=%s id=%d", "myCase", 42)
+		assertFormattedMessage(t, mockT)
+	})
+
+	t.Run("(*Require).Error (two wrap sites stacked)", func(t *testing.T) {
+		mockT := &captureT{}
+		r := New(mockT)
+		func() {
+			defer func() { _ = recover() }()
+			r.Error(nil, Has("never-matches"), "ctx=%s id=%d", "myCase", 42)
+		}()
+		assertFormattedMessage(t, mockT)
+	})
+}
+
+type captureT struct {
+	fails []string
+}
+
+func (c *captureT) Errorf(format string, args ...any) {
+	c.fails = append(c.fails, fmt.Sprintf(format, args...))
+}
+
+func (c *captureT) FailNow() { panic("captureT.FailNow") }
+
+func assertFormattedMessage(t *testing.T, mockT *captureT) {
+	t.Helper()
+	if len(mockT.fails) == 0 {
+		t.Fatal("expected captured failure message, got none")
+	}
+	msg := mockT.fails[0]
+	if !strings.Contains(msg, "ctx=myCase id=42") {
+		t.Errorf("expected formatted message to contain %q, got: %q", "ctx=myCase id=42", msg)
+	}
+	if strings.Contains(msg, "%s") || strings.Contains(msg, "%d") {
+		t.Errorf("expected format verbs to be applied, but they appear verbatim in: %q", msg)
 	}
 }

--- a/pkg/goutils/testingu/require/require.go
+++ b/pkg/goutils/testingu/require/require.go
@@ -132,7 +132,7 @@ func (r *Require) Error(err error, constaintsAndMsgAndArgs ...interface{}) {
 		}
 	}
 	if len(cc) > 0 {
-		errorWith(r.t, err, cc, msgAndArgs)
+		errorWith(r.t, err, cc, msgAndArgs...)
 	} else {
 		r.Assertions.Error(err, msgAndArgs...)
 	}

--- a/uspecs/changes/archive/2605/2605261349-fix-require-msgandargs-spread/change.md
+++ b/uspecs/changes/archive/2605/2605261349-fix-require-msgandargs-spread/change.md
@@ -1,0 +1,85 @@
+---
+change_id: 2605261332-fix-require-msgandargs-spread
+type: fix
+issue_url: https://untill.atlassian.net/browse/AIR-4058
+---
+
+# Change request: Spread msgAndArgs in require wrapper forwarding sites
+
+Refs:
+
+- [AIR-4058: testingu/require: wrong variadic args usage](./issue-AIR-4058.md)
+
+## Why
+
+The `pkg/goutils/testingu/require` wrapper forwards `msgAndArgs []any` into variadic `...any` parameters at two sites without the `...` spread, boxing the slice as a single `any`. When an assertion of the form `require.Error(nil, constraint, "ctx=%s", v)` fails, testify prints the raw slice (`[ctx=%s v]` or doubly wrapped `[[ctx=%s v]]`) instead of the formatted message, which makes diagnostics misleading and silently breaks the documented `msgAndArgs` contract.
+
+## What
+
+The failure message produced when `require.Error` / `errorWith` reports a nil error contains the raw `msgAndArgs` slice literal with unprocessed format verbs instead of the formatted text.
+
+```text
+caller invokes require.Error(nil, Has(...), "ctx=%s id=%d", v1, v2)
+      |
+      v
+(*Require).Error                 <-- fault: forwards msgAndArgs without ...
+      |
+      v
+errorWith (err == nil branch)    <-- fault: forwards msgAndArgs without ...
+      |
+      v
+assert.Fail receives a single boxed []any
+      |
+      v
+testify prints "Messages: [[ctx=%s id=%d v1 v2]]"   (symptom)
+```
+
+Failure messages reported by both forwarding paths render `msgAndArgs` through their format string, so the printed `Messages:` line matches the caller's intent and contains no unprocessed format verbs or slice-literal brackets.
+
+## How
+
+Decisions:
+
+- Drive the change test-first: land a failing regression test that captures the malformed `Messages:` text from both forwarding paths, then apply the fix and watch it turn green
+- Spread `msgAndArgs` with `...` at both forwarding sites instead of restructuring the helper signatures, keeping the public API of `(*Require).Error` and `errorWith` unchanged
+- Capture failure-message text with a minimal in-package `assert.TestingT` mock (`captureT`), since `*testing.T` exposes no way to read back `Errorf` content; mirrors testify's own self-test pattern
+- Exercise both bug sites through subtests of one parent test (`errorWith` direct, `(*Require).Error` through `errorWith`) so the doubly wrapped `[[ … ]]` symptom is visible alongside the singly wrapped `[ … ]` one
+
+Out of scope:
+
+- Auditing `msgAndArgs` forwarding patterns elsewhere in the repository (whole-repo `asasalint` run confirmed these are the only two sites)
+- The latent issue that `(*Require).Error` discards `errorWith`'s return value on the constraint branch and never calls `FailNow()` on failure
+- Adjacent linter warnings in the same files (`modernize`, `gocritic`, etc.) that are unrelated to variadic forwarding
+
+References:
+
+- [forwarding fault site in errorWith](../../../../../pkg/goutils/testingu/require/constraint.go)
+- [forwarding fault site in (\*Require).Error](../../../../../pkg/goutils/testingu/require/require.go)
+- [existing constraint tests for the package](../../../../../pkg/goutils/testingu/require/constraint_test.go)
+- [asasalint linter rationale](https://github.com/alingse/asasalint)
+
+## Construction
+
+### Tests
+
+- [x] update: [require/constraint_test.go](../../../../../pkg/goutils/testingu/require/constraint_test.go)
+  - add: regression test that demonstrates the malformed `Messages:` diagnostic and locks the fixed behavior
+  - add: `captureT` minimal `assert.TestingT` mock that records each `Errorf` call (no public `*testing.T` API exposes failure-message text)
+  - add: `assertFormattedMessage` helper asserting the captured message contains `ctx=myCase id=42` and does not contain unprocessed verbs (`%s`, `%d`)
+  - add: parent test `TestErrorWith_NilErrorMsgAndArgs_FormatsCorrectly` with two subtests:
+    - `errorWith direct (single wrap site)` — exercises `errorWith(mockT, nil, []Constraint{}, "ctx=%s id=%d", "myCase", 42)`
+    - `(*Require).Error (two wrap sites stacked)` — exercises `New(mockT).Error(nil, Has("never-matches"), "ctx=%s id=%d", "myCase", 42)` inside a recover to swallow the `FailNow` panic
+  - add: `strings` import for the contains-check helper
+
+### Implementation
+
+- [x] update: [require/constraint.go](../../../../../pkg/goutils/testingu/require/constraint.go)
+  - fix: line 156 — spread `msgAndArgs` when forwarding to `assert.Fail`: `assert.Fail(t, "error expected", msgAndArgs...)`
+
+- [x] update: [require/require.go](../../../../../pkg/goutils/testingu/require/require.go)
+  - fix: line 135 — spread `msgAndArgs` when forwarding to `errorWith`: `errorWith(r.t, err, cc, msgAndArgs...)`
+
+### Verification
+
+- [x] verify: `go test ./pkg/goutils/testingu/require/...` passes (both subtests green)
+- [x] verify: `golangci-lint run --default=none --enable asasalint ./pkg/goutils/testingu/require/...` reports zero issues

--- a/uspecs/changes/archive/2605/2605261349-fix-require-msgandargs-spread/issue-AIR-4058.md
+++ b/uspecs/changes/archive/2605/2605261349-fix-require-msgandargs-spread/issue-AIR-4058.md
@@ -1,0 +1,61 @@
+# testingu/require: wrong variadic args usage
+
+- URL: https://untill.atlassian.net/browse/AIR-4058
+- ID: AIR-4058
+- State: in-progress
+- Author: Denis Gribanov
+- Assignees: Denis Gribanov
+- Labels: none
+
+## Description
+
+### Why
+
+`pkg/goutils/testingu/require` provides a wrapper around `testify/assert` and `testify/require` that adds constraint-based error assertions (`ErrorWith`, `PanicsWith`, `Has`, `Is`, etc.). Two call sites forward a `msgAndArgs []any` value into a variadic `...any` parameter without the `...` spread operator, causing the slice to be boxed as a single `any` argument:
+
+- `pkg/goutils/testingu/require/constraint.go:156` — `assert.Fail(t, "error expected", msgAndArgs)`
+- `pkg/goutils/testingu/require/require.go:135` — `errorWith(r.t, err, cc, msgAndArgs)`
+
+`asasalint` flags the first site:
+
+```text
+pkg/goutils/testingu/require/constraint.go:156:43:
+  pass []any as any to func assert.Fail (asasalint)
+```
+
+The defect is reachable only when all of the following are true:
+
+- The caller passed extra `msgAndArgs` past the constraints to `require.Error(err, …)` or `errorWith(t, err, c, …)`
+- `err == nil` (the `assert.Fail` branch in `errorWith`)
+
+Because the failing branch is the only consumer of `msgAndArgs`, ordinary callers never notice. When the conditions do meet, testify writes a diagnostic in which:
+
+- format verbs (`%s`, `%d`, …) are not applied — they appear verbatim
+- the arguments are printed as a slice literal with surrounding `[ ]` brackets
+- when both call sites compose (the `(*Require).Error` → `errorWith` path), the slice is wrapped twice, producing `[[ … ]]`
+
+Observed message text on the buggy code paths:
+
+| Call site reached | Captured `Messages:` content |
+|---|---|
+| `errorWith` direct | `[ctx=%s id=%d myCase 42]` |
+| `(*Require).Error` → `errorWith` | `[[ctx=%s id=%d myCase 42]]` |
+
+Functional outcome is unaffected — the assertion still fails. Only the developer-visible diagnostic is malformed, which makes test failures harder to diagnose and silently invalidates the `msgAndArgs` contract that all `testify/require`-style wrappers promise.
+
+### What
+
+Spread the slice at both forwarding sites:
+
+- `pkg/goutils/testingu/require/constraint.go:156` — change `assert.Fail(t, "error expected", msgAndArgs)` to `assert.Fail(t, "error expected", msgAndArgs...)`
+- `pkg/goutils/testingu/require/require.go:135` — change `errorWith(r.t, err, cc, msgAndArgs)` to `errorWith(r.t, err, cc, msgAndArgs...)`
+
+Add a regression test in `pkg/goutils/testingu/require/constraint_msgargs_test.go` that:
+
+- uses a capturing `assert.TestingT` mock (no public `*testing.T` API to read back `Errorf` text)
+- exercises both forwarding paths via subtests
+- asserts the diagnostic contains the formatted result (`ctx=myCase id=42`) and does not contain unprocessed verbs (`%s`, `%d`)
+
+Verify with `golangci-lint run --default=none --enable asasalint ./pkg/goutils/testingu/require/...` — must report zero issues.
+
+Verify `go test ./pkg/goutils/testingu/require/...` is green.


### PR DESCRIPTION
```yaml
change_id: 2605261332-fix-require-msgandargs-spread
type: fix
issue_url: https://untill.atlassian.net/browse/AIR-4058
```
## Why

The `pkg/goutils/testingu/require` wrapper forwards `msgAndArgs []any` into variadic `...any` parameters at two sites without the `...` spread, boxing the slice as a single `any`. When an assertion of the form `require.Error(nil, constraint, "ctx=%s", v)` fails, testify prints the raw slice (`[ctx=%s v]` or doubly wrapped `[[ctx=%s v]]`) instead of the formatted message, which makes diagnostics misleading and silently breaks the documented `msgAndArgs` contract.

## What

The failure message produced when `require.Error` / `errorWith` reports a nil error contains the raw `msgAndArgs` slice literal with unprocessed format verbs instead of the formatted text.

```text
caller invokes require.Error(nil, Has(...), "ctx=%s id=%d", v1, v2)
      |
      v
(*Require).Error                 <-- fault: forwards msgAndArgs without ...
      |
      v
errorWith (err == nil branch)    <-- fault: forwards msgAndArgs without ...
      |
      v
assert.Fail receives a single boxed []any
      |
      v
testify prints "Messages: [[ctx=%s id=%d v1 v2]]"   (symptom)
```

Failure messages reported by both forwarding paths render `msgAndArgs` through their format string, so the printed `Messages:` line matches the caller's intent and contains no unprocessed format verbs or slice-literal brackets.

## How

Decisions:

- Drive the change test-first: land a failing regression test that captures the malformed `Messages:` text from both forwarding paths, then apply the fix and watch it turn green
- Spread `msgAndArgs` with `...` at both forwarding sites instead of restructuring the helper signatures, keeping the public API of `(*Require).Error` and `errorWith` unchanged
- Capture failure-message text with a minimal in-package `assert.TestingT` mock (`captureT`), since `*testing.T` exposes no way to read back `Errorf` content; mirrors testify's own self-test pattern
- Exercise both bug sites through subtests of one parent test (`errorWith` direct, `(*Require).Error` through `errorWith`) so the doubly wrapped `[[ … ]]` symptom is visible alongside the singly wrapped `[ … ]` one



---
Content omitted. See change.md for full details.
