### PR TITLE
feat: Skill enforcing the correct copyright header on new files [AIR-4097]

### DIFF
--- a/.claude/skills/copyright-header/SKILL.md
+++ b/.claude/skills/copyright-header/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: copyright-header
+description: Use this skill whenever creating a new source file in this repository with extension `.go` (including `_test.go`) or `.vsql`. Emits the canonical copyright header with the current calendar year, the legal entity `unTill Software Development Group B.V.`, and an `@author` line populated from the current Git user (`git config user.name`). Does not apply to files that already exist; do not rewrite committed headers.
+user-invocable: false
+---
+
+## When to use
+
+- Creating any new `.go` file (production or `_test.go`)
+- Creating any new `.vsql` file
+
+## When not to use
+
+- Editing an existing file - leave its header untouched even if it uses the legacy wording
+- Generated files that already carry a generator-specific header (e.g. `// Code generated ... DO NOT EDIT.`) - keep the generator header
+
+## Procedure
+
+1. Resolve the current calendar year (`<YEAR>`)
+2. Resolve `<AUTHOR>` by running `git config user.name`; if it is empty, fall back to the configured commit identity in the active environment
+3. Choose the template by file extension:
+   - `.go` -> Go template
+   - `.vsql` -> VSQL template
+4. Emit the header as the first lines of the file, followed by one blank line, then the package / SQL statements
+5. Do not add a trailing period, do not localize the entity name, do not abbreviate it
+
+## Templates
+
+### Go (`.go`, `_test.go`)
+
+```go
+/*
+ * Copyright (c) <YEAR>-present unTill Software Development Group B.V.
+ * @author <AUTHOR>
+ */
+
+package <package>
+```
+
+### VSQL (`.vsql`)
+
+```sql
+-- Copyright (c) <YEAR>-present unTill Software Development Group B.V.
+-- @author <AUTHOR>
+
+<first SQL statement>
+```
+
+## Rules
+
+- The year is fixed at file creation; it is not bumped on later edits
+- Exactly one `@author` line per new file (the creator); additional authors may be appended on subsequent edits as separate `@author` lines, but that is out of scope for this skill
+- Never substitute `unTill Pro, Ltd.`, `Sigma-Soft, Ltd.`, or any other historical entity - those wordings remain only on files that already carry them
+- Never wrap the header in an extra blank comment line above or below the `/*` / `*/`
+- For Go, the header must precede the `package` clause with exactly one blank line between them
+- For VSQL, the header must precede the first statement with exactly one blank line between them
+
+## Anti-patterns
+
+bad -- wrong entity, missing author:
+
+```go
+/*
+ * Copyright (c) 2021-present unTill Pro, Ltd.
+ */
+
+package foo
+```
+
+bad -- year fixed to a past value on a file created today:
+
+```go
+/*
+ * Copyright (c) 2021-present unTill Software Development Group B.V.
+ * @author Jane Doe
+ */
+```
+
+bad -- VSQL using a block comment instead of line comments:
+
+```sql
+/*
+ * Copyright (c) 2026-present unTill Software Development Group B.V.
+ * @author Jane Doe
+ */
+
+ABSTRACT WORKSPACE Workspace ();
+```
+
+good -- Go, current year, current Git user:
+
+```go
+/*
+ * Copyright (c) 2026-present unTill Software Development Group B.V.
+ * @author Jane Doe
+ */
+
+package foo
+```
+
+good -- VSQL, current year, current Git user:
+
+```sql
+-- Copyright (c) 2026-present unTill Software Development Group B.V.
+-- @author Jane Doe
+
+ABSTRACT WORKSPACE Workspace ();
+```

--- a/uspecs/changes/archive/2605/2605291007-correct-copyright-skill/change.md
+++ b/uspecs/changes/archive/2605/2605291007-correct-copyright-skill/change.md
@@ -1,5 +1,5 @@
 ---
-change_id: 2605290953-correct-copyright-skill
+change_id: 2605291007-correct-copyright-skill
 type: feat
 issue_url: https://untill.atlassian.net/browse/AIR-4097
 ---

--- a/uspecs/changes/archive/2605/2605291007-correct-copyright-skill/change.md
+++ b/uspecs/changes/archive/2605/2605291007-correct-copyright-skill/change.md
@@ -1,0 +1,48 @@
+---
+change_id: 2605290953-correct-copyright-skill
+type: feat
+issue_url: https://untill.atlassian.net/browse/AIR-4097
+---
+
+# Change request: Skill enforcing the correct copyright header on new files
+
+Refs:
+
+- [AIR-4097: implement skill that will force to produce the correct copyright](./issue-AIR-4097.md)
+
+## Why
+
+AI-assisted file creation currently emits an outdated copyright header attributed to the wrong legal entity and without an author line, which then has to be corrected by hand on every new file. A repository-level skill is needed so the agent always produces the canonical header for the current owner and the current contributor without manual intervention.
+
+## What
+
+Add a development-tooling skill that governs the copyright header authored on every newly created source file in the repository:
+
+- Triggers automatically whenever the agent creates a new source file in the Go codebase or in the `sql/vsql` sources
+- Emits a header that uses the current calendar year, the current legal entity, and the current Git user as author
+- Replaces the previously emitted legacy header so that no new file is committed with the outdated wording
+- Leaves existing files and existing headers untouched, so the change has no effect on already-committed sources
+
+## How
+
+Decisions:
+
+- Encode the policy as a Claude Code skill at `.claude/skills/copyright-header/SKILL.md`, mirroring the layout of the existing `golang-fmt-string-escape` skill
+- Phrase the `description` so the skill auto-activates on creation of any `.go` or `.vsql` source file (the only file families called out by the issue)
+- Pin the entity to `unTill Software Development Group B.V.` and require the current calendar year, replacing the legacy `unTill Pro, Ltd.` / `Sigma-Soft, Ltd.` wording for newly created files
+- Require an `@author <name>` line populated from the current Git user (`git config user.name`)
+- Provide two header templates verbatim in the skill body: a `/* ... */` block for Go, a `-- ...` line block for VSQL
+- Apply only when the agent creates a new file; existing files keep their committed header
+
+Out of scope:
+
+- Rewriting copyright headers on already-committed files
+- Updating the year on files that change in subsequent edits
+- Mirroring the policy as an `.augment/rules/` always-applied rule (deferred unless the skill proves unreliable)
+
+References:
+
+- [existing Claude skills folder](../../../../../.claude/skills)
+- [reference skill layout and frontmatter](../../../../../.claude/skills/golang-fmt-string-escape/SKILL.md)
+- [Go header example](../../../../../pkg/itokensjwt/types.go)
+- [VSQL header example](../../../../../pkg/sys/sys.vsql)

--- a/uspecs/changes/archive/2605/2605291007-correct-copyright-skill/issue-AIR-4097.md
+++ b/uspecs/changes/archive/2605/2605291007-correct-copyright-skill/issue-AIR-4097.md
@@ -1,0 +1,31 @@
+# implement skill that will force to produce the correct copyright
+
+- URL: https://untill.atlassian.net/browse/AIR-4097
+- ID: AIR-4097
+- State: in-progress
+- Author: Denis Gribanov
+- Labels: none
+- Assignees: Denis Gribanov
+
+## Why
+
+AI generates wrong copyright for new files like:
+
+```text
+/*
+ * Copyright (c) 2021-present unTill Pro, Ltd.
+ */
+```
+
+## What
+
+implement  skill that will force to produce the correct header comment for new files:
+
+```text
+/*
+ * Copyright (c) <current year>-present unTill Software Development Group B.V.
+ * @author <current git user>
+ */
+```
+
+same for sql\vsql


### PR DESCRIPTION
```yaml
change_id: 2605290953-correct-copyright-skill
type: feat
issue_url: https://untill.atlassian.net/browse/AIR-4097
```
## Why

AI-assisted file creation currently emits an outdated copyright header attributed to the wrong legal entity and without an author line, which then has to be corrected by hand on every new file. A repository-level skill is needed so the agent always produces the canonical header for the current owner and the current contributor without manual intervention.

## What

Add a development-tooling skill that governs the copyright header authored on every newly created source file in the repository:

- Triggers automatically whenever the agent creates a new source file in the Go codebase or in the `sql/vsql` sources
- Emits a header that uses the current calendar year, the current legal entity, and the current Git user as author
- Replaces the previously emitted legacy header so that no new file is committed with the outdated wording
- Leaves existing files and existing headers untouched, so the change has no effect on already-committed sources

## How

Decisions:

- Encode the policy as a Claude Code skill at `.claude/skills/copyright-header/SKILL.md`, mirroring the layout of the existing `golang-fmt-string-escape` skill
- Phrase the `description` so the skill auto-activates on creation of any `.go` or `.vsql` source file (the only file families called out by the issue)
- Pin the entity to `unTill Software Development Group B.V.` and require the current calendar year, replacing the legacy `unTill Pro, Ltd.` / `Sigma-Soft, Ltd.` wording for newly created files
- Require an `@author <name>` line populated from the current Git user (`git config user.name`)
- Provide two header templates verbatim in the skill body: a `/* ... */` block for Go, a `-- ...` line block for VSQL
- Apply only when the agent creates a new file; existing files keep their committed header

Out of scope:

- Rewriting copyright headers on already-committed files
- Updating the year on files that change in subsequent edits
- Mirroring the policy as an `.augment/rules/` always-applied rule (deferred unless the skill proves unreliable)

References:

- [existing Claude skills folder](../../../../../.claude/skills)
- [reference skill layout and frontmatter](../../../../../.claude/skills/golang-fmt-string-escape/SKILL.md)
- [Go header example](../../../../../pkg/itokensjwt/types.go)


---
Content omitted. See change.md for full details.
