### PR TITLE
fix(apps): Correct parser data type string names [AIR-4109]

### DIFF
--- a/pkg/parser/impl_test.go
+++ b/pkg/parser/impl_test.go
@@ -2936,6 +2936,41 @@ func Test_Jobs(t *testing.T) {
 }
 
 func Test_DataTypes(t *testing.T) {
+	t.Run("String", func(t *testing.T) {
+		varcharMaxLen := uint64(10)
+		bytesMaxLen := uint64(20)
+
+		cases := []struct {
+			name string
+			typ  DataType
+			want string
+		}{
+			{name: "varchar with max len", typ: DataType{Varchar: &TypeVarchar{MaxLen: &varcharMaxLen}}, want: "varchar[10]"},
+			{name: "varchar default max len", typ: DataType{Varchar: &TypeVarchar{}}, want: fmt.Sprintf("varchar[%d]", appdef.DefaultFieldMaxLength)},
+			{name: "int8", typ: DataType{Int8: true}, want: "int8"},
+			{name: "int16", typ: DataType{Int16: true}, want: "int16"},
+			{name: "int32", typ: DataType{Int32: true}, want: "int32"},
+			{name: "int64", typ: DataType{Int64: true}, want: "int64"},
+			{name: "float32", typ: DataType{Float32: true}, want: "float32"},
+			{name: "float64", typ: DataType{Float64: true}, want: "float64"},
+			{name: "qname", typ: DataType{QName: true}, want: "qname"},
+			{name: "bool", typ: DataType{Bool: true}, want: "bool"},
+			{name: "bytes with max len", typ: DataType{Bytes: &TypeBytes{MaxLen: &bytesMaxLen}}, want: "bytes[20]"},
+			{name: "bytes default max len", typ: DataType{Bytes: &TypeBytes{}}, want: fmt.Sprintf("bytes[%d]", appdef.DefaultFieldMaxLength)},
+			{name: "blob", typ: DataType{Blob: true}, want: "blob"},
+			{name: "timestamp", typ: DataType{Timestamp: true}, want: "timestamp"},
+			{name: "currency", typ: DataType{Currency: true}, want: "currency"},
+			{name: "unknown", typ: DataType{}, want: "?"},
+		}
+
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				require := require.New(t)
+
+				require.Equal(c.want, c.typ.String())
+			})
+		}
+	})
 
 	require := assertions(t)
 	schema, err := require.AppSchema(`APPLICATION test();

--- a/pkg/parser/types.go
+++ b/pkg/parser/types.go
@@ -360,9 +360,9 @@ func (q DataType) String() (s string) {
 	} else if q.Int64 {
 		return "int64"
 	} else if q.Float32 {
-		return "int32"
+		return "float32"
 	} else if q.Float64 {
-		return "int64"
+		return "float64"
 	} else if q.QName {
 		return "qname"
 	} else if q.Bool {
@@ -574,7 +574,7 @@ type RateValueTimeUnit struct {
 }
 
 type RateValue struct {
-	Count           *uint32              `parser:"(@Int"`
+	Count           *uint32           `parser:"(@Int"`
 	Variable        *DefQName         `parser:"| @@) 'PER'"`
 	TimeUnitAmounts *uint32           `parser:"@Int?"`
 	TimeUnit        RateValueTimeUnit `parser:"@@"`

--- a/uspecs/changes/archive/2605/2605281244-fix-parser-datatype-string/change.md
+++ b/uspecs/changes/archive/2605/2605281244-fix-parser-datatype-string/change.md
@@ -1,0 +1,67 @@
+---
+change_id: 2605281228-fix-parser-datatype-string
+type: fix
+issue_url: https://untill.atlassian.net/browse/AIR-4109
+scope: apps
+---
+
+# Change request: Correct parser data type string names
+
+Refs:
+
+- [AIR-4109: voedger: fix wrong cases in parser/DataType.String()](./issue-AIR-4109.md)
+
+## Why
+
+The parser data type string conversion reports `Float32` and `Float64` as integer type names. This produces misleading string representations for floating-point data types and can propagate wrong type names to parser consumers.
+
+## What
+
+`DataType.String()` returns integer type names for floating-point parser data types.
+
+```text
+VSQL schema contains a float32 or float64 data type
+      |
+      v
+parser builds a DataType value
+      |
+      v
+DataType.String() maps Float32/Float64 cases   <-- fault: returns int32/int64
+      |
+      v
+consumer receives the wrong data type name      (symptom)
+```
+
+`DataType.String()` returns `float32` for `Float32` and `float64` for `Float64`, while preserving the existing names for all other data types.
+
+## How
+
+Decisions:
+
+- Correct only the `Float32` and `Float64` branches in `DataType.String()`; keep all parser grammar and data-kind analysis behavior unchanged
+- Cover the string conversion with focused parser tests so future integer/float mapping regressions are caught directly
+
+Out of scope:
+
+- Changing VSQL parsing aliases such as `real`, `float`, or `double precision`
+- Changing appdef data kind mapping or storage representation for floating-point fields
+
+References:
+
+- [parser data type string conversion](../../../../../pkg/parser/types.go)
+- [parser data type tests](../../../../../pkg/parser/impl_test.go)
+
+## Construction
+
+- [x] update: [parser data type tests](../../../../../pkg/parser/impl_test.go)
+  - add focused assertions that cover every `DataType.String()` return branch, including `float32` for `Float32` and `float64` for `Float64`
+  - preserve existing data-kind parsing assertions for VSQL aliases such as `real`, `float`, and `double precision`
+
+- [x] update: [parser data type string conversion](../../../../../pkg/parser/types.go)
+  - change only the `Float32` and `Float64` cases in `DataType.String()` to return `float32` and `float64`
+  - keep the current return values for all other data type cases
+  - keep gofmt-applied struct tag alignment changes in the same file behavior-neutral
+
+- [x] verify: `go test ./pkg/parser -run Test_DataTypes -count=1` passes
+
+- [x] verify: `go test ./pkg/parser -count=1` passes

--- a/uspecs/changes/archive/2605/2605281244-fix-parser-datatype-string/issue-AIR-4109.md
+++ b/uspecs/changes/archive/2605/2605281244-fix-parser-datatype-string/issue-AIR-4109.md
@@ -1,0 +1,16 @@
+# voedger: fix wrong cases in parser/DataType.String()
+
+- URL: https://untill.atlassian.net/browse/AIR-4109
+- ID: AIR-4109
+- State: In Progress
+- Author: unknown
+- Labels: none
+- Assignees: Denis Gribanov
+
+## Description
+
+Why
+parser/DataType.String() has wrong result for Float32 (int32) and Float64 (int64) data types
+
+What
+return float32 and float64 respectively

--- a/uspecs/changes/archive/2605/2605281244-fix-parser-datatype-string/issue-AIR-4109.md
+++ b/uspecs/changes/archive/2605/2605281244-fix-parser-datatype-string/issue-AIR-4109.md
@@ -3,7 +3,7 @@
 - URL: https://untill.atlassian.net/browse/AIR-4109
 - ID: AIR-4109
 - State: In Progress
-- Author: unknown
+- Author: Denis Gribanov
 - Labels: none
 - Assignees: Denis Gribanov
 


### PR DESCRIPTION
```yaml
change_id: 2605281228-fix-parser-datatype-string
type: fix
issue_url: https://untill.atlassian.net/browse/AIR-4109
scope: apps
```
## Why

The parser data type string conversion reports `int32` and `int64` for Float32 and Float64 data kinds. This produces misleading string representations for floating-point data types and can propagate wrong type names to parser consumers.

## What

`DataType.String()` returns integer type names for floating-point parser data types.

```text
VSQL schema contains a float32 or float64 data type
      |
      v
parser builds a DataType value
      |
      v
DataType.String() maps Float32/Float64 cases   <-- fault: returns int32/int64
      |
      v
consumer receives the wrong data type name      (symptom)
```

`DataType.String()` returns `float32` for `Float32` and `float64` for `Float64`, while preserving the existing names for all other data types.

## How

Decisions:

- Correct only the `Float32` and `Float64` branches in `DataType.String()`; keep all parser grammar and data-kind analysis behavior unchanged
- Cover the string conversion with focused parser tests so future integer/float mapping regressions are caught directly

Out of scope:

- Changing VSQL parsing aliases such as `real`, `float`, or `double precision`
- Changing appdef data kind mapping or storage representation for floating-point fields


---
Content omitted. See change.md for full details.
