### PR TITLE
docs: Derive `routing` context architecture [AIR-4160]

### DIFF
--- a/uspecs/changes/archive/2606/2606031402-derive-app-context-architecture/issue-AIR-4154.md
+++ b/uspecs/changes/archive/2606/2606031402-derive-app-context-architecture/issue-AIR-4154.md
@@ -13,6 +13,6 @@ missing architecture for App context mentioned in [domain.md](https://github.com
 
 ## What
 
-- derive architeture from App context considering exisitng documentation and codebase. Devide the architecture to deployment and processing (processors).
+- derive architecture from App context considering exisitng documentation and codebase. Devide the architecture to deployment and processing (processors).
   - For deployment: consider vsql ddl, deployment desriptors, app partitions engine, bootstrap, protection against uncompatible schema and deployment descriptor change.
   - For processing: consider all processors pipelines, authnz, acl, response sending, app partitions engine.

--- a/uspecs/changes/archive/2606/2606040846-derive-routing-context-architecture/change.md
+++ b/uspecs/changes/archive/2606/2606040846-derive-routing-context-architecture/change.md
@@ -1,0 +1,104 @@
+---
+change_id: 2606031418-derive-routing-context-architecture
+type: docs
+issue_url: https://untill.atlassian.net/browse/AIR-4160
+domains: [prod]
+---
+
+# Change request: Derive `routing` context architecture
+
+Refs:
+
+- [AIR-4160: voedger: derive architecture from routing context](./issue-AIR-4160.md)
+
+## Why
+
+The `routing` context listed in `uspecs/specs/prod/domain.md` has no Context Architecture; reviewers and contributors lack a single architecture reference for the HTTP boundary of voedger — request routing, reverse-proxy forwarding, HTTPS/ACME, BLOB and N10N endpoints, the per-workspace concurrent-query limit, domain management, and the admin/debug listener.
+
+## What
+
+Add architecture specifications for the `routing` context, derived from existing documentation and the codebase:
+
+- Add a Context Architecture for `routing` split across five new files under `uspecs/specs/prod/routing/`:
+  - `arch.md` — context overview, external actors and dependencies, cross-subsystem components, the admin endpoint, and links to the subsystem chapters below
+  - `arch-ingress.md` — the public HTTP/HTTPS listener subsystem
+  - `arch-tls.md` — the TLS / ACME subsystem (HTTPS certificate provisioning, HTTP-01 challenge listener, autocert manager and cache)
+  - `arch-reverse-proxy.md` — the reverse-proxy subsystem
+  - `arch-debug.md` — the debug endpoints (pprof handlers) mounted on the admin endpoint
+- Cover every externally observable capability the production `routing` implementation exposes, treating the HTTP boundary as the context boundary:
+  - Public HTTP/HTTPS listener that terminates TLS and dispatches API v1 and API v2 requests to the `apps` context, with CORS handling for browser callers (`arch-ingress.md`)
+  - BLOB transfer endpoints (upload and download) that validate the HTTP request and delegate to the `apps`-owned `[BLOB processor]` (`arch-ingress.md`)
+  - N10N real-time subscription endpoints over Server-Sent Events — subscribe, unsubscribe, channel watch, offset update — that translate HTTP calls into subscriptions on the `apps`-owned `[N10n broker]` and stream the resulting events back to the client (`arch-ingress.md`)
+  - HTTPS certificate provisioning via ACME, including the dedicated HTTP-01 challenge listener on port 80 (`arch-tls.md`)
+  - Per-workspace concurrent-query limit on API endpoints — a cap on in-flight queries per `WSID` configured via `MaxQueriesPerWS`, with backpressure rejections when the cap is reached (`arch-ingress.md`)
+  - Reverse-proxy forwarding to external upstream services, including the four route kinds exposed to operators — path-prefix routes, path-prefix routes with rewrite, host-based domain routes, and the default fallback route (`arch-reverse-proxy.md`)
+  - Admin endpoint: localhost-only listener on `AdminPort` (default `55555`) that mounts the same handler set as the public endpoint except BLOB endpoints and the per-WS query limiter; started before bootstrap so the bootstrap operator can invoke internal API functions via `federation.AdminFunc` before the public endpoint opens (`arch.md`); debug endpoints (pprof) mounted on it (`arch-debug.md`)
+- Cover domain management as cluster-wide operator configuration supplied by `@Admin` at VVM startup (reverse-proxy route table and the ACME-managed hostname list); per-app dynamic domain registration is not implemented in `pkg/router` and is out of scope
+- Keep boundary descriptions boundary-only: name the `apps`-side components that the `routing` context dispatches to (`[BLOB processor]`, `[N10n broker]`, command/query processors via the request bus) and cross-reference `apps/arch-processing.md` for their behavior; do not duplicate how `apps` processes the request once dispatched
+- Document only the production implementation wired through the VVM (`pkg/router`); note the separate HTTP abstraction (`pkg/ihttpimpl`) as out of scope
+- Give reviewers and contributors a complete architecture reference for the `routing` context that complements `uspecs/specs/prod/domain.md`
+
+## How
+
+Decisions:
+
+- Author five new architecture files under `uspecs/specs/prod/routing/`: `arch.md` (context overview + admin endpoint + cross-subsystem components), `arch-ingress.md` (public HTTP/HTTPS listener subsystem), `arch-tls.md` (TLS / ACME subsystem), `arch-reverse-proxy.md` (reverse-proxy subsystem), `arch-debug.md` (pprof endpoints mounted on the admin endpoint)
+- Derive the architecture from the production implementation in `pkg/router` (`provide.go`, `impl_http.go`, `impl_apiv2.go`, `impl_blob.go`, `impl_n10n.go`, `impl_reverseproxy.go`, `impl_acme.go`, `impl_limiter.go`, `types.go`) and the VVM wiring in `pkg/vvm/provide.go::provideServicePipeline`
+- Use a layered structure comparable to `uspecs/specs/prod/apps/arch-processing.md` for each subsystem chapter — external actors → listeners / entry points → in-pipeline operators → shared infrastructure / boundary / state — with per-subsystem label adjustments and tier counts as the subsystem shape requires (e.g. `Boundary to apps` in `arch-ingress.md`, `TLS material` in `arch-tls.md`, `Shared infrastructure` in `arch-reverse-proxy.md` and `arch-debug.md`)
+- Cross-reference `uspecs/specs/prod/apps/arch-processing.md` for the `apps`-owned `[BLOB processor]` and `[N10n broker]` from `arch-ingress.md` instead of redescribing them
+- Document the admin endpoint's bootstrap role in `arch.md` (admin endpoint starts before bootstrap so `pkg/btstrp/impl.go::callDeployApp` can invoke internal API functions via `federation.AdminFunc` over `localhost:AdminPort`)
+
+Out of scope:
+
+- The standalone HTTP processor abstraction (`pkg/ihttp`, `pkg/ihttpctl`, `pkg/ihttpimpl`) used by `cmd/voedger server`
+- Per-app dynamic domain registration (not implemented in `pkg/router`)
+- Any behavior change in the `routing` context — this is a `docs` change that derives architecture from the existing codebase
+
+References (internal):
+
+- [routing production implementation](../../../../../pkg/router)
+- [router service wiring and admin endpoint construction](../../../../../pkg/router/provide.go)
+- [HTTP route registration and handler set](../../../../../pkg/router/impl_http.go)
+- [API v2 dispatch handlers](../../../../../pkg/router/impl_apiv2.go)
+- [BLOB upload and download handlers](../../../../../pkg/router/impl_blob.go)
+- [N10N SSE subscription handlers](../../../../../pkg/router/impl_n10n.go)
+- [reverse-proxy matcher and handler](../../../../../pkg/router/impl_reverseproxy.go)
+- [ACME / autocert manager and HTTP-01 listener](../../../../../pkg/router/impl_acme.go)
+- [per-workspace concurrent-query limiter](../../../../../pkg/router/impl_limiter.go)
+- [RouterParams configuration surface](../../../../../pkg/router/types.go)
+- [VVM service pipeline ordering admin-endpoint → bootstrap → public-endpoint](../../../../../pkg/vvm/provide.go)
+- [default AdminPort 55555](../../../../../pkg/vvm/consts.go)
+- [bootstrap call to federation.AdminFunc](../../../../../pkg/btstrp/impl.go)
+- [domain index of the prod domain](../../../../../uspecs/specs/prod/domain.md)
+- [apps context architecture — BLOB processor and N10n broker reference](../../../../../uspecs/specs/prod/apps/arch-processing.md)
+
+References (external):
+
+- [ACME RFC 8555](https://datatracker.ietf.org/doc/html/rfc8555)
+- [Server-Sent Events (HTML Living Standard)](https://html.spec.whatwg.org/multipage/server-sent-events.html)
+
+## Technical design
+
+- [x] create: [routing/arch.md](../../../../specs/prod/routing/arch.md)
+  - Context Architecture: overview of the `routing` context, external actors and dependencies (`@Admin`, `@ACME`), cross-subsystem components, the cluster-wide operator configuration supplied at VVM startup via `RouterParams` (reverse-proxy route table, ACME-managed hostname list, query limit, ports), and the admin endpoint (localhost-only listener on `AdminPort`, default `55555`) including its bootstrap role (started before bootstrap so `pkg/btstrp` can invoke internal API functions via `federation.AdminFunc` before the public endpoint opens); links to the subsystem chapters below
+  - Also lists `*Client` as the external system invoking commands, queries, BLOB transfers, and N10n SSE subscriptions over HTTP/HTTPS
+  - Cross-cutting concerns: dependencies on `apps` (request processing via `bus.IRequestSender`, `[BLOB processor]`, `[N10n broker]`), `auth` (principal token validation; routing only carries the `Authorization` header through), and `observability` (structured logs on listener lifecycle, requests, query-limit rejections, N10N errors); `pkg/ihttp` / `pkg/ihttpctl` / `pkg/ihttpimpl` called out as a parallel HTTP stack outside the production VVM wiring
+
+- [x] create: [routing/arch-ingress.md](../../../../specs/prod/routing/arch-ingress.md)
+  - Context Subsystem Architecture: public HTTP/HTTPS listener subsystem — API v1/v2 dispatch with CORS, BLOB endpoints delegating to the `apps`-owned `[BLOB processor]`, N10N SSE endpoints subscribing on the `apps`-owned `[N10n broker]`, per-workspace concurrent-query limit (`MaxQueriesPerWS`); TLS termination consumes certificates from the TLS subsystem
+  - `[VSqlUpdate v1 shim]` (`dispatchVSqlUpdateShim_V1`) re-routes API v1 `c.cluster.VSqlUpdate` calls to `q.cluster.VSqlUpdate2` so the workpiece runs on the query processor instead of synchronously re-entering the command processor
+  - `[Router checker]` on `POST|GET|OPTIONS /api/check` returning `ok`, used by health probes
+
+- [x] create: [routing/arch-tls.md](../../../../specs/prod/routing/arch-tls.md)
+  - Context Subsystem Architecture: TLS / ACME subsystem — `[ACME HTTP-01 listener]` on port 80, `[autocert.Manager]` configured with `HostPolicy: autocert.HostWhitelist(HTTP01ChallengeHosts...)` and the Let's Encrypt production directory, `[(autocert.Cache)]` keyed by `RouterParams.CertDir`; scenarios for first-request provisioning, cached-certificate serving, background renewal, and hostname rejection
+  - `Notes` section records that the public listener fixes `tls.Config.MinVersion = tls.VersionTLS12` (TLS 1.3 is disabled because of a third-party billing integration, per the inline comment in `pkg/router/impl_http.go`) and links the underlying ACME (RFC 8555) and HTTP-01 challenge references
+
+- [x] create: [routing/arch-reverse-proxy.md](../../../../specs/prod/routing/arch-reverse-proxy.md)
+  - Context Subsystem Architecture: reverse-proxy subsystem — the four route kinds (path-prefix, path-prefix with rewrite, host-based domain, default fallback), route matching and upstream forwarding model
+  - `Decline unmatched request` scenario: when no domain, path, or default route matches, the matcher returns false and gorilla/mux replies with `404 Not Found`
+  - `Notes` section clarifies that the rewrite mechanism is not modeled on Apache `mod_rewrite` (no regex, captures, `RewriteCond`, flags, or chained passes); the closer analogs are Apache `ProxyPass` and Nginx `location { proxy_pass; }`, mapping `Routes` to "preserve prefix" and `RoutesRewrite` to "strip-and-replace prefix"
+
+- [x] create: [routing/arch-debug.md](../../../../specs/prod/routing/arch-debug.md)
+  - Context Subsystem Architecture: debug endpoints (pprof handlers — `/debug/pprof`, `cmdline`, `profile`, `symbol`, `trace`) mounted on the admin endpoint
+  - `[Debug alias]` on `/debug/{cmd}` rewrites the request path to `/debug/pprof/{cmd}` and delegates to `pprof.Index`, allowing shorter URLs for per-name pprof handlers (heap, goroutine, block, mutex, threadcreate, allocs)
+  - Cross-cutting concerns: `registerDebugHandlers` runs unconditionally in `routerService.Prepare`, so the same `/debug/*` routes are also registered on the public endpoint without authentication; safe exposure on the public listener is therefore an operator-side concern (network ACLs)

--- a/uspecs/changes/archive/2606/2606040846-derive-routing-context-architecture/decisions.md
+++ b/uspecs/changes/archive/2606/2606040846-derive-routing-context-architecture/decisions.md
@@ -1,0 +1,233 @@
+# Decisions: Derive `routing` context architecture
+
+## Vagueness: which capabilities of `pkg/router` should the `routing` architecture cover?
+
+Decision: Document all externally observable capabilities of `pkg/router` — API v1/v2 dispatch, BLOB endpoints, N10N SSE, reverse proxy, ACME challenge listener, admin/debug pprof port, per-route rate limiting, CORS — plus domain management and HTTPS termination. Keep descriptions boundary-only so behavior owned by `apps` is not duplicated.
+
+- Pros: matches what the production binary actually exposes; reviewers can map each `pkg/router` handler to an architecture component; avoids hidden capabilities; consistent with the breadth of `apps/arch-processing.md`
+- Cons: largest scope; risk of duplicating descriptions that conceptually belong to `apps` — must be kept boundary-only
+- Confidence: high
+
+Alternatives:
+
+1. Document HTTP boundary + cross-cutting concerns only — request reception, TLS termination, ACME, domain management, reverse proxy, rate limiting, CORS, admin/debug port; treat API/BLOB/N10N as "dispatched to `apps`" without listing each route family
+   - Pros: cleaner separation from `apps`; smaller, more stable architecture
+   - Cons: hides that `pkg/router` owns N10N SSE state and BLOB endpoint shapes; reviewers can't tell from the architecture which routes exist
+   - Confidence: medium
+2. Narrow scope: only what `domain.md` already attributes to `routing` — request routing, domain management, HTTPS/ACME, reverse proxy; defer N10N, BLOB, admin port, rate limiting to other contexts or future change requests
+   - Pros: smallest, fastest to write; sticks to the issue text literally
+   - Cons: misrepresents the codebase; reviewers will flag missing coverage; likely to be revisited soon
+   - Confidence: low
+
+## Ambiguity: should the `routing` architecture be a single `arch.md` or split into `arch-{subsystem}.md` chapters?
+
+Decision: Split into four chapters — `arch.md` (overview + admin endpoint + cross-subsystem components) + `arch-ingress.md` (public HTTP/HTTPS listener, TLS termination, ACME, CORS, query limit, dispatch to `apps`, N10N SSE, BLOB) + `arch-reverse-proxy.md` (the four route kinds, host/path matching, upstream forwarding) + `arch-debug.md` (pprof endpoints mounted on the admin endpoint). The admin/debug placement is refined further in a separate decision below.
+
+- Pros: mirrors the `apps` precedent; isolates the reverse proxy (a self-contained subsystem with its own configuration model) from the main ingress pipeline; keeps each chapter focused
+- Cons: more files to maintain; small risk of cross-chapter duplication for shared concepts (e.g., domain config drives both ACME and reverse-proxy host routes)
+- Confidence: high
+
+Alternatives:
+
+1. Single `arch.md` covering everything
+   - Pros: smallest footprint; everything in one place; easy to navigate for a context that is essentially "the HTTP boundary"
+   - Cons: one large file mixing ingress pipeline, reverse-proxy route model, ACME state machine, admin port, and domain config; harder to review in chunks; diverges from the `apps` precedent
+   - Confidence: medium
+2. Split by lifecycle, mirroring `apps`: `arch.md` + `arch-deployment.md` + `arch-processing.md`
+   - Pros: maximum consistency with `apps`; clear separation between "what the operator configures" and "what happens per request"
+   - Cons: forced fit — reverse-proxy matching is per-request but its route table is deployment-time, so it would straddle both chapters; ACME is mostly background, neither pure deployment nor per-request
+   - Confidence: medium
+
+## Inconsistency: "cluster and per-app domain configuration" vs. what the codebase actually supports
+
+Decision: Drop "per-app" and describe domain management as cluster-wide operator configuration supplied by `@Admin` at VVM startup via `RouterParams` (reverse-proxy route table and ACME-managed hostname list). Per-app dynamic domain registration is not implemented and is out of scope.
+
+- Pros: matches the codebase exactly (`pkg/router/types.go::RouterParams`); matches `uspecs/specs/prod/domain.md`; nothing aspirational sneaks into a derived architecture
+- Cons: under-promises if per-app domain provisioning is on a near-term roadmap (architecture would need to be revised then)
+- Confidence: high
+
+Alternatives:
+
+1. Keep "per-app" as an aspirational/future capability and mark it explicitly
+   - Pros: signals known direction; reviewers see what is missing
+   - Cons: this change is `type: docs` deriving architecture from the existing codebase; aspirational content belongs in a different change request; risks confusing readers about what is built
+   - Confidence: low
+2. Investigate further before deciding
+   - Pros: avoids both under- and over-promising
+   - Cons: extra research step; likely to return the same "not implemented" answer
+   - Confidence: medium
+
+## Ambiguity: "per-route rate limiting" mischaracterizes what `pkg/router` actually limits
+
+Decision: Rephrase as a per-workspace concurrent-query limit on API endpoints — a cap on in-flight queries per `WSID` configured via `MaxQueriesPerWS`, with backpressure rejections when the cap is reached.
+
+- Pros: matches `pkg/router/impl_limiter.go::wsQueryLimiter` exactly; avoids inventing a feature that does not exist; correctly conveys that throttling is per-workspace, not per-route or per-client-IP
+- Cons: slightly longer phrasing; reviewers expecting traditional rate limiting may be surprised
+- Confidence: high
+
+Alternatives:
+
+1. Drop the bullet entirely from `## What`
+   - Pros: smallest `## What`; avoids the framing debate altogether
+   - Cons: the limit is externally observable — clients get rejections when they exceed it; omitting it understates what the routing context guarantees
+   - Confidence: low
+2. Keep "per-route rate limiting" wording but expand scope to add a true per-route rate limiter
+   - Pros: would deliver a commonly expected capability
+   - Cons: this change is `type: docs` deriving architecture from existing code; adding behavior belongs in a separate `feat` change request
+   - Confidence: low
+
+## Ambiguity: how `routing`'s BLOB and N10N endpoints relate to the `apps` context's `[BLOB processor]` and `[N10n broker]`
+
+Decision: Make the seam explicit in `## What` for both capabilities. BLOB endpoints in `routing` validate the HTTP request and delegate to the `apps`-owned `[BLOB processor]`; N10N SSE endpoints in `routing` translate HTTP calls into subscriptions on the `apps`-owned `[N10n broker]` and stream the resulting events back to the client. The routing architecture references these `apps` components by name and cross-references `apps/arch-processing.md`; it does not redescribe their behavior.
+
+- Pros: removes overlap with `apps/arch-processing.md`; makes the cross-context dependency visible; gives the technical-design pass a clear instruction for `arch-ingress.md`
+- Cons: requires the routing `arch-ingress.md` to cross-reference `apps/arch-processing.md` for the BLOB processor and N10N broker
+- Confidence: high
+
+Alternatives:
+
+1. Keep the current high-level phrasing and resolve the seam during `uimpl`
+   - Pros: keeps `## What` shorter
+   - Cons: the boundary rule in `## What` is too generic to enforce for BLOB/N10N without naming the receiving components
+   - Confidence: medium
+2. Treat BLOB processor and N10N broker as `routing` components instead
+   - Pros: consolidates each capability in one context
+   - Cons: contradicts the existing `apps` architecture; the processor and broker are invoked from `apps` actualizers and command processors too, not only from HTTP; misplaces them
+   - Confidence: low
+
+## Inconsistency: `## Why` and the last `## What` bullet still imply a narrow, single-file scope
+
+Decision: Widen `## Why` to reflect the full HTTP-boundary scope (request routing, reverse-proxy forwarding, HTTPS/ACME, BLOB and N10N endpoints, domain management, admin/debug listener) and reword the closing `## What` bullet from "single architecture reference" to "complete architecture reference" so the three-file split is no longer contradicted.
+
+- Pros: aligns the framing of the change with the resolved scope; removes the "single file" implication; reviewer can read `## Why` and predict the deliverable
+- Cons: minor edits across two sections
+- Confidence: high
+
+Alternatives:
+
+1. Fix only the last `## What` bullet ("single" → "complete"), leave `## Why` as-is
+   - Pros: smaller diff; `## Why` rule allows brevity
+   - Cons: `## Why` continues to undersell the change; reviewers may misjudge blast radius
+   - Confidence: medium
+2. Leave both as-is — readers will infer scope from `## What`
+   - Pros: no further edits
+   - Cons: keeps a real inconsistency between sections
+   - Confidence: low
+
+## Inconsistency: the admin endpoint description is duplicated in two places with inconsistent depth vs. peer bullets
+
+Decision: Trim the `arch.md` file-split sub-bullet to a peer-style one-liner ("the admin endpoint") so it matches the brevity of the other three file-split sub-bullets. Keep the full admin-endpoint description (localhost port, bootstrap rationale, `federation.AdminFunc`, file markers `(arch.md)` and `(arch-debug.md)`) only in the capability bullet.
+
+- Pros: matches the structure of the peer sub-bullets; removes the duplication; capability bullets remain the single source of truth for what is documented and where
+- Cons: a reader scanning only the file-split bullet learns less about `arch.md`'s contents
+- Confidence: high
+
+Alternatives:
+
+1. Trim the capability bullet to a one-liner pointer; keep the full description only in the file-split sub-bullet for `arch.md`
+   - Pros: collocates the description with the file it belongs to
+   - Cons: breaks symmetry with the other capability bullets (each of which carries the full description); the capability list becomes a non-uniform mix of full descriptions and pointers
+   - Confidence: medium
+2. Leave both as-is
+   - Pros: no further edits
+   - Cons: keeps the duplication and the structural inconsistency with peer sub-bullets
+   - Confidence: low
+
+## Ambiguity: where the admin/debug HTTP listener belongs in the file split
+
+Decision (user-provided): The admin listener is a single endpoint that listens on `localhost:AdminPort` (default `55555`) and mounts the full handler set, including the debug endpoints. Describe the admin endpoint in `arch.md`, including its bootstrapping role — the VVM service pipeline starts the admin endpoint before the bootstrap operator so that bootstrap can call internal API functions (e.g. `c.cluster.DeployApp`) via `federation.AdminFunc` over the localhost-only port before the public endpoint opens to external traffic. Describe the debug endpoints (pprof) in a separate `arch-debug.md`. This adds a fourth chapter (`arch-debug.md`) to the file split decided earlier.
+
+- Pros: matches the production code shape (`pkg/router/provide.go` builds the admin endpoint via `getRouterService` bound to `httpu.LocalhostIP:AdminPort`; `pkg/vvm/provide.go::provideServicePipeline` orders admin-endpoint → bootstrap → public-endpoint; `pkg/btstrp/impl.go::callDeployApp` uses `federation.AdminFunc`); keeps `arch.md` focused on the operator-local endpoint concept; isolates pprof handlers in their own chapter so future debug surface can grow there without bloating `arch.md`
+- Cons: introduces a fourth chapter; readers must follow a link from `arch.md` to `arch-debug.md` to see which debug routes are mounted
+- Confidence: user-provided
+
+Alternatives:
+
+1. Move the admin/debug listener into `arch-ingress.md` as a sibling of the public and ACME listeners
+   - Pros: all listeners in one chapter; uniform listener model
+   - Cons: stretches "ingress" to include an operator-facing localhost port; mixes user-facing and operator-facing surfaces
+   - Confidence: high
+2. Give the admin/debug listener its own chapter `arch-admin.md` (instead of splitting admin endpoint and debug endpoints)
+   - Pros: clean separation between user-facing ingress and operator-facing admin
+   - Cons: less granular than the chosen split; conflates "the localhost endpoint" with "what is mounted on it"
+   - Confidence: medium
+3. Keep the admin/debug listener in `arch.md` and accept that `arch.md` mixes overview and one concrete component
+   - Pros: no file change; smallest deliverable
+   - Cons: violates the overview/subsystem split rationale from the prior decision
+   - Confidence: low
+
+## Vagueness: `pkg/ihttpimpl` out-of-scope marker does not say where the alternative implementation is actually used
+
+Decision (user-provided): Leave the bullet as-is — keep the terse "Document only the production implementation wired through the VVM (`pkg/router`); note the separate HTTP abstraction (`pkg/ihttpimpl`) as out of scope" wording. Do not expand it to name `cmd/voedger server`, `pkg/ihttp`, or `pkg/ihttpctl`.
+
+- Pros: shortest framing; keeps `## What` focused on the in-scope deliverable; out-of-scope marker is sufficient for reviewers who only need to know it is excluded
+- Cons: any reviewer who has not read `cmd/voedger/server.go` will wonder what `pkg/ihttpimpl` is and may grep before commenting
+- Confidence: user-provided
+
+Alternatives:
+
+1. Name the consumer: expand the bullet to "the HTTP processor abstraction used by the standalone `cmd/voedger server` command (`pkg/ihttp` + `pkg/ihttpctl` + `pkg/ihttpimpl`) is out of scope"
+   - Pros: factual; reviewer immediately understands what is being excluded and why
+   - Cons: longer bullet; introduces extra package names that may not matter at `## What` level
+   - Confidence: high
+2. Drop the `pkg/ihttpimpl` mention entirely
+   - Pros: simplest; no out-of-scope debate
+   - Cons: loses the negative-space signal that there is a second HTTP stack in the repo
+   - Confidence: medium
+
+## Inconsistency: `## What` (admin endpoint bullet) claims "the full handler set" but BLOB endpoints and the per-WS query limiter are not mounted on the admin endpoint
+
+Decision: Replace "that mounts the full handler set" with "that mounts the same handler set as the public endpoint except BLOB endpoints and the per-WS query limiter" in the admin-endpoint bullet of `## What`. The fact that BLOB requests would 404 on the admin port and that queries are not rate-limited there is caller-observable behavior, so it belongs in `## What`. Reasons for the carve-outs (`blobRequestHandler == nil`, `limiter is nil for Admin and ACME services`) stay in `arch.md`.
+
+- Pros: matches reality exactly (per `pkg/router/provide.go::Provide`); matches `arch.md` line 89; stays at behavior level — no implementation symbols leak into `## What`
+- Cons: slightly longer bullet
+- Confidence: user-provided
+
+Alternatives:
+
+1. Drop the qualifier — "that mounts the routing handlers"
+   - Pros: shortest fix
+   - Cons: loses the comparison-to-public-endpoint signal that helps readers locate the admin endpoint in the spec
+   - Confidence: medium
+2. Enumerate the mounted families — "that mounts the router-checker, API v1, API v2, debug, and reverse-proxy handlers (no BLOB endpoints, no query limiter)"
+   - Pros: most precise; no follow-up read of `arch.md` needed
+   - Cons: leaks handler-family names into `## What`, contrary to the boundary rule that `## What` should not name implementation symbols just to make a bullet concrete
+   - Confidence: medium
+
+## Inconsistency: `tls--td.md` (Feature Technical Design) was added but `change.md` only authorizes architecture files
+
+Decision: Convert `tls--td.md` into `arch-tls.md`, a fifth Context Subsystem Architecture chapter, and extract the TLS-related components (`[ACME HTTP-01 listener]`, `[autocert.Manager]`, `[(autocert.Cache)]`, the "Provision and renew TLS certificate" scenario, the `@ACME` external actor, and the "TLS material" layer) from `arch-ingress.md` into the new chapter. The public listener in `arch-ingress.md` keeps its TLS-termination role and cross-references `arch-tls.md` for certificate lifecycle. Update `change.md` `## What`, `## How` Decisions, and the `## Technical design` checklist to list five files. Drop the Mermaid sequence diagram and the protocol Concepts section from the original TD because both deviate from the convention used by the other four arch files (ASCII flows; voedger components only); preserve protocol references in a `## Notes` section.
+
+- Pros: stays inside the originally clarified "architecture only" scope; eliminates the inconsistency cleanly; gives TLS provisioning its own first-class subsystem chapter parallel to ingress / reverse-proxy / debug; aligns with the file-naming convention used by the other three arch chapters (`arch-{subsystem}.md`); removes the cross-file overlap that would otherwise exist between `tls--td.md` and `arch-ingress.md`
+- Cons: loses the Mermaid sequence diagram and the protocol-background Concepts section the original TD carried; substantial rewrite of `arch-ingress.md` (removed `@ACME` actor, removed `[ACME HTTP-01 listener]`, removed "TLS material" layer, trimmed `[Public listener]` TLS sub-bullet to a cross-reference)
+- Confidence: user-provided
+
+Alternatives:
+
+1. Convert to `arch-tls.md` but keep the Mermaid diagram and the Concepts section as exceptions
+   - Pros: keeps the diagram and the protocol narrative; minimal content loss
+   - Cons: dilutes the arch-file convention; `arch-tls.md` would look structurally different from the other arch files
+   - Confidence: medium
+2. Keep `tls--td.md` as-is and widen the change scope to include topic TDs
+   - Pros: minimal edits; preserves the file unchanged
+   - Cons: widens the originally clarified scope from pure architecture to mixed; mixes deliverable classes inside one change request
+   - Confidence: high
+3. Keep `tls--td.md` as-is and split the TLS work into a separate Change Folder
+   - Pros: each change request stays focused
+   - Cons: extra bureaucracy; the file is already on the current branch
+   - Confidence: medium
+
+## Inconsistency: `## Why` enumerates the routing-context capabilities but omits the per-workspace concurrent-query limit covered by `## What` and by `arch-ingress.md`
+
+Decision: Add "the per-workspace concurrent-query limit" to the `## Why` capability enumeration between "BLOB and N10N endpoints" and "domain management". The query limit is a first-class capability documented in `## What` (`MaxQueriesPerWS`, backpressure rejections) and in `arch-ingress.md` (`### Reject excess concurrent query` scenario, `[Query limiter]` operator), so it belongs in the `## Why` scope list too.
+
+- Pros: aligns `## Why` with `## What` and with the implemented chapter coverage; minimal edit (one inserted phrase); reviewers scanning `## Why` see the full scope
+- Cons: lengthens the `## Why` sentence by one item
+- Confidence: user-provided
+
+Alternatives:
+
+1. Drop the comma-separated capability list from `## Why` entirely — replace with a single phrase like "for the public HTTP boundary of voedger", letting `## What` enumerate capabilities authoritatively
+   - Pros: shorter `## Why`; removes the risk of `## Why` drifting out of sync with `## What` again
+   - Cons: weaker scoping signal in `## Why`; reviewers must click through to `## What` to gauge breadth
+   - Confidence: medium

--- a/uspecs/changes/archive/2606/2606040846-derive-routing-context-architecture/issue-AIR-4160.md
+++ b/uspecs/changes/archive/2606/2606040846-derive-routing-context-architecture/issue-AIR-4160.md
@@ -1,0 +1,16 @@
+# voedger: derive architecture from routing context
+
+- URL: https://untill.atlassian.net/browse/AIR-4160
+- ID: AIR-4160
+- State: in-progress
+- Author: Denis Gribanov
+- Labels: none
+- Assignees: d.gribanov@dev.untill.com
+
+## Why
+
+missing architecture for Routing context mentioned in domain.md
+
+## What
+
+derive architeture from Routing context considering exisitng documentation and codebase.

--- a/uspecs/changes/archive/2606/2606040846-derive-routing-context-architecture/issue-AIR-4160.md
+++ b/uspecs/changes/archive/2606/2606040846-derive-routing-context-architecture/issue-AIR-4160.md
@@ -13,4 +13,4 @@ missing architecture for Routing context mentioned in domain.md
 
 ## What
 
-derive architeture from Routing context considering exisitng documentation and codebase.
+derive architecture from Routing context considering exisitng documentation and codebase.

--- a/uspecs/specs/prod/routing/arch-debug.md
+++ b/uspecs/specs/prod/routing/arch-debug.md
@@ -1,18 +1,18 @@
 # Context subsystem architecture: prod/routing/debug
 
-Routing debug subsystem architecture: `net/http/pprof` handlers mounted on the admin endpoint (and, for compatibility, also on the public router) for runtime profiling and diagnostics. Context-level overview: [arch.md](./arch.md).
+Routing debug subsystem architecture: `net/http/pprof` handlers mounted by `registerDebugHandlers` on every `routerService` instance — both the loopback-only admin endpoint and the public HTTP/HTTPS listener — for runtime profiling and diagnostics. Context-level overview: [arch.md](./arch.md).
 
 ## External actors
 
-Roles:
+Systems:
 
-- `@Admin`
-  - Operator collecting CPU / heap / goroutine / trace profiles for diagnostics over loopback.
+- `*Client`
+  - Any caller able to open a TCP connection to either listener. The debug routes carry no authentication, role check, or method restriction, so every reachable caller can collect the same profiles. Restricting access on the public listener is an operator-side concern (network ACLs, upstream reverse proxy, or wrapping the listener with an authentication layer); the admin listener is restricted only by its loopback bind address (`httpu.LocalhostIP:AdminPort`).
 
 ## Scenarios overview
 
 - **`Collect pprof profile`**
-  - The operator opens a loopback connection to the admin endpoint and reads any of the standard `pprof` handlers (`/debug/pprof`, `/debug/cmdline`, `/debug/profile`, `/debug/symbol`, `/debug/trace`, or `/debug/{cmd}` aliasing into `/debug/pprof/{cmd}`); the handler returns the corresponding profile.
+  - `*Client` opens a connection to either listener and reads any of the standard `pprof` handlers (`/debug/pprof`, `/debug/cmdline`, `/debug/profile`, `/debug/symbol`, `/debug/trace`, or `/debug/{cmd}` aliasing into `/debug/pprof/{cmd}`); the handler returns the corresponding profile.
 
 ## Components
 
@@ -21,7 +21,7 @@ Roles:
 ```text
 External actors
     |
-    +-- @Admin
+    +-- *Client
     |
     v
 Entry points
@@ -37,6 +37,7 @@ Entry points
 Cross-subsystem components
     |
     +-- [Admin endpoint]
+    +-- [Public listener]
     +-- [Router (gorilla/mux)]
 ```
 
@@ -69,11 +70,15 @@ Cross-subsystem components
 ### Cross-subsystem components
 
 - `[Admin endpoint]`
-  - Shared with the rest of the routing context; see [arch.md](./arch.md#cross-subsystem-components). All debug handlers are reachable on `localhost:AdminPort`.
+  - Shared with the rest of the routing context; see [arch.md](./arch.md#cross-subsystem-components). All debug handlers are reachable on `localhost:AdminPort`; restricted only by the loopback bind address.
   - Path to file: [pkg/router/provide.go](../../../../pkg/router/provide.go)
 
+- `[Public listener]`
+  - Shared with the rest of the routing context; defined in [arch-ingress.md](./arch-ingress.md#listeners). `registerDebugHandlers` is invoked from the same `routerService.Prepare` that runs on the public listener, so the same `/debug/*` routes are mounted there without authentication and are reachable by any `*Client`.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
 - `[Router (gorilla/mux)]`
-  - Shared with the rest of the routing context; see [arch.md](./arch.md#cross-subsystem-components). `registerDebugHandlers` runs after `registerHandlersV1` / `registerHandlersV2` and before `registerReverseProxyHandler`, so debug routes take precedence over the reverse-proxy fallback.
+  - Shared with the rest of the routing context; see [arch.md](./arch.md#cross-subsystem-components). `registerDebugHandlers` runs after `registerHandlersV1` / `registerHandlersV2` and before `registerReverseProxyHandler`, so debug routes take precedence over the reverse-proxy fallback on whichever listener they are mounted.
   - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
 
 ## Scenarios
@@ -81,19 +86,24 @@ Cross-subsystem components
 ### Collect pprof profile
 
 ```text
-@Admin curl http://localhost:55555/debug/pprof
+*Client curl http://localhost:55555/debug/pprof
   -> [Admin endpoint] -> [Router (gorilla/mux)] match "/debug/pprof"
   -> [Debug index] (pprof.Index) -> respond with profile listing
 
-@Admin curl http://localhost:55555/debug/profile?seconds=30
+*Client curl http://localhost:55555/debug/profile?seconds=30
   -> [Admin endpoint] -> [Router (gorilla/mux)] match "/debug/profile"
   -> [Debug profile] (pprof.Profile) -> respond with CPU profile
 
-@Admin curl http://localhost:55555/debug/heap
+*Client curl http://localhost:55555/debug/heap
   -> [Admin endpoint] -> [Router (gorilla/mux)] match "/debug/{cmd}"
   -> [Debug alias] rewrite to /debug/pprof/heap -> pprof.Index -> respond with heap profile
+
+*Client curl https://<public-host>/debug/profile?seconds=30
+  -> [Public listener] -> [Router (gorilla/mux)] match "/debug/profile"
+  -> [Debug profile] (pprof.Profile) -> respond with CPU profile
+       (same handler graph; no authentication is performed)
 ```
 
 ## Cross-cutting concerns
 
-`registerDebugHandlers` runs unconditionally in `routerService.Prepare`, so the same `/debug/*` routes are also registered on the public endpoint without authentication. The admin endpoint is loopback-only by construction (`httpu.LocalhostIP:AdminPort`); exposing the debug routes on the public listener safely is therefore an operator-side concern (network ACLs).
+`registerDebugHandlers` is invoked from `routerService.Prepare` and is therefore part of the handler graph on every listener that runs a `routerService` — both the admin endpoint (loopback by construction: `httpu.LocalhostIP:AdminPort`) and the public HTTP/HTTPS listener. The debug routes are not gated by `[Query limiter]`, `[Request validator]`, authentication, or any other operator. Restricting external access to `/debug/*` on the public listener is an operator-side concern (network ACLs, upstream reverse proxy, or wrapping the listener with an authentication layer).

--- a/uspecs/specs/prod/routing/arch-debug.md
+++ b/uspecs/specs/prod/routing/arch-debug.md
@@ -1,0 +1,99 @@
+# Context subsystem architecture: prod/routing/debug
+
+Routing debug subsystem architecture: `net/http/pprof` handlers mounted on the admin endpoint (and, for compatibility, also on the public router) for runtime profiling and diagnostics. Context-level overview: [arch.md](./arch.md).
+
+## External actors
+
+Roles:
+
+- `@Admin`
+  - Operator collecting CPU / heap / goroutine / trace profiles for diagnostics over loopback.
+
+## Scenarios overview
+
+- **`Collect pprof profile`**
+  - The operator opens a loopback connection to the admin endpoint and reads any of the standard `pprof` handlers (`/debug/pprof`, `/debug/cmdline`, `/debug/profile`, `/debug/symbol`, `/debug/trace`, or `/debug/{cmd}` aliasing into `/debug/pprof/{cmd}`); the handler returns the corresponding profile.
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- @Admin
+    |
+    v
+Entry points
+    |
+    +-- [Debug index]
+    +-- [Debug cmdline]
+    +-- [Debug profile]
+    +-- [Debug symbol]
+    +-- [Debug trace]
+    +-- [Debug alias]
+    |
+    v
+Cross-subsystem components
+    |
+    +-- [Admin endpoint]
+    +-- [Router (gorilla/mux)]
+```
+
+### Entry points
+
+- `[Debug index]`
+  - `pprof.Index` mounted at `/debug/pprof`. Lists the available profiles.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+- `[Debug cmdline]`
+  - `pprof.Cmdline` mounted at `/debug/cmdline`. Returns the process command line.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+- `[Debug profile]`
+  - `pprof.Profile` mounted at `/debug/profile`. Returns a CPU profile (default 30s).
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+- `[Debug symbol]`
+  - `pprof.Symbol` mounted at `/debug/symbol`. Resolves program counters to function names.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+- `[Debug trace]`
+  - `pprof.Trace` mounted at `/debug/trace`. Returns an execution trace.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+- `[Debug alias]`
+  - `/debug/{cmd}` rewrites the request path to `/debug/pprof/{cmd}` and delegates to `pprof.Index`; registered last among the debug handlers. Allows shorter URLs for the per-name pprof handlers (heap, goroutine, block, mutex, threadcreate, allocs).
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+### Cross-subsystem components
+
+- `[Admin endpoint]`
+  - Shared with the rest of the routing context; see [arch.md](./arch.md#cross-subsystem-components). All debug handlers are reachable on `localhost:AdminPort`.
+  - Path to file: [pkg/router/provide.go](../../../../pkg/router/provide.go)
+
+- `[Router (gorilla/mux)]`
+  - Shared with the rest of the routing context; see [arch.md](./arch.md#cross-subsystem-components). `registerDebugHandlers` runs after `registerHandlersV1` / `registerHandlersV2` and before `registerReverseProxyHandler`, so debug routes take precedence over the reverse-proxy fallback.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+## Scenarios
+
+### Collect pprof profile
+
+```text
+@Admin curl http://localhost:55555/debug/pprof
+  -> [Admin endpoint] -> [Router (gorilla/mux)] match "/debug/pprof"
+  -> [Debug index] (pprof.Index) -> respond with profile listing
+
+@Admin curl http://localhost:55555/debug/profile?seconds=30
+  -> [Admin endpoint] -> [Router (gorilla/mux)] match "/debug/profile"
+  -> [Debug profile] (pprof.Profile) -> respond with CPU profile
+
+@Admin curl http://localhost:55555/debug/heap
+  -> [Admin endpoint] -> [Router (gorilla/mux)] match "/debug/{cmd}"
+  -> [Debug alias] rewrite to /debug/pprof/heap -> pprof.Index -> respond with heap profile
+```
+
+## Cross-cutting concerns
+
+`registerDebugHandlers` runs unconditionally in `routerService.Prepare`, so the same `/debug/*` routes are also registered on the public endpoint without authentication. The admin endpoint is loopback-only by construction (`httpu.LocalhostIP:AdminPort`); exposing the debug routes on the public listener safely is therefore an operator-side concern (network ACLs).

--- a/uspecs/specs/prod/routing/arch-ingress.md
+++ b/uspecs/specs/prod/routing/arch-ingress.md
@@ -61,6 +61,7 @@ In-pipeline operators
     +-- [CORS wrapper]
     +-- [Query limiter]
     +-- [VSqlUpdate v1 shim]
+    +-- [VSqlUpdate v2 shim]
     +-- [Response writer]
     |
     v
@@ -84,7 +85,7 @@ Boundary to apps
   - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
 
 - `[API v2 handler]`
-  - Family of handlers registered by `registerHandlersV2` covering `docs`, `cdocs`, `commands`, `queries`, `views`, `schemas` (`/api/v2/apps/{owner}/{app}/...`), workspace roles, BLOB temporary and persistent endpoints, and a generic catch-all for unknown v2 paths. Every handler acquires `[Query limiter]` and forwards through `[bus.IRequestSender]`.
+  - Family of handlers registered by `registerHandlersV2` covering `docs`, `cdocs`, `commands`, `queries`, `views`, `schemas` (`/api/v2/apps/{owner}/{app}/...`), workspace roles, BLOB temporary and persistent endpoints, and a generic catch-all for unknown v2 paths. Each handler forwards through `[bus.IRequestSender]`; `[Query limiter]` is acquired only for query-processor-bound `GET` requests (`queries`, `views`, `docs`, `cdocs` — selected by `isQPBoundAPIPath`) and for the `[VSqlUpdate v2 shim]`.
   - Path to file: [pkg/router/impl_apiv2.go](../../../../pkg/router/impl_apiv2.go)
 
 - `[BLOB handler]`
@@ -92,7 +93,7 @@ Boundary to apps
   - Path to file: [pkg/router/impl_blob.go](../../../../pkg/router/impl_blob.go)
 
 - `[N10N SSE handler]`
-  - Four handlers on `GET /n10n/...`: `subscribeAndWatchHandler` (`/n10n/channel` - opens an SSE stream and subscribes), `subscribeHandler` (`/n10n/subscribe`), `unSubscribeHandler` (`/n10n/unsubscribe`), and `updateHandler` (`/n10n/update/{offset}`). Each manipulates a channel on `[in10n.IN10nBroker]` and streams events over `text/event-stream` until the request context is cancelled. `routerService.Stop` waits for `MetricNumSubscriptions() == 0` before completing shutdown.
+  - Four handlers on `/n10n/...`: three on `GET` — `subscribeAndWatchHandler` (`/n10n/channel`; opens an SSE stream, creates a channel on `[in10n.IN10nBroker]` and subscribes), `subscribeHandler` (`/n10n/subscribe`; adds a projection-key subscription to an existing channel), `unSubscribeHandler` (`/n10n/unsubscribe`; removes a subscription) — and `updateHandler` (`/n10n/update/{offset:[0-9]{1,10}}`; no method restriction, documented in source as `POST` because it reads the projection key from the request body and calls `[in10n.IN10nBroker].Update` to publish an offset). The `/n10n/channel` handler streams updates over `text/event-stream` until the request context is cancelled. `routerService.Stop` waits for `MetricNumSubscriptions() == 0` before completing shutdown.
   - Path to file: [pkg/router/impl_n10n.go](../../../../pkg/router/impl_n10n.go)
 
 - `[Router checker]`
@@ -110,12 +111,16 @@ Boundary to apps
   - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
 
 - `[Query limiter]`
-  - Shared with the rest of the routing context; see [arch.md](./arch.md#cross-subsystem-components). On the public listener it wraps every API v2 handler and the `q.*` / `q.cluster.VSqlUpdate2` paths of `[API v1 handler]`; the admin endpoint mounts the same handler set but with the limiter disabled (`limiter is nil for Admin and ACME services`, see [arch.md](./arch.md#cross-subsystem-components)). Rejections reply `503 Service Unavailable`.
+  - Shared with the rest of the routing context; see [arch.md](./arch.md#cross-subsystem-components). On the public listener it wraps query-processor-bound `GET` requests of `[API v2 handler]` (`queries`, `views`, `docs`, `cdocs` — selected by `isQPBoundAPIPath`), the `q.*` paths of `[API v1 handler]`, and both `[VSqlUpdate v1 shim]` and `[VSqlUpdate v2 shim]` (which reroute to `q.cluster.VSqlUpdate2`); other v2 endpoints (commands, schemas, workspace roles, auth, user/device creation, BLOBs) and non-`q.*` v1 calls bypass it. The admin endpoint mounts the same handler set, but the limiter is constructed with `MaxQueriesPerWS = 0` and `acquire` short-circuits to `true` whenever `maxQPerWS <= 0`, so admin traffic is not capped (see [arch.md](./arch.md#cross-subsystem-components)). Rejections on the public listener reply `503 Service Unavailable`.
   - Path to file: [pkg/router/impl_limiter.go](../../../../pkg/router/impl_limiter.go)
 
 - `[VSqlUpdate v1 shim]`
   - `dispatchVSqlUpdateShim_V1` re-routes API v1 `c.cluster.VSqlUpdate` calls to `q.cluster.VSqlUpdate2` so the workpiece runs on the query processor instead of synchronously re-entering the command processor.
-  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+  - Path to file: [pkg/router/impl_vsqlupdate_shim.go](../../../../pkg/router/impl_vsqlupdate_shim.go)
+
+- `[VSqlUpdate v2 shim]`
+  - `dispatchVSqlUpdateShim_V2` re-routes API v2 `c.cluster.VSqlUpdate` calls (detected by `isVSqlUpdateV2Call`) to `q.cluster.VSqlUpdate2` so the workpiece runs on the query processor; shares `[Query limiter]` gating with native queries.
+  - Path to file: [pkg/router/impl_vsqlupdate_shim.go](../../../../pkg/router/impl_vsqlupdate_shim.go)
 
 - `[Response writer]`
   - `initResponse` / `reply_v1` / `reply_v2` translate the `bus.ResponseMeta` mode (`Single`, `StreamJSON`, `StreamEvents`) into HTTP headers and stream-or-buffer the response body; `applySysErrorHeaders` propagates `coreutils.SysError` headers.
@@ -156,8 +161,9 @@ Boundary to apps
 *Client {GET|POST|PATCH|DELETE} /api/v2/apps/{owner}/{app}/...
   -> [Public listener] -> [Router (gorilla/mux)] match by API v2 path
   -> [CORS wrapper] -> [Request validator]
-  -> [Query limiter].acquire(WSID)
-  -> [API v2 handler] -> [bus.IRequestSender] -> apps v2 processor
+  -> if GET on queries/views/docs/cdocs, or VSqlUpdate v2 shim: [Query limiter].acquire(WSID)
+  -> if VSqlUpdate shim: [VSqlUpdate v2 shim] -> q.cluster.VSqlUpdate2
+  -> else: [API v2 handler] -> [bus.IRequestSender] -> apps v2 processor
   -> [Response writer]
   -> *Client
 ```

--- a/uspecs/specs/prod/routing/arch-ingress.md
+++ b/uspecs/specs/prod/routing/arch-ingress.md
@@ -1,0 +1,198 @@
+# Context subsystem architecture: prod/routing/ingress
+
+Routing ingress subsystem architecture for the public HTTP/HTTPS listener: API v1 and API v2 dispatch with CORS, BLOB transfer endpoints, N10N Server-Sent Events subscription endpoints, and the per-workspace concurrent-query limit. TLS termination uses certificates supplied by the TLS subsystem ([arch-tls.md](./arch-tls.md)). Context-level overview: [arch.md](./arch.md).
+
+## External actors
+
+Roles:
+
+- `@Admin`
+  - Configures the public listener (port, TLS, ACME-managed hostname list, proxy-protocol, connection cap, per-WS query limit) via `RouterParams`. See [arch.md](./arch.md#configuration).
+
+Systems:
+
+- `*Client`
+  - Browser, mobile, or backend caller invoking commands, queries, BLOB transfers, and N10n subscriptions.
+
+## Scenarios overview
+
+- **`Dispatch API v1 request`**
+  - Validate the URL placeholders (`appOwner/appName/wsid/resourceName`), apply CORS, acquire the per-WS query limit on `q.*` and on the `q.cluster.VSqlUpdate2` shim, forward the request through `bus.IRequestSender` to the `apps` command or query processor, and stream the response back.
+
+- **`Dispatch API v2 request`**
+  - Match the path against the API v2 catalog (`docs`, `cdocs`, `commands`, `queries`, `views`, `schemas`, BLOB temporary/persistent), acquire the per-WS query limit, dispatch through `bus.IRequestSender` to the v2 processor, and stream rows.
+
+- **`Transfer BLOB`**
+  - Validate the BLOB URL and headers, delegate to the `apps`-owned `[BLOB processor]` (`blobprocessor.IRequestHandler.HandleWrite` / `HandleRead`) which streams bytes between the client and `[(BLOB storage)]`; return `503 Service Unavailable` with `Retry-After` when the handler is busy.
+
+- **`Subscribe to N10n over SSE`**
+  - Parse the subscription payload, open an SSE stream (`Content-Type: text/event-stream`), create a channel on the `apps`-owned `[N10n broker]`, subscribe to the requested projection keys, and forward broker updates to the client until the request context is cancelled.
+
+- **`Reject excess concurrent query`**
+  - When the per-`WSID` query count reaches `MaxQueriesPerWS`, reply `503 Service Unavailable` and aggregate per-extension rejection counters logged every `10s`.
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- *Client
+    |
+    v
+Listeners
+    |
+    +-- [Public listener]
+    |
+    v
+Entry points
+    |
+    +-- [API v1 handler]
+    +-- [API v2 handler]
+    +-- [BLOB handler]
+    +-- [N10N SSE handler]
+    +-- [Router checker]
+    |
+    v
+In-pipeline operators
+    |
+    +-- [Request validator]
+    +-- [CORS wrapper]
+    +-- [Query limiter]
+    +-- [VSqlUpdate v1 shim]
+    +-- [Response writer]
+    |
+    v
+Boundary to apps
+    |
+    +-- [bus.IRequestSender]
+    +-- [blobprocessor.IRequestHandler]
+    +-- [in10n.IN10nBroker]
+```
+
+### Listeners
+
+- `[Public listener]`
+  - `[HTTP server]` bound to `RouterParams.Port`. On `Port == 443` (`HTTPSPort`) wrapped by `httpsService` which configures `tls.Config{GetCertificate: crtMgr.GetCertificate, MinVersion: tls.VersionTLS12}` and serves via `ServeTLS`; otherwise serves plain HTTP. Optional PROXY-protocol decoration and connection-count cap are applied by the shared `[HTTP server]` from [arch.md](./arch.md#cross-subsystem-components). Certificate provisioning and `crtMgr` lifecycle: [arch-tls.md](./arch-tls.md).
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+### Entry points
+
+- `[API v1 handler]`
+  - `RequestHandler_V1` registered on `POST|PATCH|OPTIONS /api/{appOwner}/{appName}/{wsid:[0-9]+}/{resourceName}`. Builds a `bus.Request`, optionally acquires `[Query limiter]` (for `q.*` and the `[VSqlUpdate v1 shim]`), sends through `[bus.IRequestSender]`, and replies via `[Response writer]`.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+- `[API v2 handler]`
+  - Family of handlers registered by `registerHandlersV2` covering `docs`, `cdocs`, `commands`, `queries`, `views`, `schemas` (`/api/v2/apps/{owner}/{app}/...`), workspace roles, BLOB temporary and persistent endpoints, and a generic catch-all for unknown v2 paths. Every handler acquires `[Query limiter]` and forwards through `[bus.IRequestSender]`.
+  - Path to file: [pkg/router/impl_apiv2.go](../../../../pkg/router/impl_apiv2.go)
+
+- `[BLOB handler]`
+  - `blobHTTPRequestHandler_Write` on `POST|OPTIONS /blob/{appOwner}/{appName}/{wsid}` and `blobHTTPRequestHandler_Read` on `POST|GET|OPTIONS /blob/{appOwner}/{appName}/{wsid}/{blobIDOrSUUID}`. Each calls `[blobprocessor.IRequestHandler]` and falls back to `503 Service Unavailable` with `Retry-After: 1` when the handler reports it is overloaded.
+  - Path to file: [pkg/router/impl_blob.go](../../../../pkg/router/impl_blob.go)
+
+- `[N10N SSE handler]`
+  - Four handlers on `GET /n10n/...`: `subscribeAndWatchHandler` (`/n10n/channel` - opens an SSE stream and subscribes), `subscribeHandler` (`/n10n/subscribe`), `unSubscribeHandler` (`/n10n/unsubscribe`), and `updateHandler` (`/n10n/update/{offset}`). Each manipulates a channel on `[in10n.IN10nBroker]` and streams events over `text/event-stream` until the request context is cancelled. `routerService.Stop` waits for `MetricNumSubscriptions() == 0` before completing shutdown.
+  - Path to file: [pkg/router/impl_n10n.go](../../../../pkg/router/impl_n10n.go)
+
+- `[Router checker]`
+  - `POST|GET|OPTIONS /api/check` replies `ok`; used by health probes.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+### In-pipeline operators
+
+- `[Request validator]`
+  - `withValidateForFuncs` / `withValidateForBLOBs` parse URL placeholders into a `validatedData` record (`appQName`, `wsid`, headers, body) and short-circuit malformed requests before any apps-side dispatch.
+  - Path to file: [pkg/router/impl_validation.go](../../../../pkg/router/impl_validation.go)
+
+- `[CORS wrapper]`
+  - Shared with the rest of the routing context; see [arch.md](./arch.md#cross-subsystem-components).
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+- `[Query limiter]`
+  - Shared with the rest of the routing context; see [arch.md](./arch.md#cross-subsystem-components). On the public listener it wraps every API v2 handler and the `q.*` / `q.cluster.VSqlUpdate2` paths of `[API v1 handler]`; the admin endpoint mounts the same handler set but with the limiter disabled (`limiter is nil for Admin and ACME services`, see [arch.md](./arch.md#cross-subsystem-components)). Rejections reply `503 Service Unavailable`.
+  - Path to file: [pkg/router/impl_limiter.go](../../../../pkg/router/impl_limiter.go)
+
+- `[VSqlUpdate v1 shim]`
+  - `dispatchVSqlUpdateShim_V1` re-routes API v1 `c.cluster.VSqlUpdate` calls to `q.cluster.VSqlUpdate2` so the workpiece runs on the query processor instead of synchronously re-entering the command processor.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+- `[Response writer]`
+  - `initResponse` / `reply_v1` / `reply_v2` translate the `bus.ResponseMeta` mode (`Single`, `StreamJSON`, `StreamEvents`) into HTTP headers and stream-or-buffer the response body; `applySysErrorHeaders` propagates `coreutils.SysError` headers.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+### Boundary to apps
+
+- `[bus.IRequestSender]`
+  - Asynchronous request bus carrying every API v1 / API v2 request from ingress to the matching processor in the `apps` context; the response channel is consumed by `[Response writer]`. Definition and processors: see [../apps/arch-processing.md](../apps/arch-processing.md).
+  - Path to file: [pkg/bus/interface.go](../../../../pkg/bus/interface.go)
+
+- `[blobprocessor.IRequestHandler]`
+  - HandleWrite / HandleRead surface implemented by the `apps`-owned `[BLOB processor]`; ingress streams bytes through it without owning BLOB metadata or storage. See [../apps/arch-processing.md](../apps/arch-processing.md).
+  - Path to file: [pkg/processors/blobber/interface.go](../../../../pkg/processors/blobber/interface.go)
+
+- `[in10n.IN10nBroker]`
+  - Channel / subscription / watch surface implemented by the `apps`-owned `[N10n broker]`; ingress opens channels, subscribes to projection keys, and forwards updates over SSE. See [../apps/arch-processing.md](../apps/arch-processing.md).
+  - Path to file: [pkg/in10n/interface.go](../../../../pkg/in10n/interface.go)
+
+## Scenarios
+
+### Dispatch API v1 request
+
+```text
+*Client POST /api/{owner}/{app}/{wsid}/{resource}
+  -> [Public listener] -> [Router (gorilla/mux)] match "api"
+  -> [CORS wrapper] -> [Request validator]
+  -> if q.* or VSqlUpdate shim: [Query limiter].acquire(WSID)
+  -> if VSqlUpdate shim: [VSqlUpdate v1 shim] -> q.cluster.VSqlUpdate2
+  -> else: [bus.IRequestSender].SendRequest -> apps processor
+  -> [Response writer] (Single / StreamJSON / StreamEvents)
+  -> *Client
+```
+
+### Dispatch API v2 request
+
+```text
+*Client {GET|POST|PATCH|DELETE} /api/v2/apps/{owner}/{app}/...
+  -> [Public listener] -> [Router (gorilla/mux)] match by API v2 path
+  -> [CORS wrapper] -> [Request validator]
+  -> [Query limiter].acquire(WSID)
+  -> [API v2 handler] -> [bus.IRequestSender] -> apps v2 processor
+  -> [Response writer]
+  -> *Client
+```
+
+### Transfer BLOB
+
+```text
+*Client {POST|GET} /blob/{owner}/{app}/{wsid}[/{blobID}]
+  -> [Public listener] -> [Router (gorilla/mux)] match "blob write" / "blob read"
+  -> [CORS wrapper] -> [Request validator (BLOBs)]
+  -> [BLOB handler] -> [blobprocessor.IRequestHandler].HandleWrite / HandleRead
+       (apps-owned [BLOB processor] streams bytes to/from [(BLOB storage)])
+  -> if handler returns false: HTTP 503 Service Unavailable + Retry-After
+  -> *Client
+```
+
+### Subscribe to N10n over SSE
+
+```text
+*Client GET /n10n/channel?payload={SubjectLogin,ProjectionKey[]}
+  -> [Public listener] -> [Router (gorilla/mux)] match "/n10n/channel"
+  -> [CORS wrapper] -> [N10N SSE handler].subscribeAndWatchHandler
+  -> set headers: Content-Type=text/event-stream, Cache-Control=no-cache, Connection=keep-alive
+  -> [in10n.IN10nBroker].NewChannel -> Subscribe(channel, projectionKey)
+  -> stream "event: <name>\ndata: <payload>\n\n" until req.Context() is done
+  -> on Stop: routerService.Stop waits for MetricNumSubscriptions() == 0
+```
+
+### Reject excess concurrent query
+
+```text
+*Client query while [Query limiter] count for WSID == MaxQueriesPerWS
+  -> [Public listener] -> [Router (gorilla/mux)] -> [CORS wrapper] (sets CORS headers, also on rejection)
+  -> [Query limiter].acquire returns false
+  -> onQueryDrop: increment per (WSID, extension) counter; flush aggregated log every 10s
+  -> replyServiceUnavailable: HTTP 503 Service Unavailable
+  -> *Client
+```

--- a/uspecs/specs/prod/routing/arch-reverse-proxy.md
+++ b/uspecs/specs/prod/routing/arch-reverse-proxy.md
@@ -1,0 +1,162 @@
+# Context subsystem architecture: prod/routing/reverse-proxy
+
+Routing reverse-proxy subsystem architecture: a single matcher registered last on the public router that forwards any request not consumed by API, BLOB, N10N, or debug routes to an operator-configured upstream. Context-level overview: [arch.md](./arch.md).
+
+## External actors
+
+Roles:
+
+- `@Admin`
+  - Configures the route table at VVM startup via `RouterParams.RouteDefault`, `Routes`, `RoutesRewrite`, and `RouteDomains`. Per-app dynamic registration is not implemented.
+
+Systems:
+
+- `*Client`
+  - External caller whose request is not matched by any API / BLOB / N10N / debug handler.
+
+- `*Upstream`
+  - External HTTP service (e.g. Grafana, reseller portal, fallback "not found" page) reached by the reverse proxy.
+
+## Scenarios overview
+
+- **`Forward host-based domain route`**
+  - When the request host (without port) is a key in `RouteDomains`, rewrite the request to the configured target host and forward.
+
+- **`Forward path-prefix route`**
+  - When the request path starts with a prefix in `Routes`, forward to the configured target preserving the original path.
+
+- **`Forward path-prefix route with rewrite`**
+  - When the request path starts with a prefix in `RoutesRewrite`, replace the matched prefix with the target path before forwarding.
+
+- **`Forward to default route`**
+  - When no host or path matches and `RouteDefault` is configured, prepend the default target path to the original request path and forward.
+
+- **`Decline unmatched request`**
+  - When neither a domain, path, nor default route matches, the matcher returns false and gorilla/mux replies with `404 Not Found`.
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- @Admin
+    +-- *Client
+    +-- *Upstream
+    |
+    v
+Entry points
+    |
+    +-- [Reverse-proxy matcher]
+    |
+    v
+In-pipeline operators
+    |
+    +-- [Route table parser]
+    +-- [Domain rule]
+    +-- [Path-prefix rule]
+    +-- [Rewrite rule]
+    +-- [Default rule]
+    +-- [Request redirector]
+    |
+    v
+Shared infrastructure
+    |
+    +-- [httputil.ReverseProxy]
+```
+
+### Entry points
+
+- `[Reverse-proxy matcher]`
+  - `mux.MatcherFunc` registered as the final route on the public router by `registerReverseProxyHandler`. Acts as both matcher and director: when it returns true it stores `httputil.ReverseProxy` on the route match and the rewritten request is forwarded; when it returns false gorilla/mux falls through to its default 404 handler.
+  - Path to file: [pkg/router/impl_reverseproxy.go](../../../../pkg/router/impl_reverseproxy.go)
+
+### In-pipeline operators
+
+- `[Route table parser]`
+  - `parseRoutes` validates every path prefix starts with `/` and parses every target URL once at `Prepare` time. Failures abort listener startup.
+  - Path to file: [pkg/router/impl_reverseproxy.go](../../../../pkg/router/impl_reverseproxy.go)
+
+- `[Domain rule]`
+  - Looks up the request host (with the port stripped) in `RouteDomains`; on hit, rewrites the request host to the target host and forwards regardless of path. Highest precedence _within the reverse-proxy matcher_ — domain matches short-circuit `[Path-prefix rule]` and `[Default rule]`, but only requests that fall through the earlier API / BLOB / N10N / debug routes reach the matcher in the first place (the reverse proxy is registered last on the gorilla/mux router).
+  - Path to file: [pkg/router/impl_reverseproxy.go](../../../../pkg/router/impl_reverseproxy.go)
+
+- `[Path-prefix rule]`
+  - Walks the request path one slash-separated segment at a time and looks up the accumulated prefix in the merged `Routes` + `RoutesRewrite` table; first hit wins. Non-rewrite hit forwards preserving the original path.
+  - Path to file: [pkg/router/impl_reverseproxy.go](../../../../pkg/router/impl_reverseproxy.go)
+
+- `[Rewrite rule]`
+  - On a hit whose route has `isRewrite = true`, replaces the matched prefix in the request path with the target URL's path before forwarding.
+  - Path to file: [pkg/router/impl_reverseproxy.go](../../../../pkg/router/impl_reverseproxy.go)
+
+- `[Default rule]`
+  - When neither `[Domain rule]` nor `[Path-prefix rule]` matches and `RouteDefault` is set, prepends the default target path to the original request path and forwards.
+  - Path to file: [pkg/router/impl_reverseproxy.go](../../../../pkg/router/impl_reverseproxy.go)
+
+- `[Request redirector]`
+  - `redirect` mutates the inbound `*http.Request`: sets `URL.Scheme`, `URL.Host`, `Host`, the rewritten `URL.Path`, and merges target query string with the inbound one. `httputil.ReverseProxy` is constructed with an empty `Director` because the matcher has already performed the rewrite.
+  - Path to file: [pkg/router/impl_reverseproxy.go](../../../../pkg/router/impl_reverseproxy.go)
+
+### Shared infrastructure
+
+- `[httputil.ReverseProxy]`
+  - Single reused `net/http/httputil.ReverseProxy` instance attached to every matched request. Performs the upstream round-trip and copies the response back to the client.
+  - Path to package: [net/http/httputil](https://pkg.go.dev/net/http/httputil#ReverseProxy)
+
+## Scenarios
+
+### Forward host-based domain route
+
+```text
+*Client https://resellerportal.dev.untill.ru/foo
+  -> [Reverse-proxy matcher]
+  -> [Domain rule] resellerportal.dev.untill.ru -> http://resellerportal
+  -> [Request redirector] req.URL = http://resellerportal/foo
+  -> [httputil.ReverseProxy] -> *Upstream
+```
+
+### Forward path-prefix route
+
+```text
+*Client https://alpha.dev.untill.ru/grafana/foo
+  -> [Reverse-proxy matcher]
+  -> [Path-prefix rule] /grafana -> http://10.0.0.3:3000
+  -> [Request redirector] req.URL = http://10.0.0.3:3000/grafana/foo
+  -> [httputil.ReverseProxy] -> *Upstream
+```
+
+### Forward path-prefix route with rewrite
+
+```text
+*Client https://alpha.dev.untill.ru/grafana-rewrite/foo
+  -> [Reverse-proxy matcher]
+  -> [Path-prefix rule] /grafana-rewrite -> http://10.0.0.3:3000/rewritten (isRewrite)
+  -> [Rewrite rule] /grafana-rewrite/foo -> /rewritten/foo
+  -> [Request redirector] req.URL = http://10.0.0.3:3000/rewritten/foo
+  -> [httputil.ReverseProxy] -> *Upstream
+```
+
+### Forward to default route
+
+```text
+*Client https://alpha.dev.untill.ru/unknown/foo
+  -> [Reverse-proxy matcher]
+  -> no [Domain rule] hit, no [Path-prefix rule] hit
+  -> [Default rule] RouteDefault = http://10.0.0.3:3000/not-found
+  -> [Request redirector] req.URL = http://10.0.0.3:3000/not-found/unknown/foo
+  -> [httputil.ReverseProxy] -> *Upstream
+```
+
+### Decline unmatched request
+
+```text
+*Client request with no matching route and no RouteDefault
+  -> [Reverse-proxy matcher] returns false
+  -> gorilla/mux default 404 Not Found
+  -> *Client
+```
+
+## Notes
+
+The rewrite mechanism here is not modeled on Apache `mod_rewrite`. `mod_rewrite` is a regex engine with capture groups, `RewriteCond`, per-rule flags (`[P]`, `[L]`, `[QSA]`, `[R]`), and chained rewrite passes; the matcher in `pkg/router` does literal prefix matching on host or path with a single substitution per route in a single pass. The closer analogs are Apache [`ProxyPass`](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) and Nginx [`location { proxy_pass; }`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass), which expose the same "preserve or strip the matched prefix" choice as `Routes` and `RoutesRewrite` respectively.

--- a/uspecs/specs/prod/routing/arch-reverse-proxy.md
+++ b/uspecs/specs/prod/routing/arch-reverse-proxy.md
@@ -75,11 +75,11 @@ Shared infrastructure
 ### In-pipeline operators
 
 - `[Route table parser]`
-  - `parseRoutes` validates every path prefix starts with `/` and parses every target URL once at `Prepare` time. Failures abort listener startup.
+  - `parseRoutes` validates every path prefix starts with `/` and parses `Routes` / `RoutesRewrite` target URLs once at `Prepare` time; `RouteDefault`, when configured, is parsed once at the same point. Failures abort listener startup. `RouteDomains` target URLs are not handled here — they are parsed on demand inside `[Domain rule]` during request matching and the matcher panics on a parse error.
   - Path to file: [pkg/router/impl_reverseproxy.go](../../../../pkg/router/impl_reverseproxy.go)
 
 - `[Domain rule]`
-  - Looks up the request host (with the port stripped) in `RouteDomains`; on hit, rewrites the request host to the target host and forwards regardless of path. Highest precedence _within the reverse-proxy matcher_ — domain matches short-circuit `[Path-prefix rule]` and `[Default rule]`, but only requests that fall through the earlier API / BLOB / N10N / debug routes reach the matcher in the first place (the reverse proxy is registered last on the gorilla/mux router).
+  - Looks up the request host (with the port stripped) in `RouteDomains`; on hit, parses the configured target URL on demand (panics on parse error), rewrites the request host to the target host and forwards regardless of path. Highest precedence _within the reverse-proxy matcher_ — domain matches short-circuit `[Path-prefix rule]` and `[Default rule]`, but only requests that fall through the earlier API / BLOB / N10N / debug routes reach the matcher in the first place (the reverse proxy is registered last on the gorilla/mux router).
   - Path to file: [pkg/router/impl_reverseproxy.go](../../../../pkg/router/impl_reverseproxy.go)
 
 - `[Path-prefix rule]`

--- a/uspecs/specs/prod/routing/arch-tls.md
+++ b/uspecs/specs/prod/routing/arch-tls.md
@@ -1,0 +1,125 @@
+# Context subsystem architecture: prod/routing/tls
+
+Routing TLS subsystem architecture for HTTPS certificate provisioning via ACME: the dedicated HTTP-01 challenge listener on port 80, the autocert manager that orders and caches certificates from `@ACME` (Let's Encrypt by default), and the certificate cache consumed by the public listener during TLS handshakes. Context-level overview: [arch.md](./arch.md). Public listener that consumes the certificates: [arch-ingress.md](./arch-ingress.md).
+
+## External actors
+
+Roles:
+
+- `@Admin`
+  - Configures the ACME-managed hostname whitelist and certificate cache directory via `RouterParams.HTTP01ChallengeHosts` and `RouterParams.CertDir`. See [arch.md](./arch.md#configuration).
+
+Systems:
+
+- `*Client`
+  - HTTPS caller whose TLS handshake against the public listener triggers `GetCertificate` lookups in `[autocert.Manager]`.
+
+- `@ACME`
+  - ACME directory (Let's Encrypt production by default, `https://acme-v02.api.letsencrypt.org/directory`) that issues certificates after validating control over each host via the HTTP-01 challenge.
+
+## Scenarios overview
+
+- **`Provision certificate on first request`**
+  - On a TLS handshake whose SNI matches `HTTP01ChallengeHosts` but has no cached certificate, `[autocert.Manager]` opens an ACME order, publishes the HTTP-01 key-authorization on `[ACME HTTP-01 listener]`, receives the signed certificate, persists it in `[(autocert.Cache)]`, and returns it to the public listener.
+
+- **`Serve cached certificate`**
+  - Subsequent TLS handshakes hit the in-memory or on-disk cache and complete without contacting `@ACME`.
+
+- **`Renew certificate`**
+  - `[autocert.Manager]` refreshes certificates near expiry by repeating the HTTP-01 flow in the background.
+
+- **`Reject hostname outside the whitelist`**
+  - SNI values not in `HTTP01ChallengeHosts` are refused by `[autocert.Manager]`'s `HostPolicy`, preventing rogue ACME orders that would burn the CA's per-account rate limits.
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- @Admin
+    +-- *Client
+    +-- @ACME
+    |
+    v
+Listeners
+    |
+    +-- [ACME HTTP-01 listener]
+    |
+    v
+TLS material
+    |
+    +-- [autocert.Manager]
+    +-- [(autocert.Cache)]
+```
+
+### Listeners
+
+- `[ACME HTTP-01 listener]`
+  - Separate `[HTTP server]` from [arch.md](./arch.md#cross-subsystem-components) bound to `:80` whose only handler is `autocert.Manager.HTTPHandler(nil)`, which answers `/.well-known/acme-challenge/<token>` with the key-authorization string and returns 404 for all other paths. Provisioned only when the public listener runs on `HTTPSPort` (`443`); on any other public port the TLS subsystem is not wired at all. Port `80` is mandatory: the HTTP-01 challenge spec forbids redirecting validation to a non-standard port. Uses defaults `DefaultACMEServerWriteTimeout` / `DefaultACMEServerReadTimeout`.
+  - Path to file: [pkg/router/impl_acme.go](../../../../pkg/router/impl_acme.go), [pkg/router/provide.go](../../../../pkg/router/provide.go)
+
+### TLS material
+
+- `[autocert.Manager]`
+  - `golang.org/x/crypto/acme/autocert.Manager` with `Prompt: autocert.AcceptTOS`, `HostPolicy: autocert.HostWhitelist(HTTP01ChallengeHosts...)`, `Cache: autocertCache` (caller-injected) or `autocert.DirCache(CertDir)` when nil. Exposes two surfaces consumed by routing: `GetCertificate` (wired into the public listener's `tls.Config` with `MinVersion: tls.VersionTLS12` — see [arch-ingress.md](./arch-ingress.md#listeners)) and `HTTPHandler(nil)` (wired into `[ACME HTTP-01 listener]`). Talks to the Let's Encrypt production directory by default; a comment in `provide.go` describes switching to the staging directory (`https://acme-staging-v02.api.letsencrypt.org/directory`) when issuance volume risks Let's Encrypt rate limits during testing.
+  - Path to file: [pkg/router/provide.go](../../../../pkg/router/provide.go)
+
+- `[(autocert.Cache)]`
+  - Certificate and ACME account-key store consumed by `[autocert.Manager]`. Supplied by the caller; defaults to `autocert.DirCache(RouterParams.CertDir)` when nil. Must persist across VVM restarts; losing it forces a fresh ACME account on next start and risks hitting Let's Encrypt's per-domain weekly issuance limit.
+  - Path to file: [pkg/router/provide.go](../../../../pkg/router/provide.go)
+
+## Scenarios
+
+### Provision certificate on first request
+
+```text
+*Client TLS ClientHello (SNI = host, host in HTTP01ChallengeHosts)
+  -> public [HTTP server] (see arch-ingress.md) tls.Config.GetCertificate
+  -> [autocert.Manager].GetCertificate(SNI)
+       -> [(autocert.Cache)].Get(host) returns cache miss
+       -> ACME newOrder(host) -> @ACME returns authorization with http-01 challenge {token}
+       -> [autocert.Manager] computes keyAuthorization = token.thumbprint(accountKey)
+       -> @ACME GET http://host/.well-known/acme-challenge/{token}
+            -> [ACME HTTP-01 listener] (:80) -> [autocert.Manager].HTTPHandler
+            -> respond 200 + keyAuthorization
+       -> @ACME validates control -> [autocert.Manager] submits CSR -> @ACME returns signed cert
+       -> [(autocert.Cache)].Put(host, cert+key)
+  -> *tls.Certificate returned to public listener
+  -> TLS handshake completes -> *Client
+```
+
+### Serve cached certificate
+
+```text
+*Client TLS ClientHello (SNI = host)
+  -> public [HTTP server] tls.Config.GetCertificate
+  -> [autocert.Manager].GetCertificate(SNI)
+       -> [(autocert.Cache)].Get(host) returns cert
+  -> *tls.Certificate returned -> TLS handshake completes -> *Client
+```
+
+### Renew certificate
+
+```text
+[autocert.Manager] background refresh detects expiry approaching
+  -> repeats `Provision certificate on first request` flow
+  -> [(autocert.Cache)].Put(host, new cert+key)
+```
+
+### Reject hostname outside the whitelist
+
+```text
+*Client TLS ClientHello (SNI = host, host NOT in HTTP01ChallengeHosts)
+  -> public [HTTP server] tls.Config.GetCertificate
+  -> [autocert.Manager].GetCertificate(SNI)
+       -> HostPolicy returns error
+  -> tls.Config returns no certificate -> TLS handshake aborted by Go runtime
+```
+
+## Notes
+
+The TLS subsystem is built on the [Automatic Certificate Management Environment protocol (RFC 8555)](https://datatracker.ietf.org/doc/html/rfc8555) and the [HTTP-01 challenge](https://letsencrypt.org/docs/challenge-types/#http-01-challenge); see [`golang.org/x/crypto/acme/autocert`](https://pkg.go.dev/golang.org/x/crypto/acme/autocert) for the Go implementation that voedger consumes without modification.
+
+The minimum TLS version is fixed at TLS 1.2 (`tls.VersionTLS12`) at the public listener; TLS 1.3 is disabled because of a third-party billing integration, as noted in the inline comment in `pkg/router/impl_http.go`.

--- a/uspecs/specs/prod/routing/arch.md
+++ b/uspecs/specs/prod/routing/arch.md
@@ -86,7 +86,7 @@ Configuration
 ### Cross-subsystem components
 
 - `[Admin endpoint]`
-  - Localhost-only listener on `AdminPort` (default `55555`) sharing the same handler registration sequence as the public endpoint (router checker, API v1, API v2, debug, reverse-proxy) with two carve-outs: BLOB routes are skipped because `blobRequestHandler` is nil, and the `[Query limiter]` is disabled (the comment in source: `limiter is nil for Admin and ACME services`). The VVM service pipeline (`provideServicePipeline`) runs the admin endpoint operator strictly before the bootstrap operator so `pkg/btstrp.callDeployApp` can invoke `c.cluster.DeployApp` via `federation.AdminFunc` (which targets `localhost:AdminPort`) before the public endpoint accepts external traffic.
+  - Localhost-only listener on `AdminPort` (default `55555`) sharing the same handler registration sequence as the public endpoint (router checker, API v1, API v2, debug, reverse-proxy) with two carve-outs: BLOB routes are skipped because `blobRequestHandler` is nil, and the `[Query limiter]` has no effective limit on this endpoint — `getRouterService` always allocates a non-nil `wsQueryLimiter`, but the admin service is constructed from an empty `RouterParams` so `MaxQueriesPerWS` stays `0`, and `acquire` short-circuits to `true` whenever `maxQPerWS <= 0`. The VVM service pipeline (`provideServicePipeline`) runs the admin endpoint operator strictly before the bootstrap operator so `pkg/btstrp.callDeployApp` can invoke `c.cluster.DeployApp` via `federation.AdminFunc` (which targets `localhost:AdminPort`) before the public endpoint accepts external traffic.
   - Path to file: [pkg/router/provide.go](../../../../pkg/router/provide.go)
 
 - `[HTTP server]`
@@ -98,11 +98,11 @@ Configuration
   - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
 
 - `[CORS wrapper]`
-  - Wraps every API, BLOB, and N10N handler to set `Access-Control-Allow-Origin: *`, allow the headers used by the browser SDK, and short-circuit `OPTIONS` preflight requests.
+  - Wraps API, BLOB, and N10N handlers to set `Access-Control-Allow-Origin: *` and allow the headers used by the browser SDK; for routes that include `OPTIONS` (API v1, API v2, BLOB read/write, `/api/check`, `/n10n/update/{offset}`) it also short-circuits preflight requests. The `GET`-only N10N subscribe endpoints (`/n10n/channel`, `/n10n/subscribe`, `/n10n/unsubscribe`) do not accept `OPTIONS`, so no preflight is served on them.
   - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
 
 - `[Query limiter]`
-  - Per-`WSID` concurrent-query cap (`MaxQueriesPerWS`, default `10`) gating API v1 queries and the `q.cluster.VSqlUpdate2` shim as well as every API v2 handler; rejects excess requests with `503 Service Unavailable` and logs aggregated rejections every `10s`. Disabled on the admin endpoint (`limiter is nil for Admin and ACME services`).
+  - Per-`WSID` concurrent-query cap (`MaxQueriesPerWS`, default `10`) gating API v1 `q.*` calls and the `q.cluster.VSqlUpdate2` shim, plus query-processor-bound `GET` requests on API v2 (`queries`, `views`, `docs`, `cdocs` — selected by `isQPBoundAPIPath`). Other v2 endpoints (commands, schemas, workspace roles, auth, user/device creation, BLOBs) and non-`q.*` v1 calls bypass the limiter. Rejects excess requests with `503 Service Unavailable` and logs aggregated rejections every `10s`. On the admin endpoint the limiter struct is allocated but `MaxQueriesPerWS` stays `0`, so `acquire` always succeeds (no effective limit); the ACME service runs no `routerService` at all and has no limiter.
   - Path to file: [pkg/router/impl_limiter.go](../../../../pkg/router/impl_limiter.go)
 
 ### Configuration

--- a/uspecs/specs/prod/routing/arch.md
+++ b/uspecs/specs/prod/routing/arch.md
@@ -29,7 +29,7 @@ Systems:
   - The reverse-proxy matcher (registered last on the public router) inspects the request host and path and forwards unmatched requests to the configured upstream (path-prefix, path-prefix with rewrite, host-based domain, or default fallback). Details: [arch-reverse-proxy.md](./arch-reverse-proxy.md).
 
 - **`Serve bootstrap and operator request`**
-  - The admin endpoint accepts loopback requests for internal API calls used by `pkg/btstrp` (via `federation.AdminFunc`) and for debug endpoints used by operators. Details: [arch-debug.md](./arch-debug.md).
+  - The admin endpoint accepts loopback requests for internal API calls used by `pkg/btstrp` (via `federation.AdminFunc`). The debug endpoints are mounted on every `routerService` instance — both the admin endpoint and the public listener — without authentication. Details: [arch-debug.md](./arch-debug.md).
 
 ## Components
 
@@ -80,7 +80,7 @@ Configuration
   - Path to file: [arch-reverse-proxy.md](./arch-reverse-proxy.md)
 
 - `[[Debug]]`
-  - `net/http/pprof` endpoints (`/debug/pprof`, `/debug/cmdline`, `/debug/profile`, `/debug/symbol`, `/debug/trace`) mounted on the admin endpoint (and also on the public router, currently without authentication).
+  - `net/http/pprof` endpoints (`/debug/pprof`, `/debug/cmdline`, `/debug/profile`, `/debug/symbol`, `/debug/trace`, and `/debug/{cmd}` alias) mounted by `registerDebugHandlers` on every `routerService` instance. The routes carry no authentication, role check, or method restriction and are reachable by any `*Client` on whichever listener they are mounted; access control on the public listener is an operator-side concern (network ACLs).
   - Path to file: [arch-debug.md](./arch-debug.md)
 
 ### Cross-subsystem components
@@ -159,9 +159,13 @@ pkg/btstrp.callDeployApp
   -> [Router (gorilla/mux)] -> registerHandlersV1 -> RequestHandler_V1
   -> bus.IRequestSender -> command processor
 
-@Admin / operator
-  -> [Admin endpoint] /debug/...
+*Client
+  -> [Admin endpoint] (loopback) /debug/...
   -> [[Debug]] pprof handler
+
+*Client
+  -> [Public listener] /debug/...
+  -> [[Debug]] pprof handler  (same routes, no authentication)
 ```
 
 Details: [arch-debug.md](./arch-debug.md).

--- a/uspecs/specs/prod/routing/arch.md
+++ b/uspecs/specs/prod/routing/arch.md
@@ -1,0 +1,179 @@
+# Context architecture: prod/routing
+
+Routing context architecture for the HTTP boundary of voedger: terminating client connections, dispatching API v1 and v2 requests, streaming BLOB transfers and N10N notifications, provisioning HTTPS certificates, forwarding configured paths and hosts to upstream services, and exposing the localhost-only admin endpoint used by bootstrap and operators.
+
+## External actors
+
+Roles:
+
+- `@Admin`
+  - Supplies cluster-wide operator configuration at VVM startup (reverse-proxy route table, ACME-managed hostname list, query limit, ports, TLS / proxy-protocol switches) via `RouterParams`.
+
+Systems:
+
+- `*Client`
+  - External caller invoking commands, queries, BLOB transfers, and N10n SSE subscriptions over HTTP/HTTPS.
+
+- `@ACME`
+  - ACME directory (e.g. Let's Encrypt) issuing TLS certificates via the HTTP-01 challenge served on port 80.
+
+## Scenarios overview
+
+- **`Serve client request`**
+  - Public listener accepts a TLS connection, the gorilla/mux router matches the request against API v1 / API v2 / BLOB / N10N / reverse-proxy routes, applies CORS and the per-workspace query limit where applicable, and dispatches to the matching subsystem.
+
+- **`Provision TLS certificate`**
+  - When the public listener runs on `HTTPSPort`, the autocert manager fetches and renews certificates from `@ACME` for the operator-supplied hostname whitelist; the HTTP-01 challenge listener on port 80 answers the validation requests. Details: [arch-tls.md](./arch-tls.md).
+
+- **`Forward to upstream`**
+  - The reverse-proxy matcher (registered last on the public router) inspects the request host and path and forwards unmatched requests to the configured upstream (path-prefix, path-prefix with rewrite, host-based domain, or default fallback). Details: [arch-reverse-proxy.md](./arch-reverse-proxy.md).
+
+- **`Serve bootstrap and operator request`**
+  - The admin endpoint accepts loopback requests for internal API calls used by `pkg/btstrp` (via `federation.AdminFunc`) and for debug endpoints used by operators. Details: [arch-debug.md](./arch-debug.md).
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- @Admin
+    +-- *Client
+    +-- @ACME
+    |
+    v
+Routing subsystems
+    |
+    +-- [[Ingress]]
+    +-- [[TLS]]
+    +-- [[Reverse proxy]]
+    +-- [[Debug]]
+    |
+    v
+Cross-subsystem components
+    |
+    +-- [Admin endpoint]
+    +-- [HTTP server]
+    +-- [Router (gorilla/mux)]
+    +-- [CORS wrapper]
+    +-- [Query limiter]
+    |
+    v
+Configuration
+    |
+    +-- [RouterParams]
+```
+
+### Routing subsystems
+
+- `[[Ingress]]`
+  - Public HTTP/HTTPS listener that terminates TLS and dispatches API v1 / API v2 / BLOB / N10N requests to the `apps` context.
+  - Path to file: [arch-ingress.md](./arch-ingress.md)
+
+- `[[TLS]]`
+  - HTTPS certificate provisioning via ACME: the autocert manager that orders, caches, and renews certificates from `@ACME` (Let's Encrypt) for the operator-supplied hostname whitelist, and the dedicated HTTP-01 challenge listener on port 80 that answers validation requests. Wired only when the public listener runs on `HTTPSPort`.
+  - Path to file: [arch-tls.md](./arch-tls.md)
+
+- `[[Reverse proxy]]`
+  - Last-resort matcher on the public router that forwards requests not matched by ingress routes to operator-configured upstreams.
+  - Path to file: [arch-reverse-proxy.md](./arch-reverse-proxy.md)
+
+- `[[Debug]]`
+  - `net/http/pprof` endpoints (`/debug/pprof`, `/debug/cmdline`, `/debug/profile`, `/debug/symbol`, `/debug/trace`) mounted on the admin endpoint (and also on the public router, currently without authentication).
+  - Path to file: [arch-debug.md](./arch-debug.md)
+
+### Cross-subsystem components
+
+- `[Admin endpoint]`
+  - Localhost-only listener on `AdminPort` (default `55555`) sharing the same handler registration sequence as the public endpoint (router checker, API v1, API v2, debug, reverse-proxy) with two carve-outs: BLOB routes are skipped because `blobRequestHandler` is nil, and the `[Query limiter]` is disabled (the comment in source: `limiter is nil for Admin and ACME services`). The VVM service pipeline (`provideServicePipeline`) runs the admin endpoint operator strictly before the bootstrap operator so `pkg/btstrp.callDeployApp` can invoke `c.cluster.DeployApp` via `federation.AdminFunc` (which targets `localhost:AdminPort`) before the public endpoint accepts external traffic.
+  - Path to file: [pkg/router/provide.go](../../../../pkg/router/provide.go)
+
+- `[HTTP server]`
+  - Thin wrapper over `net/http.Server` used by every listener (public, admin, ACME). Owns the TCP listener, optional PROXY-protocol decoration (`pires/go-proxyproto`), connection-count cap (`golang.org/x/net/netutil.LimitListener`), and read/write timeouts. Logs `endpoint.listen.start` on startup and `endpoint.shutdown` on graceful stop.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+- `[Router (gorilla/mux)]`
+  - Per-listener `mux.Router` populated in fixed order by `routerService.Prepare`: `registerRouterCheckerHandler` (`/api/check`) → `registerHandlersV1` (`/blob/...` when `blobRequestHandler != nil`, `/api/...`, `/n10n/...`) → `registerHandlersV2` (`/api/v2/...`) → `registerDebugHandlers` (`/debug/...`) → `registerReverseProxyHandler` (matcher-only, must be last).
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+- `[CORS wrapper]`
+  - Wraps every API, BLOB, and N10N handler to set `Access-Control-Allow-Origin: *`, allow the headers used by the browser SDK, and short-circuit `OPTIONS` preflight requests.
+  - Path to file: [pkg/router/impl_http.go](../../../../pkg/router/impl_http.go)
+
+- `[Query limiter]`
+  - Per-`WSID` concurrent-query cap (`MaxQueriesPerWS`, default `10`) gating API v1 queries and the `q.cluster.VSqlUpdate2` shim as well as every API v2 handler; rejects excess requests with `503 Service Unavailable` and logs aggregated rejections every `10s`. Disabled on the admin endpoint (`limiter is nil for Admin and ACME services`).
+  - Path to file: [pkg/router/impl_limiter.go](../../../../pkg/router/impl_limiter.go)
+
+### Configuration
+
+- `[RouterParams]`
+  - Single configuration record supplied by `@Admin` at VVM startup: public port (`Port`), `AdminPort`, read/write timeouts, connections cap, `UseProxyProtocol`, `HTTP01ChallengeHosts` and `CertDir` for ACME, `RouteDefault` / `Routes` / `RoutesRewrite` / `RouteDomains` for the reverse proxy, `MaxQueriesPerWS`. Per-app dynamic registration of routes or hosts is not implemented.
+  - Path to file: [pkg/router/types.go](../../../../pkg/router/types.go)
+
+## Scenarios
+
+### Serve client request
+
+```text
+*Client
+  -> [HTTP server] (public listener: Port=443 with TLS, or Port=DefaultPort plain)
+  -> [Router (gorilla/mux)] match by method + path
+  -> [CORS wrapper] (set CORS headers, short-circuit OPTIONS)
+  -> [Query limiter].acquire(WSID) on q.* / API v2 calls
+  -> [[Ingress]] handler -> apps context via bus.IRequestSender / blobprocessor.IRequestHandler / in10n.IN10nBroker
+  -> response back to *Client
+```
+
+Details: [arch-ingress.md](./arch-ingress.md).
+
+### Provision TLS certificate
+
+```text
+@ACME
+  -> HTTP-01 challenge on :80
+  -> ACME challenge listener (autocert.Manager.HTTPHandler) -> respond with token
+  -> autocert.Manager caches the certificate in autocert.Cache (or autocert.DirCache(CertDir))
+  -> public [HTTP server] serves TLS using crtMgr.GetCertificate for hosts in HTTP01ChallengeHosts
+```
+
+Details: [arch-tls.md](./arch-tls.md).
+
+### Forward to upstream
+
+```text
+*Client request
+  -> [Router (gorilla/mux)] no API / BLOB / N10N / debug match
+  -> [[Reverse proxy]] matcher resolves route (domain, path-prefix, rewrite, or default)
+  -> httputil.ReverseProxy forwards to upstream
+```
+
+Details: [arch-reverse-proxy.md](./arch-reverse-proxy.md).
+
+### Serve bootstrap and operator request
+
+```text
+pkg/btstrp.callDeployApp
+  -> federation.AdminFunc("api/sys.cluster/.../c.cluster.DeployApp", body)
+  -> [Admin endpoint] (localhost:AdminPort) [HTTP server]
+  -> [Router (gorilla/mux)] -> registerHandlersV1 -> RequestHandler_V1
+  -> bus.IRequestSender -> command processor
+
+@Admin / operator
+  -> [Admin endpoint] /debug/...
+  -> [[Debug]] pprof handler
+```
+
+Details: [arch-debug.md](./arch-debug.md).
+
+## Cross-cutting concerns
+
+### Context dependencies
+
+- The `apps` context owns request processing once dispatched: the `[BLOB processor]`, the `[N10n broker]`, and the command / query processors invoked via `bus.IRequestSender`. See [../apps/arch-processing.md](../apps/arch-processing.md).
+- The `auth` context owns principal token validation; routing only carries the `Authorization` header through to `apps`. See [../auth/arch.md](../auth/arch.md).
+- The `observability` context receives structured logs emitted on every listener lifecycle event, request, query-limit rejection, and N10N error.
+
+### Out-of-context implementations
+
+The standalone HTTP processor abstraction in `pkg/ihttp`, `pkg/ihttpctl`, and `pkg/ihttpimpl` (used by `cmd/voedger server`) is a parallel HTTP stack outside the production VVM wiring and is not covered here.


### PR DESCRIPTION
```yaml
change_id: 2606031418-derive-routing-context-architecture
type: docs
issue_url: https://untill.atlassian.net/browse/AIR-4160
domains: [prod]
```
## Why

The `routing` context listed in `uspecs/specs/prod/domain.md` has no Context Architecture; reviewers and contributors lack a single architecture reference for the HTTP boundary of voedger — request routing, reverse-proxy forwarding, HTTPS/ACME, BLOB and N10N endpoints, the per-workspace concurrent-query limit, domain management, and the admin/debug listener.

## What

Add architecture specifications for the `routing` context, derived from existing documentation and the codebase:

- Add a Context Architecture for `routing` split across five new files under `uspecs/specs/prod/routing/`:
  - `arch.md` — context overview, external actors and dependencies, cross-subsystem components, the admin endpoint, and links to the subsystem chapters below
  - `arch-ingress.md` — the public HTTP/HTTPS listener subsystem
  - `arch-tls.md` — the TLS / ACME subsystem (HTTPS certificate provisioning, HTTP-01 challenge listener, autocert manager and cache)
  - `arch-reverse-proxy.md` — the reverse-proxy subsystem
  - `arch-debug.md` — the debug endpoints (pprof handlers) mounted on the admin endpoint
- Cover every externally observable capability the production `routing` implementation exposes, treating the HTTP boundary as the context boundary:
  - Public HTTP/HTTPS listener that terminates TLS and dispatches API v1 and API v2 requests to the `apps` context, with CORS handling for browser callers (`arch-ingress.md`)
  - BLOB transfer endpoints (upload and download) that validate the HTTP request and delegate to the `apps`-owned `[BLOB processor]` (`arch-ingress.md`)
  - N10N real-time subscription endpoints over Server-Sent Events — subscribe, unsubscribe, channel watch, offset update — that translate HTTP calls into subscriptions on the `apps`-owned `[N10n broker]` and stream the resulting events back to the client (`arch-ingress.md`)
  - HTTPS certificate provisioning via ACME, including the dedicated HTTP-01 challenge listener on port 80 (`arch-tls.md`)
  - Per-workspace concurrent-query limit on API endpoints — a cap on in-flight queries per `WSID` configured via `MaxQueriesPerWS`, with backpressure rejections when the cap is reached (`arch-ingress.md`)
  - Reverse-proxy forwarding to external upstream services, including the four route kinds exposed to operators — path-prefix routes, path-prefix routes with rewrite, host-based domain routes, and the default fallback route (`arch-reverse-proxy.md`)
  - Admin endpoint: localhost-only listener on `AdminPort` (default `55555`) that mounts the same handler set as the public endpoint except BLOB endpoints and the per-WS query limiter; started before bootstrap so the bootstrap operator can invoke internal API functions via `federation.AdminFunc` before the public endpoint opens (`arch.md`); debug endpoints (pprof) mounted on it (`arch-debug.md`)
- Cover domain management as cluster-wide operator configuration supplied by `@Admin` at VVM startup (reverse-proxy route table and the ACME-managed hostname list); per-app dynamic domain registration is not implemented in `pkg/router` and is out of scope
- Keep boundary descriptions boundary-only: name the `apps`-side components that the `routing` context dispatches to (`[BLOB processor]`, `[N10n broker]`, command/query processors via the request bus) and cross-reference `apps/arch-processing.md` for their behavior; do not duplicate how `apps` processes the request once dispatched
- Document only the production implementation wired through the VVM (`pkg/router`); note the separate HTTP abstraction (`pkg/ihttpimpl`) as out of scope
- Give reviewers and contributors a complete architecture reference for the `routing` context that complements `uspecs/specs/prod/domain.md`

## How

Decisions:

- Author five new architecture files under `uspecs/specs/prod/routing/`: `arch.md` (context

---
Content omitted. See change.md for full details.
