### PR TITLE
docs: Derive `apps` context architecture [AIR-4154]

### DIFF
--- a/uspecs/changes/archive/2606/2606031402-derive-app-context-architecture/change.md
+++ b/uspecs/changes/archive/2606/2606031402-derive-app-context-architecture/change.md
@@ -1,0 +1,66 @@
+---
+change_id: 2606030916-derive-app-context-architecture
+type: docs
+issue_url: https://untill.atlassian.net/browse/AIR-4154
+---
+
+# Change request: Derive `apps` context architecture
+
+Refs:
+
+- [AIR-4154: voedger: derive architecture from app context](./issue-AIR-4154.md)
+
+## Why
+
+The `apps` context listed in `uspecs/specs/prod/domain.md` has no Context Architecture (`apps/arch.md`); existing files under `uspecs/specs/prod/apps/` cover narrower concerns (sequences, VVM orchestration, logging) but none provides a top-level architecture reference for deployment and processing.
+
+## What
+
+Add architecture specifications for the `apps` context, derived from existing documentation and the codebase:
+
+- Add a Context Architecture at `uspecs/specs/prod/apps/arch.md` that overviews the `apps` context and links to its subsystem architectures
+- Add a Context Subsystem Architecture `uspecs/specs/prod/apps/arch-deployment.md` covering vsql DDL, deployment descriptors, the app partitions engine (deploy and undeploy of app partitions), VVM startup bootstrap (`pkg/btstrp`: initializing the cluster-app workspace, registering built-in and sidecar apps via `c.cluster.DeployApp`, and deploying their app partitions), and protection against incompatible schema and deployment descriptor changes
+- Add a Context Subsystem Architecture `uspecs/specs/prod/apps/arch-processing.md` covering the processor pipelines for Command, Query v1, Query v2, Sync Actualizer, Async Actualizer, Scheduler, BLOB, and N10N; authnz/ACL enforcement points within those pipelines (principal token validation and ACL checks delegated to the `auth` context); response sending; and the app partitions engine (invoke extensions on app partitions during request processing)
+- Introduce the app partitions engine once in `arch.md` as a shared component and link to both subsystem chapters for its deployment-time and processing-time roles
+- Leave the existing `arch-sequences.md`, `arch-vvm-orch.md`, `arch2-sequences.md`, and `logging--td.md` untouched and reference them from `arch.md` where relevant
+- Give reviewers and contributors a single architecture reference for the `apps` context that complements `uspecs/specs/prod/domain.md`
+
+## How
+
+Decisions:
+
+- Adopt uspecs-td conventions: `arch.md` for the Context Architecture, `arch-{subsystem}.md` for Context Subsystem Architectures
+- Introduce the app partitions engine once in `apps/arch.md` and cross-link from both subsystem chapters for its deploy/undeploy and invoke-extensions roles
+- Derive `apps/arch-deployment.md` from `pkg/btstrp`, `pkg/cluster` (`c.cluster.DeployApp`), `pkg/appparts` (`AppDeploymentDescriptor`, `DeployApp`, `DeployAppPartitions`), and VSQL DDL handling in `pkg/parser`
+- Derive `apps/arch-processing.md` from `pkg/processors/{command,query,query2,actualizers,schedulers,blobber,n10n}`, with authnz/ACL enforcement points described as calls into `pkg/iauthnz` and response sending via `pkg/bus`
+- Link existing `apps/arch-sequences.md`, `apps/arch-vvm-orch.md`, `apps/arch2-sequences.md`, and `apps/logging--td.md` from `apps/arch.md` without modifying them
+
+Out of scope:
+
+- Modifying or consolidating existing `apps/arch-sequences.md`, `apps/arch-vvm-orch.md`, `apps/arch2-sequences.md`, `apps/logging--td.md`
+- Cluster-provisioning bootstrap performed by `cmd/ctool`
+- Authnz/ACL policy and identity model owned by the `auth` context
+- Any behavior change to deployment or processing code paths
+
+References:
+
+- [apps context in the domain specification](../../../../../uspecs/specs/prod/domain.md)
+- [existing apps arch-sequences subsystem](../../../../../uspecs/specs/prod/apps/arch-sequences.md)
+- [existing apps arch-vvm-orch subsystem](../../../../../uspecs/specs/prod/apps/arch-vvm-orch.md)
+- [auth context architecture cross-referenced for authnz/ACL](../../../../../uspecs/specs/prod/auth/arch.md)
+- [VVM startup bootstrap package](../../../../../pkg/btstrp)
+- [cluster app DeployApp command](../../../../../pkg/cluster)
+- [app partitions engine package](../../../../../pkg/appparts)
+- [processors packages (command, query, query2, actualizers, schedulers, blobber, n10n)](../../../../../pkg/processors)
+- [VSQL parser package](../../../../../pkg/parser)
+- [authnz interface used at enforcement points](../../../../../pkg/iauthnz)
+- [response sender bus package](../../../../../pkg/bus)
+
+## Technical design
+
+- [x] create: [apps/arch.md](../../../../specs/prod/apps/arch.md)
+  - Context Architecture for the `apps` context: overview, shared app partitions engine, links to subsystem chapters and existing `arch-*.md`
+- [x] create: [apps/arch-deployment.md](../../../../specs/prod/apps/arch-deployment.md)
+  - Context Subsystem Architecture for deployment: vsql DDL, deployment descriptors, app partitions engine (deploy/undeploy), VVM startup bootstrap, schema/descriptor change protection
+- [x] create: [apps/arch-processing.md](../../../../specs/prod/apps/arch-processing.md)
+  - Context Subsystem Architecture for processing: processor pipelines, authnz/ACL enforcement, response sending, app partitions engine (invoke extensions)

--- a/uspecs/changes/archive/2606/2606031402-derive-app-context-architecture/decisions.md
+++ b/uspecs/changes/archive/2606/2606031402-derive-app-context-architecture/decisions.md
@@ -1,0 +1,119 @@
+# Decisions: derive-app-context-architecture
+
+## Inconsistency: `change.md` says "App context", but `uspecs/specs/prod/domain.md` and the folder layout name the context `apps`
+
+Decision: Rename "App context" to "`apps` context" throughout `change.md` (title, Why, What)
+
+- Pros: matches `domain.md` and the `uspecs/specs/prod/apps/` folder verbatim; avoids introducing a second name for the same context; aligns with the uspecs convention of using the lowercase identifier in prose
+- Cons: change request title becomes slightly less prose-like ("Derive `apps` context architecture")
+- Confidence: high
+
+Alternatives:
+
+1. Keep "App context" wording but add a one-line clarification in Why that "App context" refers to the `apps` context in `domain.md`
+   - Pros: keeps the title human-readable; preserves the issue's wording
+   - Cons: introduces a synonym readers must learn; risks the same drift recurring in the derived specs
+   - Confidence: low
+2. Rename the context in `domain.md` from `apps` to `App` to match the change request
+   - Pros: aligns documentation with the issue title
+   - Cons: out-of-scope rename touching many references; breaks existing folder name `apps/` and existing files (`arch-sequences.md`, `arch-vvm-orch.md`, `vsql-*.feature`, `logging--td.md`); not what the issue asks for
+   - Confidence: low
+
+## Inconsistency: `change.md` claims the `apps` context "has no architecture specification", but `uspecs/specs/prod/apps/` already contains architecture files
+
+Decision: Add a new Context Architecture (`apps/arch.md`) plus two new Context Subsystem Architectures (`apps/arch-deployment.md` and `apps/arch-processing.md`); leave the existing `arch-sequences.md`, `arch-vvm-orch.md`, `arch2-sequences.md`, and `logging--td.md` untouched and reference them from `arch.md` where relevant
+
+- Pros: matches uspecs-td layering (Context Architecture + Context Subsystem Architecture); minimal blast radius; preserves prior work and lets it be reorganized later if needed; aligns Why ("no overall architecture reference") with What ("split into deployment and processing")
+- Cons: temporary overlap between `arch.md` overview and the older `arch-*.md` files until they are reconciled; reader must follow links to get full picture
+- Confidence: high
+
+Alternatives:
+
+1. Add only `apps/arch.md` containing both deployment and processing as sections inside one file; do not create separate subsystem files
+   - Pros: single document, easier for readers to scan
+   - Cons: violates the uspecs-td convention that subsystem architectures live in `arch-{subsystem}.md`; contradicts the explicit "split into deployment subsystem and processing subsystem" wording in What
+   - Confidence: low
+2. Replace the existing `arch-sequences.md`, `arch-vvm-orch.md`, and `arch2-sequences.md` with the new deployment/processing architecture by folding their content into the new files
+   - Pros: leaves a cleaner final layout without overlap
+   - Cons: substantially out of scope for a `docs` change; risks losing detail or context; not requested by the issue; high review burden
+   - Confidence: low
+
+## Ambiguity: "the app partitions engine" is listed under both the deployment subsystem and the processing subsystem
+
+Decision: Keep the engine in both subsystem files, split by role -- deployment covers deploy and undeploy of app partitions, processing covers invoking extensions on app partitions during request processing; introduce the engine once in `arch.md` as a shared component and link to both subsystem chapters
+
+- Pros: matches the codebase, where the app partitions engine genuinely participates in both phases; gives readers a single conceptual entry point in `arch.md`; keeps each subsystem self-contained; user-provided role split is precise and actionable
+- Cons: requires explicit cross-references and a brief shared definition in `arch.md` to avoid duplication drift
+- Confidence: user-provided
+
+Alternatives:
+
+1. Place the app partitions engine only in the deployment subsystem; processing references it but does not describe it
+   - Pros: avoids duplication; one canonical location
+   - Cons: processing pipelines are inseparable from how requests reach the right app partition, so the processing chapter would be incomplete without describing the engine's runtime contract
+   - Confidence: medium
+2. Place the app partitions engine only in the processing subsystem; deployment references it but does not describe it
+   - Pros: avoids duplication; one canonical location
+   - Cons: bootstrap and deployment-time concerns (partition allocation, engine startup, descriptor changes) genuinely belong in deployment; placing them under processing misclassifies them
+   - Confidence: low
+3. Promote the app partitions engine to its own Context Subsystem Architecture (`apps/arch-app-partitions-engine.md`), referenced by both deployment and processing
+   - Pros: cleanest separation; no duplication; engine gets a dedicated specification
+   - Cons: expands scope beyond the two subsystems the issue asks for; adds a third deliverable; risks fragmenting deployment and processing narratives
+   - Confidence: medium
+
+## Ambiguity: "authnz, ACL" in the processing subsystem overlaps with the `auth` context defined in `domain.md`
+
+Decision: Reword to describe `apps` processing as covering "authnz/ACL enforcement points within request pipelines (principal token validation and ACL checks delegated to the `auth` context)"; the `apps` processing subsystem describes where and how the pipeline applies authnz/ACL, while the rules and identity model remain owned by the `auth` context
+
+- Pros: respects the existing context boundary in `domain.md`; aligns with the codebase pattern where processors invoke auth/iauthnz to validate tokens and check ACL; gives clear scope to `arch-processing.md` (enforcement, not policy)
+- Cons: slightly longer wording; requires `arch-processing.md` to cross-link the `auth` context
+- Confidence: high
+
+Alternatives:
+
+1. Keep "authnz, ACL" verbatim and let `arch-processing.md` cover both enforcement and policy mechanics for the `apps` context
+   - Pros: shortest wording in `change.md`
+   - Cons: duplicates ownership claimed by the `auth` context; readers cannot tell which context's spec is authoritative; risks contradictions between `apps/arch-processing.md` and `auth/arch.md`
+   - Confidence: low
+2. Drop "authnz, ACL" from the processing subsystem and place them entirely in the `auth` context architecture (out of scope for this change)
+   - Pros: cleanest separation by context
+   - Cons: `arch-processing.md` would omit a central concern of every request flow (the pipeline cannot be described without naming its authnz/ACL steps); contradicts the issue body which explicitly lists "authnz, acl"
+   - Confidence: low
+
+## Vagueness: "processor pipelines" in the processing subsystem does not enumerate which processors are in scope
+
+Decision: List the in-scope processors explicitly in the What bullet -- Command, Query v1, Query v2, Sync Actualizer, Async Actualizer, Scheduler, BLOB, and N10N
+
+- Pros: matches the codebase under `pkg/processors/*`; gives `arch-processing.md` a concrete table of contents; avoids re-litigating scope later
+- Cons: longest bullet in the What section; if a new processor appears later, the change request becomes stale (acceptable for a docs change)
+- Confidence: high
+
+Alternatives:
+
+1. Cover only the request-driven processors (Command, Query v1, Query v2, BLOB, N10N) and treat Sync Actualizer, Async Actualizer, and Scheduler as separate "background processors" mentioned briefly with a forward reference
+   - Pros: keeps `arch-processing.md` focused on the user-request flow; matches how readers usually approach a processing chapter
+   - Cons: actualizers and scheduler are central to event sourcing in Voedger; deferring them risks omitting authnz/ACL/response concerns that differ for non-request processors
+   - Confidence: medium
+2. Cover only Command and Query processors; everything else (BLOB, N10N, actualizers, scheduler) is out of scope and listed as future architecture work
+   - Pros: smallest scope; fastest to deliver
+   - Cons: contradicts the issue body which says "all processors pipelines"; leaves the processing chapter incomplete
+   - Confidence: low
+
+## Vagueness: "bootstrap" in the deployment subsystem does not say what is being bootstrapped
+
+Decision: Scope "bootstrap" to the VVM startup bootstrap performed by `pkg/btstrp` -- initializing the cluster-app workspace, registering built-in and sidecar apps via `c.cluster.DeployApp`, and deploying their app partitions
+
+- Pros: matches the deployment subsystem's existing focus (vsql DDL, deployment descriptors, app partitions engine -- all driven by the same `c.cluster.DeployApp` path); aligns with the codebase package `pkg/btstrp`; keeps cluster provisioning (`ctool`) in the `routing`/infrastructure space where it belongs
+- Cons: explicitly excludes cluster-provisioning bootstrap; readers seeking that topic must look in `ctool`
+- Confidence: high
+
+Alternatives:
+
+1. Cover both VVM startup bootstrap (`pkg/btstrp`) and cluster provisioning bootstrap (`ctool`) in `arch-deployment.md`
+   - Pros: single chapter for any "bootstrap" question a reader might ask
+   - Cons: `ctool` is an infrastructure/provisioning tool that lives outside the `apps` context; mixing it into `apps/arch-deployment.md` blurs context boundaries set by `domain.md`
+   - Confidence: low
+2. Leave "bootstrap" generic; let `arch-deployment.md` decide later
+   - Pros: keeps `change.md` short
+   - Cons: defers the vagueness instead of resolving it; the same question will resurface during spec authoring
+   - Confidence: low

--- a/uspecs/changes/archive/2606/2606031402-derive-app-context-architecture/issue-AIR-4154.md
+++ b/uspecs/changes/archive/2606/2606031402-derive-app-context-architecture/issue-AIR-4154.md
@@ -1,0 +1,18 @@
+# voedger: derive architecture from app context
+
+- URL: https://untill.atlassian.net/browse/AIR-4154
+- ID: AIR-4154
+- State: in-progress
+- Author: Denis Gribanov
+- Assignees: Denis Gribanov
+- Labels: none
+
+## Why
+
+missing architecture for App context mentioned in [domain.md](https://github.com/voedger/voedger/blob/main/uspecs/specs/prod/domain.md)
+
+## What
+
+- derive architeture from App context considering exisitng documentation and codebase. Devide the architecture to deployment and processing (processors).
+  - For deployment: consider vsql ddl, deployment desriptors, app partitions engine, bootstrap, protection against uncompatible schema and deployment descriptor change.
+  - For processing: consider all processors pipelines, authnz, acl, response sending, app partitions engine.

--- a/uspecs/specs/prod/apps/arch-deployment.md
+++ b/uspecs/specs/prod/apps/arch-deployment.md
@@ -1,0 +1,170 @@
+# Context subsystem architecture: prod/apps/deployment
+
+Apps deployment subsystem architecture for registering built-in and sidecar applications, deploying their partitions, and rejecting incompatible redeployments. Context-level overview: [arch.md](./arch.md).
+
+## External actors
+
+Roles:
+
+- `@VADeveloper`
+  - Supplies built-in app packages and sidecar app modules consumed at deployment time.
+
+- `@Admin`
+  - Operates the VVM process and triggers redeployment by restarting the VVM with updated app definitions.
+
+## Scenarios overview
+
+- **`Bootstrap VVM`**
+  - On VVM startup initialize the cluster app workspace, deploy the cluster app partition, register every built-in and sidecar app through `c.cluster.DeployApp`, and deploy their partitions.
+
+- **`Register app`**
+  - The cluster app validates compatibility against the previously stored `cluster.App` descriptor and writes the descriptor on first deployment.
+
+- **`Deploy app partitions`**
+  - The app partitions engine builds extension engine pools, deploys partition-scoped projector actualizers, and deploys schedulers per partition.
+
+- **`Reject incompatible redeployment`**
+  - Schema declarations and the deployment descriptor are cross-checked on every redeployment so a partially upgraded process cannot start with mismatched extensions or partition layout.
+
+Undeploy is not implemented: applications and partitions live for the lifetime of the VVM process; redeployment is performed by restarting the VVM with updated app definitions.
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- @VADeveloper
+    +-- @Admin
+    |
+    v
+Bootstrap
+    |
+    +-- [Bootstrap operator]
+    |
+    v
+Cluster app
+    |
+    +-- [c.cluster.DeployApp]
+    +-- [cluster.App uniqueness check]
+    |
+    v
+App partitions engine
+    |
+    +-- [DeployApp]
+    +-- [DeployAppPartitions]
+    +-- [Extension presence validator]
+    |
+    v
+Schema build
+    |
+    +-- [VSQL parser]
+    +-- [AppDef builder]
+    |
+    v
+State
+    |
+    +-- [(cluster.App)]
+    +-- [(AppStructs)]
+```
+
+### Bootstrap
+
+- `[Bootstrap operator]`
+  - Runs `btstrp.Bootstrap` once on VVM startup: initializes the cluster app workspace via `cluster.InitAppWS`, deploys the cluster app partition, then calls `c.cluster.DeployApp` for each built-in and sidecar app and deploys their partitions through the app partitions engine.
+  - Path to file: [pkg/btstrp/impl.go](../../../../pkg/btstrp/impl.go)
+
+### Cluster app
+
+- `[c.cluster.DeployApp]`
+  - Command on the cluster app workspace that takes `AppDeploymentDescriptor` (`AppQName`, `NumPartitions`, `NumAppWorkspaces`), rejects redeployment of `sys.cluster`, and either creates the `cluster.App` record or rejects mismatched `NumPartitions` / `NumAppWorkspaces` with `409 Conflict`.
+  - Path to file: [pkg/cluster/impl_deployapp.go](../../../../pkg/cluster/impl_deployapp.go)
+
+- `[cluster.App uniqueness check]`
+  - Looks up the `cluster.App` WDoc by unique `AppQName` to decide whether to insert a new descriptor or run the compatibility check.
+  - Path to file: [pkg/cluster/appws.vsql](../../../../pkg/cluster/appws.vsql)
+
+### App partitions engine
+
+- `[DeployApp]`
+  - Registers an application with the engine, builds `IAppStructs` (built-in path via `IAppStructsProvider.BuiltIn`, sidecar path via `IAppStructsProvider.New` keyed by `extModuleURLs`), and constructs per-`ProcessorKind` extension engine pools sized by `EnginePoolSize`. Redeploying the same app panics.
+  - Path to file: [pkg/appparts/impl.go](../../../../pkg/appparts/impl.go)
+
+- `[DeployAppPartitions]`
+  - For each partition ID creates an `appPartitionRT`, then concurrently deploys per-partition actualizers and schedulers using `IActualizerRunner` / `ISchedulerRunner`.
+  - Path to file: [pkg/appparts/impl.go](../../../../pkg/appparts/impl.go)
+
+- `[Extension presence validator]`
+  - Cross-checks the parsed `IAppDef` against the built-in extension registry so VSQL-declared extensions exist in code and stateless code-only extensions are tied to imported packages.
+  - Path to file: [pkg/appparts/impl_app.go](../../../../pkg/appparts/impl_app.go)
+
+### Schema build
+
+- `[VSQL parser]`
+  - Parses each `parser.PackageFS` into a `PackageSchemaAST` and merges them into an `AppSchemaAST` per app.
+  - Path to file: [pkg/parser/provide.go](../../../../pkg/parser/provide.go)
+
+- `[AppDef builder]`
+  - Materializes the merged schema into `appdef.IAppDef` via `parser.BuildAppDefs` and `builder.New`; the result is passed to `[DeployApp]`.
+  - Path to file: [pkg/vvm/impl_builder.go](../../../../pkg/vvm/impl_builder.go)
+
+### State
+
+- `[(cluster.App)]`
+  - WDoc in the cluster app workspace holding `AppQName`, `NumPartitions`, `NumAppWorkspaces` with a unique constraint on `AppQName`; written on first deployment and read on every redeployment.
+  - Path to file: [pkg/cluster/appws.vsql](../../../../pkg/cluster/appws.vsql)
+
+- `[(AppStructs)]`
+  - In-memory per-app structures (events, records, view records, resources, validators) used by the processing subsystem; created during `[DeployApp]`.
+  - Path to file: [pkg/istructsmem/appstruct-types.go](../../../../pkg/istructsmem/appstruct-types.go)
+
+## Scenarios
+
+### Bootstrap VVM
+
+```text
+[Bootstrap operator]
+  -> initClusterAppWS -> [(AppStructs)] for sys.cluster
+  -> [DeployApp](sys.cluster) -> [DeployAppPartitions](sys.cluster, [0])
+  -> for each built-in/sidecar app:
+       [c.cluster.DeployApp] -> [cluster.App uniqueness check] -> [(cluster.App)]
+  -> for each built-in/sidecar app:
+       [DeployApp](app) -> [DeployAppPartitions](app, [0..NumParts-1])
+```
+
+### Register app
+
+```text
+[c.cluster.DeployApp]
+  -> [cluster.App uniqueness check]
+       not found -> insert [(cluster.App)] {AppQName, NumPartitions, NumAppWorkspaces}
+       found     -> compare NumPartitions, NumAppWorkspaces
+                    mismatch -> 409 Conflict
+                    match    -> ok
+```
+
+### Deploy app partitions
+
+```text
+[DeployApp]
+  -> [VSQL parser] + [AppDef builder] -> appdef.IAppDef
+  -> [Extension presence validator]
+  -> build [extension engine pools] per ProcessorKind
+[DeployAppPartitions]
+  -> per partition:
+       deploy projector actualizers (async)
+       deploy schedulers (async)
+```
+
+### Reject incompatible redeployment
+
+```text
+[Bootstrap operator]
+  -> [c.cluster.DeployApp] -> [cluster.App uniqueness check]
+       descriptor mismatch (NumPartitions / NumAppWorkspaces) -> 409 Conflict, bootstrap fails
+  -> [DeployApp]
+       -> [Extension presence validator]
+            VSQL-declared extension missing in code      -> panic, bootstrap fails
+            built-in extension missing in VSQL           -> panic, bootstrap fails
+```

--- a/uspecs/specs/prod/apps/arch-processing.md
+++ b/uspecs/specs/prod/apps/arch-processing.md
@@ -115,7 +115,7 @@ State
 
 - `[Legacy ACL fallback]`
   - Falls back to `oldacl.IsOperationAllowed` when the new ACL denies, kept as a temporary bridge for Air; logged as `newACL not ok, but oldACL ok` when only the legacy path allows.
-  - Path to file: [pkg/processors/oldacl](../../../../pkg/processors/oldacl)
+  - Path to package: [pkg/processors/oldacl](../../../../pkg/processors/oldacl)
 
 ### Shared infrastructure
 
@@ -151,7 +151,7 @@ State
 
 - `[(BLOB storage)]`
   - BLOB byte storage targeted by `[BLOB processor]`.
-  - Path to file: [pkg/iblobstorage](../../../../pkg/iblobstorage)
+  - Path to package: [pkg/iblobstorage](../../../../pkg/iblobstorage)
 
 ## Scenarios
 

--- a/uspecs/specs/prod/apps/arch-processing.md
+++ b/uspecs/specs/prod/apps/arch-processing.md
@@ -1,0 +1,226 @@
+# Context subsystem architecture: prod/apps/processing
+
+Apps processing subsystem architecture for the command, query (v1 and v2), sync and async actualizer, scheduler, BLOB, and N10n pipelines that authenticate the caller, authorize against the workspace ACL, invoke extensions on application partitions, and return a response. Context-level overview: [arch.md](./arch.md).
+
+## External actors
+
+Systems:
+
+- `*Client`
+  - External caller invoking commands, queries, BLOB transfers, and N10n subscriptions over Voedger HTTP APIs.
+
+## Scenarios overview
+
+- **`Handle command`**
+  - Command pipeline authenticates the caller, authorizes the command and CUDs, executes the extension, writes the PLog event and CUDs, runs sync actualizers, sends the response, and notifies async actualizers.
+
+- **`Handle query`**
+  - Query pipeline (v1 or v2) authenticates the caller, authorizes the query, invokes the query extension, and streams result rows to the responder.
+
+- **`Run async actualizer`**
+  - Async actualizer watches the PLog notification channel, reads new events, and invokes each triggered projector extension on its partition.
+
+- **`Run scheduler job`**
+  - Scheduler waits for the next cron tick, borrows the partition, and invokes the job extension.
+
+- **`Handle BLOB transfer`**
+  - BLOB processor authenticates the caller, authorizes the operation, registers or looks up BLOB metadata via a paired command on the cluster app, streams BLOB bytes to or from storage, and returns the result to the responder.
+
+- **`Deliver N10n notification`**
+  - The command pipeline updates the N10n broker with the new PLog offset; subscribers (async actualizers and SSE clients) receive the update on their channels.
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- *Client
+    |
+    v
+Entry points
+    |
+    +-- [Command processor]
+    +-- [Query v1 processor]
+    +-- [Query v2 processor]
+    +-- [BLOB processor]
+    +-- [Async actualizer]
+    +-- [Scheduler]
+    |
+    v
+In-pipeline operators
+    |
+    +-- [Sync actualizer]
+    +-- [Authenticator call]
+    +-- [ACL check]
+    +-- [Legacy ACL fallback]
+    |
+    v
+Shared infrastructure
+    |
+    +-- [App partitions engine]
+    +-- [Bus responder]
+    +-- [N10n broker]
+    |
+    v
+State
+    |
+    +-- [(PLog)]
+    +-- [(WLog)]
+    +-- [(Records)]
+    +-- [(Views)]
+    +-- [(BLOB storage)]
+```
+
+### Entry points
+
+- `[Command processor]`
+  - Sync pipeline that borrows the partition, applies rate limits, authenticates, authorizes the command and parsed CUDs, executes the extension, runs the sync actualizer branch, validates and writes the PLog event and CUDs, and emits an N10n update on success.
+  - Path to file: [pkg/processors/command/provide.go](../../../../pkg/processors/command/provide.go)
+
+- `[Query v1 processor]`
+  - Sync pipeline behind the API v1 query route that borrows the partition, authorizes the query, invokes the query extension, and streams rows to the responder via a rows processor.
+  - Path to file: [pkg/processors/query/impl.go](../../../../pkg/processors/query/impl.go)
+
+- `[Query v2 processor]`
+  - API v2 sync pipeline that dispatches by API path (`Queries`, `Views`, `Docs`, …) to the matching handler before invoking the extension and streaming rows.
+  - Path to file: [pkg/processors/query2/impl.go](../../../../pkg/processors/query2/impl.go)
+
+- `[BLOB processor]`
+  - Pipeline that registers or reads BLOB metadata through a paired command on the cluster app and streams BLOB bytes between client and BLOB storage via a `bus.IRequestSender`.
+  - Path to file: [pkg/processors/blobber/impl.go](../../../../pkg/processors/blobber/impl.go)
+
+- `[Async actualizer]`
+  - Per-projector goroutine triggered by `[N10n broker]` notifications: reads new `[(PLog)]` events and invokes the projector extension via `IAppPartition.Invoke`.
+  - Path to file: [pkg/processors/actualizers/async.go](../../../../pkg/processors/actualizers/async.go)
+
+- `[Scheduler]`
+  - Per-job goroutine triggered by a cron tick: waits on the schedule, then invokes the job extension after `WaitForBorrow` on the partition.
+  - Path to file: [pkg/processors/schedulers/impl_scheduler.go](../../../../pkg/processors/schedulers/impl_scheduler.go)
+
+### In-pipeline operators
+
+- `[Sync actualizer]`
+  - Per-partition operator invoked from `[Command processor]` via `IAppPartition.DoSyncActualizer`; forks across registered sync projectors and applies their intents inside the command transaction.
+  - Path to file: [pkg/processors/actualizers/impl.go](../../../../pkg/processors/actualizers/impl.go)
+
+- `[Authenticator call]`
+  - Calls `iauthnz.IAuthenticator.Authenticate` with the request token, returning principals stored on the workpiece; identity and token policy are owned by the `auth` context (see [../auth/arch.md](../auth/arch.md)).
+  - Path to file: [pkg/iauthnz/authn-interface.go](../../../../pkg/iauthnz/authn-interface.go)
+
+- `[ACL check]`
+  - Per-pipeline operator that calls `IAppPartition.IsOperationAllowed` for the request operation kind (`Execute` for commands and queries, per-CUD kind for command CUDs); maps a deny to `403 Forbidden`.
+  - Path to file: [pkg/processors/command/impl.go](../../../../pkg/processors/command/impl.go)
+
+- `[Legacy ACL fallback]`
+  - Falls back to `oldacl.IsOperationAllowed` when the new ACL denies, kept as a temporary bridge for Air; logged as `newACL not ok, but oldACL ok` when only the legacy path allows.
+  - Path to file: [pkg/processors/oldacl](../../../../pkg/processors/oldacl)
+
+### Shared infrastructure
+
+- `[App partitions engine]`
+  - Borrow/invoke surface used by every entry point: `Borrow` / `WaitForBorrow` (`IAppPartitions.Borrow` / `WaitForBorrow`, pool sized to `EnginePoolSize[ProcessorKind]`), `Invoke` (`IAppPartition.Invoke`, resolves the extension and checks `ProcessorKind` compatibility), and `DoSyncActualizer` (`IAppPartition.DoSyncActualizer`, called by `[Command processor]` after writing the PLog event). Cross-subsystem definition: see [arch.md](./arch.md).
+  - Path to file: [pkg/appparts/interface.go](../../../../pkg/appparts/interface.go)
+
+- `[Bus responder]`
+  - `bus.IRequestSender` / `IResponder` carry the response (single payload for commands, streamed rows for queries) back to the caller through a per-request channel.
+  - Path to file: [pkg/bus/interface.go](../../../../pkg/bus/interface.go)
+
+- `[N10n broker]`
+  - In-memory broker that fans out projection-key updates to subscriber channels: `[Command processor]` publishes the new PLog offset, `[Async actualizer]` and SSE subscribers consume it.
+  - Path to file: [pkg/in10nmem/impl.go](../../../../pkg/in10nmem/impl.go)
+
+### State
+
+- `[(PLog)]`
+  - Partition-scoped event log appended by `[Command processor]` and read by `[Async actualizer]`.
+  - Path to file: [pkg/istructs/interface.go](../../../../pkg/istructs/interface.go)
+
+- `[(WLog)]`
+  - Workspace-scoped event log appended by `[Command processor]`.
+  - Path to file: [pkg/istructs/interface.go](../../../../pkg/istructs/interface.go)
+
+- `[(Records)]`
+  - Record storage updated by `[Command processor]` CUDs and read by `[Query v1 processor]` / `[Query v2 processor]`.
+  - Path to file: [pkg/istructs/interface.go](../../../../pkg/istructs/interface.go)
+
+- `[(Views)]`
+  - Projection view storage updated by `[Sync actualizer]` and `[Async actualizer]` intents.
+  - Path to file: [pkg/istructs/interface.go](../../../../pkg/istructs/interface.go)
+
+- `[(BLOB storage)]`
+  - BLOB byte storage targeted by `[BLOB processor]`.
+  - Path to file: [pkg/iblobstorage](../../../../pkg/iblobstorage)
+
+## Scenarios
+
+### Handle command
+
+```text
+*Client
+  -> [Command processor]
+  -> [App partitions engine].Borrow(Command)
+  -> [Authenticator call]
+  -> [ACL check] (+ [Legacy ACL fallback])
+  -> [App partitions engine].Invoke(command)
+  -> append [(PLog)], store [(Records)] CUDs, append [(WLog)]
+  -> [App partitions engine].DoSyncActualizer -> [Sync actualizer] -> apply [(Views)] intents
+  -> response via [Bus responder]
+  -> [N10n broker].Update(PLog offset)
+```
+
+### Handle query
+
+```text
+*Client
+  -> [Query v1 processor] | [Query v2 processor]
+  -> [App partitions engine].Borrow(Query)
+  -> [Authenticator call]
+  -> [ACL check] (+ [Legacy ACL fallback])
+  -> [App partitions engine].Invoke(query/view/doc handler)
+  -> stream rows via [Bus responder]
+```
+
+### Run async actualizer
+
+```text
+[N10n broker]: Update(PLog offset)
+  -> [Async actualizer] wakes on its channel
+  -> reads new [(PLog)] events
+  -> [App partitions engine].Borrow(Actualizer)
+  -> [App partitions engine].Invoke(projector) per triggered event
+  -> apply intents to [(Views)] (and emit further N10n updates)
+```
+
+### Run scheduler job
+
+```text
+[Scheduler] cron tick
+  -> [App partitions engine].WaitForBorrow(Scheduler)
+  -> [App partitions engine].Invoke(job)
+  -> apply intents to [(Views)] / [(Records)]
+```
+
+### Handle BLOB transfer
+
+```text
+*Client
+  -> [BLOB processor]
+  -> [Authenticator call]
+  -> [ACL check] (+ [Legacy ACL fallback])
+  -> paired command on sys.cluster (register/lookup BLOB metadata)
+       -> [Bus responder] dispatches internal request
+       -> [Command processor] handles the paired command
+  -> stream bytes to/from [(BLOB storage)]
+  -> response via [Bus responder]
+```
+
+### Deliver N10n notification
+
+```text
+[Command processor] commits a command successfully
+  -> [N10n broker].Update(ProjectionKey{App, PLogUpdates, WS=partitionID}, offset)
+  -> [Async actualizer] channel wakes (see Run async actualizer)
+  -> SSE subscribers receive the update through [N10n broker].WatchChannel
+```

--- a/uspecs/specs/prod/apps/arch.md
+++ b/uspecs/specs/prod/apps/arch.md
@@ -1,0 +1,109 @@
+# Context architecture: prod/apps
+
+Apps context architecture for deploying Voedger applications and processing their commands, queries, projectors, jobs, BLOBs, and notifications on application partitions.
+
+## External actors
+
+Roles:
+
+- `@VADeveloper`
+  - Builds application schemas and extensions delivered as built-in or sidecar apps.
+
+- `@Admin`
+  - Operates the cluster and triggers cluster-level DML through the cluster app.
+
+Systems:
+
+- `*Client`
+  - External application invoking commands, queries, BLOB transfers, and N10n subscriptions over Voedger HTTP APIs.
+
+## Scenarios overview
+
+- **`Deploy application`**
+  - Bootstrap the cluster app, register a built-in or sidecar app via `c.cluster.DeployApp`, and deploy its partitions, projectors, and schedulers.
+
+- **`Process client request`**
+  - Authenticate the caller, authorize against the workspace ACL, invoke the matching extension on an application partition, and return a response.
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- @VADeveloper
+    +-- @Admin
+    +-- *Client
+    |
+    v
+Apps subsystems
+    |
+    +-- [[Deployment]]
+    +-- [[Processing]]
+    +-- [[VVM orchestration]]
+    +-- [[Sequences]]
+    |
+    v
+Shared engine
+    |
+    +-- [App partitions engine]
+```
+
+### Apps subsystems
+
+- `[[Deployment]]`
+  - Bootstraps the VVM, registers built-in and sidecar apps in the cluster app, and deploys their partitions; checks app compatibility on every redeploy.
+  - Path to file: [arch-deployment.md](./arch-deployment.md)
+
+- `[[Processing]]`
+  - Runs the command, query (v1 and v2), sync and async actualizer, scheduler, BLOB, and N10n pipelines that invoke extensions on application partitions.
+  - Path to file: [arch-processing.md](./arch-processing.md)
+
+- `[[VVM orchestration]]`
+  - Acquires and renews VVM leadership and sequences goroutine startup and shutdown so apps subsystems run only while leadership is held.
+  - Path to file: [arch-vvm-orch.md](./arch-vvm-orch.md)
+
+- `[[Sequences]]`
+  - Generates per-partition PLog offsets, per-workspace WLog offsets, and record IDs consumed by the command pipeline.
+  - Path to file: [arch-sequences.md](./arch-sequences.md)
+  - Proposed (not implemented) redesign for scalable sequences: [arch2-sequences.md](./arch2-sequences.md)
+
+### Shared engine
+
+- `[App partitions engine]`
+  - Process-wide manager of deployed applications and partitions; `[[Deployment]]` calls `DeployApp` / `DeployAppPartitions`, `[[Processing]]` borrows partitions and invokes extensions through `IAppPartition.Invoke` and `IAppPartition.DoSyncActualizer`.
+  - Path to file: [pkg/appparts](../../../../pkg/appparts)
+
+## Scenarios
+
+### Deploy application
+
+```text
+[[Deployment]]
+  -> [App partitions engine]: DeployApp(sys.cluster), DeployAppPartitions(sys.cluster)
+  -> [App partitions engine]: DeployApp(builtin/sidecar app), DeployAppPartitions(...)
+```
+
+Details: [arch-deployment.md](./arch-deployment.md).
+
+### Process client request
+
+```text
+*Client
+  -> [[Processing]]: authenticate, authorize, dispatch by pipeline kind
+  -> [App partitions engine]: Borrow(app, partitionID, processorKind)
+  -> [App partitions engine]: Invoke(extension) or DoSyncActualizer(...)
+  -> *Client: response
+```
+
+Details: [arch-processing.md](./arch-processing.md).
+
+## Cross-cutting concerns
+
+### Context dependencies
+
+- The `auth` context owns principal token validation and ACL policy consumed by `[[Processing]]` at every pipeline's authnz enforcement points; see [../auth/arch.md](../auth/arch.md).
+- The `storage` context persists app definitions, events, records, views, and BLOBs accessed by `[[Deployment]]` and `[[Processing]]` through `istructs.IAppStructs`.
+- The `extensions` context provides the WASM and built-in extension engines invoked by `[App partitions engine]`.
+- The `observability` context receives metrics, structured logs, and traces produced by the processing pipelines; logging conventions are described in [logging--td.md](./logging--td.md).

--- a/uspecs/specs/prod/apps/arch.md
+++ b/uspecs/specs/prod/apps/arch.md
@@ -73,7 +73,7 @@ Shared engine
 
 - `[App partitions engine]`
   - Process-wide manager of deployed applications and partitions; `[[Deployment]]` calls `DeployApp` / `DeployAppPartitions`, `[[Processing]]` borrows partitions and invokes extensions through `IAppPartition.Invoke` and `IAppPartition.DoSyncActualizer`.
-  - Path to file: [pkg/appparts](../../../../pkg/appparts)
+  - Path to package: [pkg/appparts](../../../../pkg/appparts)
 
 ## Scenarios
 


### PR DESCRIPTION
```yaml
change_id: 2606030916-derive-app-context-architecture
type: docs
issue_url: https://untill.atlassian.net/browse/AIR-4154
```
## Why

The `apps` context listed in `uspecs/specs/prod/domain.md` has no Context Architecture (`apps/arch.md`); existing files under `uspecs/specs/prod/apps/` cover narrower concerns (sequences, VVM orchestration, logging) but none provides a top-level architecture reference for deployment and processing.

## What

Add architecture specifications for the `apps` context, derived from existing documentation and the codebase:

- Add a Context Architecture at `uspecs/specs/prod/apps/arch.md` that overviews the `apps` context and links to its subsystem architectures
- Add a Context Subsystem Architecture `uspecs/specs/prod/apps/arch-deployment.md` covering vsql DDL, deployment descriptors, the app partitions engine (deploy and undeploy of app partitions), VVM startup bootstrap (`pkg/btstrp`: initializing the cluster-app workspace, registering built-in and sidecar apps via `c.cluster.DeployApp`, and deploying their app partitions), and protection against incompatible schema and deployment descriptor changes
- Add a Context Subsystem Architecture `uspecs/specs/prod/apps/arch-processing.md` covering the processor pipelines for Command, Query v1, Query v2, Sync Actualizer, Async Actualizer, Scheduler, BLOB, and N10N; authnz/ACL enforcement points within those pipelines (principal token validation and ACL checks delegated to the `auth` context); response sending; and the app partitions engine (invoke extensions on app partitions during request processing)
- Introduce the app partitions engine once in `arch.md` as a shared component and link to both subsystem chapters for its deployment-time and processing-time roles
- Leave the existing `arch-sequences.md`, `arch-vvm-orch.md`, `arch2-sequences.md`, and `logging--td.md` untouched and reference them from `arch.md` where relevant
- Give reviewers and contributors a single architecture reference for the `apps` context that complements `uspecs/specs/prod/domain.md`

## How

Decisions:

- Adopt uspecs-td conventions: `arch.md` for the Context Architecture, `arch-{subsystem}.md` for Context Subsystem Architectures
- Introduce the app partitions engine once in `apps/arch.md` and cross-link from both subsystem chapters for its deploy/undeploy and invoke-extensions roles
- Derive `apps/arch-deployment.md` from `pkg/btstrp`, `pkg/cluster` (`c.cluster.DeployApp`), `pkg/appparts` (`AppDeploymentDescriptor`, `DeployApp`, `DeployAppPartitions`), and VSQL DDL handling in `pkg/parser`
- Derive `apps/arch-processing.md` from `pkg/processors/{command,query,query2,actualizers,schedulers,blobber,n10n}`, with authnz/ACL enforcement points described as calls into `pkg/iauthnz` and response sending via `pkg/bus`
- Link existing `apps/arch-sequences.md`, `apps/arch-vvm-orch.md`, `apps/arch2-sequences.md`, and `apps/logging--td.md` from `apps/arch.md` without modifying them

Out of scope:

- Modifying or consolidating existing `apps/arch-sequences.md`, `apps/arch-vvm-orch.md`, `apps/arch2-sequences.md`, `apps/logging--td.md`
- Cluster-provisioning bootstrap performed by `cmd/ctool`
- Authnz/ACL policy and identity model owned by the `auth` context
- Any behavior change to deployment or processing code paths

References:

- `[apps context in the domain specification](/uspecs/specs/prod/domain.md)`


---
Content omitted. See change.md for full details.
