### PR TITLE
refactor(apps): Deduplicate query and query2 production code flagged by dupl [AIR-4089]

### DIFF
--- a/pkg/processors/query/factory-filter-impl.go
+++ b/pkg/processors/query/factory-filter-impl.go
@@ -101,36 +101,28 @@ func newLessFilter(field string, value interface{}, _ coreutils.MapObject) (IFil
 	}, nil
 }
 
-func newAndFilter(operands []interface{}) (IFilter, error) {
-	andFilter := &AndFilter{make([]IFilter, len(operands))}
+func buildBinaryFilter(operands []interface{}, kind string, ctor func([]IFilter) IFilter) (IFilter, error) {
+	filters := make([]IFilter, len(operands))
 	for i, operandIntf := range operands {
 		operand, ok := operandIntf.(map[string]interface{})
 		if !ok {
-			return nil, fmt.Errorf("'%s' filter: each 'args' member must be an object: %w", filterKind_And, ErrWrongType)
+			return nil, fmt.Errorf("'%s' filter: each 'args' member must be an object: %w", kind, ErrWrongType)
 		}
 		filter, err := NewFilter(operand)
 		if err != nil {
-			return nil, filterErr(filterKind_And, err)
+			return nil, filterErr(kind, err)
 		}
-		andFilter.filters[i] = filter
+		filters[i] = filter
 	}
-	return andFilter, nil
+	return ctor(filters), nil
+}
+
+func newAndFilter(operands []interface{}) (IFilter, error) {
+	return buildBinaryFilter(operands, filterKind_And, func(fs []IFilter) IFilter { return &AndFilter{fs} })
 }
 
 func newOrFilter(operands []interface{}) (IFilter, error) {
-	orFilter := &OrFilter{make([]IFilter, len(operands))}
-	for i, operandIntf := range operands {
-		operand, ok := operandIntf.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("'%s' filter: each 'args' member must be an object: %w", filterKind_Or, ErrWrongType)
-		}
-		filter, err := NewFilter(operand)
-		if err != nil {
-			return nil, filterErr(filterKind_Or, err)
-		}
-		orFilter.filters[i] = filter
-	}
-	return orFilter, nil
+	return buildBinaryFilter(operands, filterKind_Or, func(fs []IFilter) IFilter { return &OrFilter{fs} })
 }
 
 func filterErr(filterKind string, err error) error {

--- a/pkg/processors/query/filter-greater-impl.go
+++ b/pkg/processors/query/filter-greater-impl.go
@@ -4,32 +4,11 @@
 
 package queryprocessor
 
-import (
-	"fmt"
-
-	"github.com/voedger/voedger/pkg/appdef"
-)
-
 type GreaterFilter struct {
 	field string
 	value interface{}
 }
 
 func (f GreaterFilter) IsMatch(fk FieldsKinds, outputRow IOutputRow) (bool, error) {
-	switch fk[f.field] {
-	case appdef.DataKind_int32:
-		return outputRow.Value(f.field).(int32) > int32(f.value.(float64)), nil
-	case appdef.DataKind_int64:
-		return outputRow.Value(f.field).(int64) > int64(f.value.(float64)), nil
-	case appdef.DataKind_float32:
-		return outputRow.Value(f.field).(float32) > float32(f.value.(float64)), nil
-	case appdef.DataKind_float64:
-		return outputRow.Value(f.field).(float64) > f.value.(float64), nil
-	case appdef.DataKind_string:
-		return outputRow.Value(f.field).(string) > f.value.(string), nil
-	case appdef.DataKind_null:
-		return false, nil
-	default:
-		return false, fmt.Errorf("'%s' filter: field %s: %w", filterKind_Gt, f.field, ErrWrongType)
-	}
+	return matchOrdered(filterKind_Gt, f.field, true, fk, outputRow, f.value)
 }

--- a/pkg/processors/query/filter-less-impl.go
+++ b/pkg/processors/query/filter-less-impl.go
@@ -4,32 +4,11 @@
 
 package queryprocessor
 
-import (
-	"fmt"
-
-	"github.com/voedger/voedger/pkg/appdef"
-)
-
 type LessFilter struct {
 	field string
 	value interface{}
 }
 
 func (f LessFilter) IsMatch(fk FieldsKinds, outputRow IOutputRow) (bool, error) {
-	switch fk[f.field] {
-	case appdef.DataKind_int32:
-		return outputRow.Value(f.field).(int32) < int32(f.value.(float64)), nil
-	case appdef.DataKind_int64:
-		return outputRow.Value(f.field).(int64) < int64(f.value.(float64)), nil
-	case appdef.DataKind_float32:
-		return outputRow.Value(f.field).(float32) < float32(f.value.(float64)), nil
-	case appdef.DataKind_float64:
-		return outputRow.Value(f.field).(float64) < f.value.(float64), nil
-	case appdef.DataKind_string:
-		return outputRow.Value(f.field).(string) < f.value.(string), nil
-	case appdef.DataKind_null:
-		return false, nil
-	default:
-		return false, fmt.Errorf("'%s' filter: field %s: %w", filterKind_Lt, f.field, ErrWrongType)
-	}
+	return matchOrdered(filterKind_Lt, f.field, false, fk, outputRow, f.value)
 }

--- a/pkg/processors/query/filter-ordering-impl.go
+++ b/pkg/processors/query/filter-ordering-impl.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021-present unTill Pro, Ltd.
+ */
+
+package queryprocessor
+
+import (
+	"cmp"
+	"fmt"
+
+	"github.com/voedger/voedger/pkg/appdef"
+)
+
+func compareOrdered[T cmp.Ordered](a, b T, gt bool) bool {
+	if gt {
+		return a > b
+	}
+	return a < b
+}
+
+func matchOrdered(filterKind, field string, gt bool, fk FieldsKinds, outputRow IOutputRow, value interface{}) (bool, error) {
+	switch fk[field] {
+	case appdef.DataKind_int32:
+		return compareOrdered(outputRow.Value(field).(int32), int32(value.(float64)), gt), nil
+	case appdef.DataKind_int64:
+		return compareOrdered(outputRow.Value(field).(int64), int64(value.(float64)), gt), nil
+	case appdef.DataKind_float32:
+		return compareOrdered(outputRow.Value(field).(float32), float32(value.(float64)), gt), nil
+	case appdef.DataKind_float64:
+		return compareOrdered(outputRow.Value(field).(float64), value.(float64), gt), nil
+	case appdef.DataKind_string:
+		return compareOrdered(outputRow.Value(field).(string), value.(string), gt), nil
+	case appdef.DataKind_null:
+		return false, nil
+	default:
+		return false, fmt.Errorf("'%s' filter: field %s: %w", filterKind, field, ErrWrongType)
+	}
+}

--- a/pkg/processors/query/filter-ordering-impl.go
+++ b/pkg/processors/query/filter-ordering-impl.go
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021-present unTill Pro, Ltd.
+ * Copyright (c) 2026-present unTill Software Development Group B.V.
+ * @author Denis Gribanov
  */
 
 package queryprocessor

--- a/pkg/processors/query2/impl_openapi.go
+++ b/pkg/processors/query2/impl_openapi.go
@@ -220,7 +220,7 @@ func (g *schemaGenerator) generateFunctionExecuteSchemas(fn appdef.IFunction, op
 		if typ.QName() == appdef.QNameANY {
 			return
 		}
-		g.generateSchemaComponent(typ.(ischema), op, nil, schemas)
+		g.generateSchemaComponent(typ, op, nil, schemas)
 	}
 }
 

--- a/pkg/processors/query2/impl_openapi.go
+++ b/pkg/processors/query2/impl_openapi.go
@@ -99,34 +99,9 @@ func (g *schemaGenerator) generateComponents() {
 
 		for op, fields := range ops {
 			g.generateSchemaComponent(t, op, fields, schemas)
-			if t.Kind() == appdef.TypeKind_Command && op == appdef.OperationKind_Execute {
-				cmd := t.(appdef.ICommand)
-				if param := cmd.Param(); param != nil {
-					if param.QName() == appdef.QNameANY {
-						continue
-					}
-					g.generateSchemaComponent(param.(ischema), op, nil, schemas)
-				}
-				if result := cmd.Result(); result != nil {
-					if result.QName() == appdef.QNameANY {
-						continue
-					}
-					g.generateSchemaComponent(result.(ischema), op, nil, schemas)
-				}
-			}
-			if t.Kind() == appdef.TypeKind_Query && op == appdef.OperationKind_Execute {
-				qry := t.(appdef.IQuery)
-				if param := qry.Param(); param != nil {
-					if param.QName() == appdef.QNameANY {
-						continue
-					}
-					g.generateSchemaComponent(param.(ischema), op, nil, schemas)
-				}
-				if result := qry.Result(); result != nil {
-					if result.QName() == appdef.QNameANY {
-						continue
-					}
-					g.generateSchemaComponent(result.(ischema), op, nil, schemas)
+			if op == appdef.OperationKind_Execute {
+				if fn, ok := t.(appdef.IFunction); ok {
+					g.generateFunctionExecuteSchemas(fn, op, schemas)
 				}
 			}
 		}
@@ -234,6 +209,18 @@ func (g *schemaGenerator) opString(op appdef.OperationKind) string {
 		return "Execute"
 	default:
 		return "Unknown"
+	}
+}
+
+func (g *schemaGenerator) generateFunctionExecuteSchemas(fn appdef.IFunction, op appdef.OperationKind, schemas map[string]interface{}) {
+	for _, typ := range []appdef.IType{fn.Param(), fn.Result()} {
+		if typ == nil {
+			continue
+		}
+		if typ.QName() == appdef.QNameANY {
+			return
+		}
+		g.generateSchemaComponent(typ.(ischema), op, nil, schemas)
 	}
 }
 

--- a/uspecs/changes/archive/2605/2605280745-dedup-query-query2-prod-dupl/change.md
+++ b/uspecs/changes/archive/2605/2605280745-dedup-query-query2-prod-dupl/change.md
@@ -1,0 +1,83 @@
+---
+change_id: 2605280725-dedup-query-query2-prod-dupl
+type: refactor
+issue_url: https://untill.atlassian.net/browse/AIR-4089
+scope: apps
+---
+
+# Change request: Deduplicate query and query2 production code flagged by dupl
+
+Refs:
+
+- [AIR-4089: voedger: Deduplicate query / query2 production code (dupl linter cleanup)](./issue-AIR-4089.md)
+
+## Why
+
+The `dupl` linter flags three independent copy-paste clones in the production code of the query and query2 processor packages. Each clone duplicates a small but non-trivial behaviour fragment, so any future change must be mirrored across the duplicated sites or the branches will silently drift apart.
+
+## What
+
+Collapse the three clone sites in the query and query2 processor packages into single shared implementations:
+
+- Unify the `Greater` / `Less` comparison filter behaviour into one ordered-comparison helper while preserving the existing public filter types
+- Unify the `And` / `Or` logical-filter factories through a shared binary-filter builder
+- Unify the Command and Query Execute OpenAPI schema branches via a single dispatch through the common function interface, preserving the existing skip-on-any-qname semantics
+- No behaviour change: the externally observable behaviour to preserve is the exact result of `IsMatch` for every supported `DataKind`, the error messages produced by the filter factories, and the OpenAPI document generated for command and query Execute endpoints
+
+## How
+
+Decisions:
+
+- Site 1: keep `GreaterFilter` and `LessFilter` as the public types; both delegate `IsMatch` to one shared unexported routine carrying a comparison discriminator (`gt` / `lt`) so the `switch` over `appdef.DataKind_*` lives in one place and adding a new kind happens once
+- Site 2: extract `buildBinaryFilter` in `factory-filter-impl.go` that takes the operands, the filter kind constant, and a constructor closure; `newAndFilter` and `newOrFilter` become thin wrappers around it
+- Site 3: dispatch the Execute branch in `impl_openapi.go` through `appdef.IFunction` (the common ancestor of `ICommand` and `IQuery`) and a new `generateFunctionExecuteSchemas` helper. The helper preserves the existing semantics that, when `Param().QName() == QNameANY`, both the param-schema component generation and the matching `Result()` processing are skipped for that op (originally achieved via `continue` on the outer `for op, fields := range ops` loop)
+- Do not change the public API of `GreaterFilter`, `LessFilter`, `AndFilter`, `OrFilter`, `newAndFilter`, `newOrFilter`, `CreateOpenAPISchema`, or `schemaGenerator`
+
+Out of scope:
+
+- Test-file duplication (addressed separately under the `pkg/appdef` / `pkg/processors/query` test-dedup work)
+- Sub-threshold (<75 token) handler boilerplate clones in `query2/impl.go`, `impl_cdocs_handler.go`, `impl_query_handler.go`, `impl_view_handler.go`, `interface.go`, `util.go`
+- The `query2/types.go` `case DataKind_int32` / `case DataKind_string` filter-loader pair
+
+References:
+
+- [GreaterFilter implementation](../../../../../pkg/processors/query/filter-greater-impl.go)
+- [LessFilter implementation](../../../../../pkg/processors/query/filter-less-impl.go)
+- [And/Or filter factories](../../../../../pkg/processors/query/factory-filter-impl.go)
+- [OpenAPI schema generator](../../../../../pkg/processors/query2/impl_openapi.go)
+- [appdef.IFunction interface](../../../../../pkg/appdef/interface_function.go)
+- [Greater filter tests](../../../../../pkg/processors/query/filter-greater-impl_test.go)
+- [Less filter tests](../../../../../pkg/processors/query/filter-less-impl_test.go)
+- [And filter tests](../../../../../pkg/processors/query/filter-and-impl_test.go)
+- [Or filter tests](../../../../../pkg/processors/query/filter-or-impl_test.go)
+- [OpenAPI integration tests](../../../../../pkg/sys/it/impl_qpv2_test.go)
+
+## Construction
+
+- [x] update: [query/filter-greater-impl.go](../../../../../pkg/processors/query/filter-greater-impl.go)
+  - rewrite `GreaterFilter.IsMatch` to delegate to a shared unexported ordered-comparison routine carrying a `gt` discriminator
+  - preserve the public `GreaterFilter` struct and its field shape
+
+- [x] update: [query/filter-less-impl.go](../../../../../pkg/processors/query/filter-less-impl.go)
+  - rewrite `LessFilter.IsMatch` to delegate to the same shared routine with an `lt` discriminator
+  - preserve the public `LessFilter` struct and its field shape
+
+- [x] create: [query/filter-ordering-impl.go](../../../../../pkg/processors/query/filter-ordering-impl.go)
+  - shared single `switch` over `appdef.DataKind_*` that compares row value against filter value for both `gt` and `lt`
+  - returns `false, nil` for `DataKind_null` and `false, ErrWrongType`-wrapped error for unsupported kinds, parameterized by the filter-kind constant
+
+- [x] update: [query/factory-filter-impl.go](../../../../../pkg/processors/query/factory-filter-impl.go)
+  - extract `buildBinaryFilter(operands []interface{}, kind string, ctor func([]IFilter) IFilter) (IFilter, error)`
+  - rewrite `newAndFilter` and `newOrFilter` as thin wrappers around `buildBinaryFilter`
+
+- [x] update: [query2/impl_openapi.go](../../../../../pkg/processors/query2/impl_openapi.go)
+  - replace the two `if t.Kind() == TypeKind_Command/_Query && op == Execute { ... }` branches in `generateComponents` with a single dispatch through `appdef.IFunction`
+  - add `generateFunctionExecuteSchemas(fn appdef.IFunction, op appdef.OperationKind, schemas map[string]interface{})` that handles `Param()` then `Result()`; preserves the original semantics that, when `Param().QName() == QNameANY`, both the param-schema generation and the subsequent `Result()` processing are skipped for that op
+
+- [x] verify: `go test ./pkg/processors/query/... ./pkg/processors/query2/...` passes
+
+- [x] verify: affected integration tests under `pkg/sys/it` pass (`TestOpenAPI`, `TestQueryProcessor2_*`)
+
+- [x] verify: `golangci-lint run --no-config --default=none --enable=dupl --tests=false ./pkg/processors/query/... ./pkg/processors/query2/...` reports 0 findings at the default threshold, and the three sites above no longer appear at threshold 75
+
+- [x] verify: `golangci-lint run ./pkg/processors/query/... ./pkg/processors/query2/...` reports no new findings in any other linter

--- a/uspecs/changes/archive/2605/2605280745-dedup-query-query2-prod-dupl/issue-AIR-4089.md
+++ b/uspecs/changes/archive/2605/2605280745-dedup-query-query2-prod-dupl/issue-AIR-4089.md
@@ -1,0 +1,61 @@
+# voedger: Deduplicate query / query2 production code (dupl linter cleanup)
+
+- URL: https://untill.atlassian.net/browse/AIR-4089
+- ID: AIR-4089
+- State: in-progress
+- Author: d.gribanov@dev.untill.com
+- Labels: none
+
+## Why
+
+`dupl` flags three independent copy-paste clones in the production code of `pkg/processors/query` and `pkg/processors/query2`. Each clone duplicates a small but non-trivial piece of behaviour, meaning a change to one branch must be mirrored in the other or the two will silently drift apart.
+
+Site 1 — `Greater` vs `Less` filter `IsMatch`
+
+Two 30-line `switch` statements over `appdef.DataKind_*` that differ only by the comparison operator (`>` vs `<`) and the error-message filter-kind constant (`filterKind_Gt` vs `filterKind_Lt`). Each new supported `DataKind` must be added in both files in lock-step.
+
+Site 2 — `newAndFilter` vs `newOrFilter` in `factory-filter-impl.go`
+
+Two 15-line factories with identical operand-validation loops; they differ only in the struct constructed (`AndFilter` vs `OrFilter`) and the kind constant used in the error message.
+
+Site 3 — Command vs Query `Execute` schema generation in `impl_openapi.go`
+
+Two 14-line branches inside `generateComponents` that handle `TypeKind_Command + Execute` and `TypeKind_Query + Execute` respectively. They differ only in the `TypeKind`, the concrete interface used for the type assertion (`appdef.ICommand` vs `appdef.IQuery`) and the local variable name (`cmd` vs `qry`). Both interfaces embed `appdef.IFunction`, which already exposes `Param()` and `Result()`.
+
+Consequences
+
+- 6 `dupl` warnings across the two packages (2 at default threshold, 4 more at threshold 75)
+- High drift risk on any change to a comparison filter, logical-filter factory, or function-schema rule
+- One latent edge case worth verifying during the refactor: in site 3 the existing `continue` skips the whole `for op, fields := range ops` iteration when `param.QName() == QNameANY`, so the matching `result` is never processed for that op. The new helper must preserve this behaviour
+
+## What
+
+Refactor each clone site so that the shared behaviour lives in one place. No behaviour change is intended; existing unit and integration tests must continue to pass without modification.
+
+1. Unify `GreaterFilter` / `LessFilter` `IsMatch`
+   - Extract one `compareOrdered[T constraints.Ordered](a, b T, op orderingOp) bool` (or an equivalent unexported helper) and route both `GreaterFilter.IsMatch` and `LessFilter.IsMatch` through it
+   - Alternative: keep the two structs but back them with one unexported `orderingFilter` type carrying a `kind` discriminator (`Gt` / `Lt`) and a single `IsMatch` method; expose `GreaterFilter` and `LessFilter` as thin constructors / type aliases to preserve the public API and existing test fixtures
+   - Acceptance: `TestGreaterFilter_IsMatch` and `TestLessFilter_IsMatch` pass unchanged; the clone between the two files no longer appears in `dupl`
+2. Unify `newAndFilter` / `newOrFilter`
+   - Extract `buildBinaryFilter(operands []interface{}, kind string, ctor func([]IFilter) IFilter) (IFilter, error)` and have both factories call it with their respective `kind` constant and constructor
+   - Acceptance: `TestAndFilter_IsMatch` and `TestOrFilter_IsMatch` pass unchanged; the clone within `factory-filter-impl.go` no longer appears in `dupl`
+3. Unify the Command/Query `Execute` schema branch in `impl_openapi.go`
+   - Replace the two `if t.Kind() == … && op == Execute { … }` blocks with a single dispatch through `appdef.IFunction`:
+
+     ```go
+     if op == appdef.OperationKind_Execute {
+         if fn, ok := t.(appdef.IFunction); ok {
+             g.generateFunctionExecuteSchemas(fn, op, schemas)
+         }
+     }
+     ```
+
+   - Add `generateFunctionExecuteSchemas(fn appdef.IFunction, op appdef.OperationKind, schemas map[string]interface{})` that handles `fn.Param()` and `fn.Result()` and returns early on `QNameANY` to preserve current semantics
+   - Acceptance: the OpenAPI integration tests in `pkg/sys/it` (e.g. `TestOpenAPI`, `TestQpv2*`) pass unchanged; the two clones inside `impl_openapi.go` no longer appear in `dupl`
+
+Verification
+
+- `go test ./pkg/processors/query/... ./pkg/processors/query2/...` passes
+- Affected integration tests under `pkg/sys/it` pass
+- `golangci-lint run --no-config --default=none --enable=dupl --tests=false ./pkg/processors/query/... ./pkg/processors/query2/...` reports 0 findings at the default threshold and ≤0 of the three sites above at threshold 75
+- `golangci-lint run ./pkg/processors/query/... ./pkg/processors/query2/...` reports no new findings in any other linter


### PR DESCRIPTION
```yaml
change_id: 2605280725-dedup-query-query2-prod-dupl
type: refactor
issue_url: https://untill.atlassian.net/browse/AIR-4089
scope: apps
```
## Why

The `dupl` linter flags three independent copy-paste clones in the production code of the query and query2 processor packages. Each clone duplicates a small but non-trivial behaviour fragment, so any future change must be mirrored across the duplicated sites or the branches will silently drift apart.

## What

Collapse the three clone sites in the query and query2 processor packages into single shared implementations:

- Unify the `Greater` / `Less` comparison filter behaviour into one ordered-comparison helper while preserving the existing public filter types
- Unify the `And` / `Or` logical-filter factories through a shared binary-filter builder
- Unify the Command and Query Execute OpenAPI schema branches via a single dispatch through the common function interface, preserving the existing skip-on-any-qname semantics
- No behaviour change: the externally observable behaviour to preserve is the exact result of `IsMatch` for every supported `DataKind`, the error messages produced by the filter factories, and the OpenAPI document generated for command and query Execute endpoints

## How

Decisions:

- Site 1: keep `GreaterFilter` and `LessFilter` as the public types; both delegate `IsMatch` to one shared unexported routine carrying a comparison discriminator (`gt` / `lt`) so the `switch` over `appdef.DataKind_*` lives in one place and adding a new kind happens once
- Site 2: extract `buildBinaryFilter` in `factory-filter-impl.go` that takes the operands, the filter kind constant, and a constructor closure; `newAndFilter` and `newOrFilter` become thin wrappers around it
- Site 3: dispatch the Execute branch in `impl_openapi.go` through `appdef.IFunction` (the common ancestor of `ICommand` and `IQuery`) and a new `generateFunctionExecuteSchemas` helper. The helper preserves the existing semantics that, when `Param().QName() == QNameANY`, both the param-schema component generation and the matching `Result()` processing are skipped for that op (originally achieved via `continue` on the outer `for op, fields := range ops` loop)
- Do not change the public API of `GreaterFilter`, `LessFilter`, `AndFilter`, `OrFilter`, `newAndFilter`, `newOrFilter`, `CreateOpenAPISchema`, or `schemaGenerator`

Out of scope:

- Test-file duplication (addressed separately under the `pkg/appdef` / `pkg/processors/query` test-dedup work)
- Sub-threshold (<75 token) handler boilerplate clones in `query2/impl.go`, `impl_cdocs_handler.go`, `impl_query_handler.go`, `impl_view_handler.go`, `interface.go`, `util.go`
- The `query2/types.go` `case DataKind_int32` / `case DataKind_string` filter-loader pair

References:

- [GreaterFilter implementation](../../../../../pkg/processors/query/filter-greater-impl.go)
- [LessFilter implementation](../../../../../pkg/processors/query/filter-less-impl.go)
- [And/Or filter factories](../../../../../pkg/processors/query/factory-filter-impl.go)
- [OpenAPI schema generator](../../../../../pkg/processors/query2/impl_openapi.go)


---
Content omitted. See change.md for full details.
