### PR TITLE
docs: Derive `auth` context architecture [AIR-4185]

### DIFF
--- a/uspecs/changes/archive/2606/2606051419-derive-auth-context-architecture/change.md
+++ b/uspecs/changes/archive/2606/2606051419-derive-auth-context-architecture/change.md
@@ -49,7 +49,7 @@ Decisions:
 - Place the verifier sub-flow (issues and consumes verified-value tokens for email verification and password reset) under the authentication chapter, since its only consumers are authn flows in `pkg/registry`
 - Derive the authorization chapter's four-source effective-roles model from `pkg/iauthnzimpl/impl.go` (invite-granted, subjects doc, principal token incl. `GlobalRoles`, ACL-engine-emitted contextual roles plus VSQL inheritance)
 - Reconcile existing TDs in the same change rather than deferring to a follow-up issue
-- Derive the two login-lifecycle behaviors (listed in `## What`) from `pkg/registry/utils.go` `IsActive` / `errLoginDoesNotExist`
+- Derive the two login-lifecycle behaviors (listed in `## What`) from `pkg/registry/utils.go` `IsActive` check and `pkg/registry/impl_issueprincipaltoken.go`'s `errLoginOrPasswordIsIncorrect` response
 
 Out of scope:
 

--- a/uspecs/changes/archive/2606/2606051419-derive-auth-context-architecture/change.md
+++ b/uspecs/changes/archive/2606/2606051419-derive-auth-context-architecture/change.md
@@ -1,0 +1,109 @@
+---
+change_id: 2606050903-derive-auth-context-architecture
+type: docs
+issue_url: https://untill.atlassian.net/browse/AIR-4185
+domains: [prod]
+---
+
+# Change request: Derive `auth` context architecture
+
+Refs:
+
+- [AIR-4185: voedger: derive architecture from auth context](./issue-AIR-4185.md)
+
+## Why
+
+The `auth` context listed in `uspecs/specs/prod/domain.md` covers authentication, authorization, token management, and workspace membership, but the existing `uspecs/specs/prod/auth/arch.md` covers only the authentication (authn) flows; authorization, principal token validation on request processing, and invite-based workspace membership have no Context Architecture or Context Subsystem Architecture reference. There is also no Context Architecture overview that ties the four subsystems together, so a reader cannot see how authn, authz, token management, and membership compose into a single context. Principal token issue and refresh have no arch coverage either — only validation is implicitly described inside the existing authn material. Finally, the existing `authn--td.md`, `authn.feature`, and `invites--td.md` were written before the four-subsystem split was made explicit in `domain.md` and may diverge from the new arch chapters as derivation surfaces contradictions, so they must be reconciled in the same change.
+
+## What
+
+Add architecture specifications for the `auth` context, derived from scratch from the current codebase across the entire repository:
+
+- Add a Context Architecture summary at `uspecs/specs/prod/auth/arch.md` that overviews the full `auth` context (authn, authz, token management, workspace membership) and links to its subsystem architectures, replacing the current narrow authn-only content at the same path
+- Add a Context Subsystem Architecture for authentication at `uspecs/specs/prod/auth/arch-authn.md` covering login creation (including login-alias set/update/clear), sign-in (by login or by active alias), password lifecycle, the verifier sub-flow that issues and consumes verified-value tokens (email verification, password reset), and the profile workspace readiness gate seen by sign-in (excluding principal token issue/refresh, which belongs to the token management chapter, and excluding profile workspace lifecycle itself, which stays owned by the `apps` context)
+- The authentication chapter must explicitly document two login-lifecycle behaviors observable to clients:
+  - when a profile workspace is deactivated, the deactivation propagates to `[(registry.Login)].IsActive=false` via `c.sys.OnChildWorkspaceDeactivated`; the deactivated login is treated as a missing login by subsequent `[q.registry.IssuePrincipalToken]` calls, which return the shared `errLoginOrPasswordIsIncorrect` response (HTTP 401, "login or password is incorrect") — the same response used for missing logins and wrong passwords to prevent enumeration
+  - re-creating a login with the same name creates a new login with a fresh profile workspace; the previously deactivated login and its profile workspace remain in storage but become unreachable
+- Add a Context Subsystem Architecture for authorization at `uspecs/specs/prod/auth/arch-authz.md` covering runtime ACL evaluation and the enforcement points exposed to other contexts (notably the `apps` context processors); VSQL schema parsing of role and grant declarations stays owned by the `apps` context, and the management of the subjects doc and joined-workspace records stays owned by the workspace membership chapter
+- The authorization chapter must enumerate the four sources of a principal's effective roles by origin:
+  - invite-granted roles — `[(cdoc.sys.Subject)]` rows in the request workspace, produced by the workspace membership subsystem
+  - token-carried roles — `PrincipalPayload.Roles` (per-app) and `PrincipalPayload.GlobalRoles` (cross-workspace), snapshotted at sign-in by the authentication subsystem
+  - request-context roles — derived at composition time from request state: `role.sys.ProfileOwner` when the request workspace is the principal's own profile, `role.sys.WorkspaceOwner` when the principal owns the request workspace, `role.sys.WorkspaceDevice` for allowed devices, `role.sys.System` for system tokens, plus `role.sys.AuthenticatedUser` and the `Host` principal
+  - anonymous-grants — emitted when no token is presented: `role.sys.Anonymous`, the `sys.Guest` user, and any `[(cdoc.sys.Subject)]` rows matching `sys.Guest`
+  - VSQL-declared role inheritance (e.g., `role.sys.ProfileOwner` implies `role.sys.WorkspaceOwner`) is expanded by the ACL engine at evaluation time, not during principal composition
+- Add a Context Subsystem Architecture for token management at `uspecs/specs/prod/auth/arch-tokens.md` covering principal token issue, refresh, validation, and the principal payload contract shared by the authentication and authorization subsystems; the principal payload contract carries the alias snapshot captured at token-issue time and is immune to subsequent alias changes (per the existing alias-snapshot scenarios in `authn.feature`); verified-value tokens are out of scope here and covered by the authentication chapter, since their only consumer is the verifier sub-flow
+- Add a Context Subsystem Architecture for workspace membership at `uspecs/specs/prod/auth/arch-membership.md` covering the invite lifecycle, the subjects doc, joined-workspace records, role updates, and member removal
+- Introduce the shared auth-context concepts once in `arch.md` — Principal Token, the subjects doc, the login record, and the `pkg/iauthnz` apps→auth enforcement boundary — and cross-link them from the subsystem chapters that produce or consume them; per-subsystem chapters reference the shared definition rather than restating it
+- Treat the existing `auth/arch.md`, `auth/authn--td.md`, `auth/authn.feature`, and `auth/invites--td.md` as reference material consulted during derivation to capture key architectural points the codebase alone might not surface; do not treat them as authoritative sources, since they may be outdated; the new `arch.md` replaces the current one at the same path
+- Update `auth/authn--td.md`, `auth/authn.feature`, and `auth/invites--td.md` in lockstep with the new arch chapters so that every divergence found during derivation is reconciled in this change (no stale or contradictory material left behind); each TD continues to live at its current path and keeps its scope (feature/technical design, not architecture)
+- Give reviewers and contributors a single architecture reference for the `auth` context that complements `uspecs/specs/prod/domain.md` and mirrors the structure of `uspecs/specs/prod/apps/arch.md`
+
+## How
+
+Decisions:
+
+- Adopt uspecs-td conventions: `arch.md` for the Context Architecture, `arch-{subsystem}.md` for Context Subsystem Architectures, mirroring `uspecs/specs/prod/apps/`
+- Split the `auth` context into four subsystems matching `domain.md`: authentication (`arch-authn.md`), authorization (`arch-authz.md`), token management (`arch-tokens.md`), workspace membership (`arch-membership.md`)
+- Derive each chapter from scratch from the current codebase; treat the existing `auth/arch.md`, `auth/authn--td.md`, `auth/authn.feature`, `auth/invites--td.md` as reference material only, not authoritative
+- Introduce shared cross-cutting concepts (Principal Token, the subjects doc, the login record, the `pkg/iauthnz` apps→auth enforcement boundary) once in `arch.md` and cross-link them from the subsystem chapters that produce or consume them
+- Place the verifier sub-flow (issues and consumes verified-value tokens for email verification and password reset) under the authentication chapter, since its only consumers are authn flows in `pkg/registry`
+- Derive the authorization chapter's four-source effective-roles model from `pkg/iauthnzimpl/impl.go` (invite-granted, subjects doc, principal token incl. `GlobalRoles`, ACL-engine-emitted contextual roles plus VSQL inheritance)
+- Reconcile existing TDs in the same change rather than deferring to a follow-up issue
+- Derive the two login-lifecycle behaviors (listed in `## What`) from `pkg/registry/utils.go` `IsActive` / `errLoginDoesNotExist`
+
+Out of scope:
+
+- VSQL schema parsing of role and grant declarations (owned by the `apps` context)
+- Profile workspace lifecycle — creation, profile-fields write-back (owned by the `apps` context); only the readiness gate seen by sign-in is in scope
+- Authnz/ACL enforcement-point internals within command/query/actualizer processors (owned by the `apps` context processing chapter; auth chapters only describe the `pkg/iauthnz` boundary they expose)
+- Any behavior change to auth code paths
+- Updates to `uspecs/specs/prod/domain.md`
+
+References:
+
+- [auth context in the domain specification](../../../../../uspecs/specs/prod/domain.md)
+- [existing auth arch reference material](../../../../../uspecs/specs/prod/auth/arch.md)
+- [existing authn technical design](../../../../../uspecs/specs/prod/auth/authn--td.md)
+- [existing authn feature](../../../../../uspecs/specs/prod/auth/authn.feature)
+- [existing invites technical design](../../../../../uspecs/specs/prod/auth/invites--td.md)
+- [apps context architecture as structural model](../../../../../uspecs/specs/prod/apps/arch.md)
+- [authnz interface used at enforcement points](../../../../../pkg/iauthnz)
+- [authnz implementation with contextual role emission and role-source composition](../../../../../pkg/iauthnzimpl/impl.go)
+- [registry package: login lifecycle, principal token issue/refresh, reset-password](../../../../../pkg/registry)
+- [authnz shared constants and types](../../../../../pkg/sys/authnz)
+- [invite package: invite lifecycle, subjects doc, joined-workspace records](../../../../../pkg/sys/invite)
+- [verifier package: verified-value token issuance and consumption](../../../../../pkg/sys/verifier)
+- [token payload contracts](../../../../../pkg/itokens-payloads/types.go)
+- [tokens interface](../../../../../pkg/itokens)
+
+## Functional design
+
+- [x] update: [auth/authn.feature](../../../../specs/prod/auth/authn.feature)
+  - update: reconcile scenarios with the new `arch-authn.md` and `arch-tokens.md` so no scenario contradicts the derived architecture (verifier sub-flow, principal token issue/refresh, profile workspace readiness gate)
+  - add: scenarios covering the two login-lifecycle behaviors required by `## What` (deactivated-login and recreate-same-name)
+
+## Technical design
+
+- [x] update: [auth/arch.md](../../../../specs/prod/auth/arch.md)
+  - rewrite: replace the current authn-only content with a Context Architecture overview of the full `auth` context (authn, authz, token management, workspace membership) and links to its subsystem architectures per `## What`
+  - add: shared cross-cutting auth-context concepts defined once and cross-linked from the subsystem chapters that produce or consume them per `## What`
+
+- [x] create: [auth/arch-authn.md](../../../../specs/prod/auth/arch-authn.md)
+  - Context Subsystem Architecture for authentication; scope per `## What` (including login-alias set/update/clear, sign-in by login or by active alias, the verifier sub-flow, the profile workspace readiness gate, and the two login-lifecycle behaviors)
+
+- [x] create: [auth/arch-authz.md](../../../../specs/prod/auth/arch-authz.md)
+  - Context Subsystem Architecture for authorization; scope per `## What` (runtime ACL evaluation, enforcement points exposed to other contexts, and the four sources of effective roles)
+
+- [x] create: [auth/arch-tokens.md](../../../../specs/prod/auth/arch-tokens.md)
+  - Context Subsystem Architecture for token management; scope per `## What` (principal token issue/refresh/validation and the principal payload contract, including the alias snapshot captured at token-issue time and its immunity to subsequent alias changes)
+
+- [x] create: [auth/arch-membership.md](../../../../specs/prod/auth/arch-membership.md)
+  - Context Subsystem Architecture for workspace membership; scope per `## What` (invite lifecycle, subjects doc, joined-workspace records, role updates, member removal)
+
+- [x] update: [auth/authn--td.md](../../../../specs/prod/auth/authn--td.md)
+  - update: reconcile with the new `arch-authn.md` and `arch-tokens.md` so no statement contradicts the derived architecture, including the alias snapshot semantics in the principal payload contract
+  - remove: any material that duplicates content now owned by `arch-authn.md`, `arch-tokens.md`, or the shared concepts in `arch.md`; replace with references
+
+- [x] update: [auth/invites--td.md](../../../../specs/prod/auth/invites--td.md)
+  - update: reconcile with the new `arch-membership.md` and `arch-authz.md` so no statement contradicts the derived architecture (subjects doc and joined-workspace records as the membership data sources consumed by authz)
+  - remove: any material that duplicates content now owned by `arch-membership.md`, `arch-authz.md`, or the shared concepts in `arch.md`; replace with references

--- a/uspecs/changes/archive/2606/2606051419-derive-auth-context-architecture/decisions.md
+++ b/uspecs/changes/archive/2606/2606051419-derive-auth-context-architecture/decisions.md
@@ -1,0 +1,298 @@
+# Decisions: Derive `auth` context architecture
+
+## Inconsistency: `change.md` lists four `auth` scope areas but only three subsystem architecture chapters
+
+Decision: Add a fourth Context Subsystem Architecture for token management covering issue, refresh, validation, and the principal and verified-value payload contracts
+
+- Pros: one-stop reference for token shape, lifetime, and validation; mirrors `domain.md`'s four-way split exactly; payload contract is a real cross-cutting concern between authn and authz
+- Cons: more files to maintain; risks duplicating material that will already appear in the authn (issue/refresh) and authz (validation) chapters
+- Confidence: user-provided
+
+Alternatives:
+
+1. Drop "token lifecycle" from the overview list; document the split explicitly (token issue/refresh in the authentication subsystem, token validation in the authorization subsystem)
+   - Pros: KISS — three chapters match the natural enforcement-vs-issuance boundary already present in the codebase (`pkg/registry` issues; `pkg/iauthnz` validates); avoids a thin chapter that mostly cross-references the other two
+   - Cons: readers scanning for "token management" have to look in two places; the JWT payload contract has no single home
+   - Confidence: high
+2. Drop "token lifecycle" from the overview list AND drop "principal token validation" from the authorization bullet, treating tokens as an internal authn implementation detail referenced only from the authn chapter
+   - Pros: smallest scope; clearest single-owner model
+   - Cons: misrepresents reality — `pkg/iauthnz` validates tokens on every request as part of authorization, not authentication; would force authz to silently depend on authn internals
+   - Confidence: low
+
+## Ambiguity: how the existing `auth/arch.md` content is handled when it is "replaced"
+
+Decision: Derive all chapters from scratch from the current codebase across the entire repository; the new `arch.md` is a summary linking to subsystem chapters and replaces the current `arch.md` at the same path; treat the existing `auth/arch.md`, `authn--td.md`, `authn.feature`, and `invites--td.md` as reference material consulted during derivation to extract key architectural points the codebase alone might not surface, but not as authoritative sources, since they may be outdated
+
+- Pros: codebase-grounded chapters cannot inherit stale wording from the existing docs; reference material is still mined so key historical points are not lost; the end state's authority on architecture is the code itself
+- Cons: largest review surface — each chapter is written from scratch; reviewers must verify both code coverage and that nothing important from the reference docs was missed; derivation effort is highest of the considered options
+- Confidence: user-provided
+
+Alternatives:
+
+1. Migrate the existing `arch.md` material verbatim into the new authentication subsystem chapter (split only between the new `arch.md` overview and the authn chapter), with token-related sections moved to the token-management chapter; no wording changes beyond the split
+   - Pros: minimum review surface; zero risk of behavior-level wording drift; lets reviewers verify the change is purely a restructure plus three new chapters
+   - Cons: leaves the authn chapter slightly long and partially redundant with `authn--td.md` (which is the deeper feature-level technical design); inherits any staleness already present in `arch.md`
+   - Confidence: high
+2. Rewrite the authentication chapter as a concise architecture-level summary and treat `authn--td.md` and `authn.feature` as the source of truth for the detailed scenarios; cross-reference rather than duplicate
+   - Pros: cleaner separation between architecture (arch-\*) and feature TD layers per uspecs-td conventions; smaller authn chapter
+   - Cons: larger review surface; reviewers must verify the rewrite preserves the architectural claims of today's `arch.md`; risk of unintended wording drift; depends on TD documents being accurate
+   - Confidence: medium
+3. Leave the existing `arch.md` in place as the authentication subsystem chapter (rename it to the authn chapter file name with no content change) and add a fresh `arch.md` overview plus the three other subsystem chapters alongside it
+   - Pros: smallest possible diff for the authn material — pure rename plus token-section excision; one less file rewrite
+   - Cons: `arch.md` rename leaves stale anchor links from any external doc that points at `auth/arch.md#…`; mixing rename with new files makes the diff harder to read; inherits any staleness already present in `arch.md`
+   - Confidence: medium
+
+## Ambiguity: whether profile workspace lifecycle is inside the auth chapter scope or a cross-context reference
+
+Decision: Authentication chapter covers only the profile workspace readiness gate visible to sign-in; profile workspace lifecycle stays owned by the `apps` context; additionally, the authentication chapter must explicitly document two login-lifecycle behaviors observable to clients — (a) when a profile workspace is deactivated, the deactivation propagates to `[(registry.Login)].IsActive=false` via `c.sys.OnChildWorkspaceDeactivated` (`pkg/sys/workspace/impl_deactivate.go`); the deactivated login is treated as a missing login by `GetCDocLogin` (`pkg/registry/utils.go` `IsActive` check returns `(nil, false, nil)` and logs "is deactivated, treating as missing login"), so subsequent `[q.registry.IssuePrincipalToken]` calls return the shared `errLoginOrPasswordIsIncorrect` response (HTTP 401, "login or password is incorrect") — the same response used for missing logins and wrong passwords to prevent enumeration; (b) re-creating a login with the same name creates a new login with a fresh profile workspace, and the previously deactivated login and its profile workspace remain in storage but become unreachable
+
+- Pros: keeps the auth/apps boundary clean and matches the current `[[Profile workspace lifecycle]]` cross-context marker; surfaces two non-obvious sign-in failure modes that integrators routinely hit; the architecture chapter, not just deeper TDs, carries these client-visible facts
+- Cons: edge-case behavior claims are typically the domain of feature TDs (`authn--td.md`) or feature scenarios, not architecture chapters; risks the architecture chapter accumulating similar specific facts over time
+- Confidence: user-provided
+
+Alternatives:
+
+1. Authentication chapter covers the full profile workspace lifecycle (creation, readiness, profile fields write-back), pulling that material into the auth context
+   - Pros: end-to-end login-to-sign-in story in one place; no cross-context dependency for the most common reader question
+   - Cons: duplicates / contradicts material that belongs to the `apps` context; widens this change's blast radius to touch apps-context architecture; risks contradicting future updates to apps workspace specs
+   - Confidence: low
+2. Drop "profile workspace readiness" from the authentication chapter scope entirely; treat readiness as a runtime concern of the sign-in scenario and reference apps for everything workspace-related
+   - Pros: smallest authn chapter scope; cleanest single-owner model
+   - Cons: hides an externally observable behavior of sign-in (sign-in fails until readiness); readers lose a key architectural fact from the authn chapter
+   - Confidence: medium
+
+## Ambiguity: authorization chapter's "role resolution from VSQL" wording does not cover invite-granted roles
+
+Decision: Expand the authorization chapter to cover runtime ACL evaluation and effective-roles computation from four role sources — invite-granted roles, roles read from `cdoc.sys.Subject` records in the request workspace, roles carried by the principal token (per-app `Roles` and cross-workspace `GlobalRoles`), and ACL-engine-emitted contextual roles based on request context (`role.sys.ProfileOwner`, `role.sys.WorkspaceOwner`, `role.sys.WorkspaceDevice`, `role.sys.System`) plus VSQL-declared role inheritance expansion (e.g., `ProfileOwner` implies `WorkspaceOwner`), all confirmed in `pkg/iauthnzimpl/impl.go`; VSQL schema parsing of role/grant declarations stays owned by the `apps` context, and the management of `cdoc.sys.Subject` / `cdoc.sys.JoinedWorkspace` records stays owned by the workspace membership chapter
+
+- Pros: captures the unconditional contextual-role emission that `pkg/iauthnzimpl` performs on every request — a key architectural fact integrators routinely miss; documents the VSQL role-inheritance chain that determines whether a permission grant actually applies; the four-source model maps 1:1 to how the code composes principals
+- Cons: broadest chapter scope of the considered options; describing role-inheritance expansion requires referencing VSQL syntax that is owned by the `apps` context, increasing the risk of duplicating role-inheritance grammar specs
+- Confidence: user-provided
+
+Alternatives:
+
+1. Three sources only (invite-granted, `cdoc.sys.Subject`, principal token) without enumerating ACL-engine-emitted contextual roles or inheritance expansion
+   - Pros: smaller chapter scope; avoids touching VSQL inheritance grammar at all
+   - Cons: hides the contextual emission (`ProfileOwner`, `WorkspaceOwner`, etc.) that happens on every request and the role-inheritance expansion that turns those into the actual ACL-matched roles
+   - Confidence: medium
+2. Re-scope to runtime ACL evaluation only, listing role sources as a black-box input but not enumerating them
+   - Pros: tightest chapter scope; no cross-chapter coupling on role shape
+   - Cons: hides the four-source composition that is the core architectural fact of `iauthnzimpl`
+   - Confidence: low
+3. Expand further to also cover VSQL schema parsing of role and grant declarations end-to-end
+   - Pros: single chapter answers all "who can do what" questions
+   - Cons: pulls VSQL ACL parsing material into authz, overlapping the `apps` context architecture
+   - Confidence: low
+
+## Inconsistency: workspace membership chapter scope (line 34) omits the subjects doc that the authz chapter (line 27) delegates to it
+
+Decision: Rewrite both lines to drop explicit QNames (`cdoc.sys.Subject`, `cdoc.sys.JoinedWorkspace`) and use conceptual wording instead — "subjects doc" and "joined-workspace records"; line 27 becomes "the management of the subjects doc and joined-workspace records stays owned by the workspace membership chapter"; line 30 becomes "roles read from the subjects doc in the request workspace"; line 34 becomes "invite lifecycle, the subjects doc, joined-workspace records, role updates, and member removal"; role QNames in line 32 stay since they are conceptual role identifiers, not records
+
+- Pros: scope statements stay at the architectural-concept level instead of binding the change request to specific VSQL QNames that may evolve; consistent terminology across all three lines; the omission flagged by the inconsistency is closed because "subjects doc" now appears in both line 27 and line 34
+- Cons: readers who grep for `cdoc.sys.Subject` in `change.md` will no longer find it; the conceptual term "subjects doc" is not yet defined in `domain.md` and will need a one-line glossary entry in the membership chapter when it is written
+- Confidence: user-provided
+
+Alternatives:
+
+1. Rewrite line 34 to explicitly name both record types and clarify the lifecycle stages, keeping line 27 unchanged
+   - Pros: terminology matches line 27 verbatim; reader can map each delegated responsibility to a concrete chapter section
+   - Cons: pins the change request to specific QNames; longest bullet in the file
+   - Confidence: high
+2. Rewrite line 34 minimally to add `cdoc.sys.Subject` alongside joined-workspace records, leaving line 27 unchanged
+   - Pros: smallest diff to fix the omission
+   - Cons: pins both lines to specific QNames; leaves "role updates" still ambiguous
+   - Confidence: high
+3. Rewrite line 27 instead to drop the record-name delegation, deferring all wording to line 34
+   - Pros: tightens line 27 and removes the cross-bullet coupling
+   - Cons: weakens the boundary statement at the place where readers will look for it
+   - Confidence: medium
+
+## Ambiguity: file paths for the four new Context Subsystem Architecture chapters are not specified
+
+Decision: Add explicit file paths to each of the four subsystem bullets, using the `arch-{subsystem}.md` convention (mirroring `uspecs/specs/prod/apps/`) with short identifiers — `uspecs/specs/prod/auth/arch-authn.md`, `arch-authz.md`, `arch-tokens.md`, `arch-membership.md`
+
+- Pros: matches the apps convention verbatim; short identifiers stay readable in markdown link text and file lists; eliminates implementer ambiguity about both convention and identifier choice
+- Cons: identifier shorthands (`authn`, `authz`, `tokens`, `membership`) diverge from the longer `domain.md` wording ("authentication", "authorization", "token management", "workspace membership")
+- Confidence: medium
+
+Alternatives:
+
+1. Add explicit file paths using full-word names (`arch-authentication.md`, `arch-authorization.md`, `arch-token-management.md`, `arch-workspace-membership.md`)
+   - Pros: file names match the chapter titles and `domain.md` wording word-for-word
+   - Cons: longer paths in link references and CLI; diverges from apps's shorter `arch-vvm-orch.md` style
+   - Confidence: medium
+2. State the convention once without listing the four exact paths
+   - Pros: smallest diff
+   - Cons: leaves the four identifiers undecided, just relocating the ambiguity
+   - Confidence: low
+
+## Ambiguity: how to handle potential staleness in `authn--td.md`, `authn.feature`, and `invites--td.md` after the new arch chapters land
+
+Decision: Expand the scope of this change to update/rewrite the three existing TD files (`auth/authn--td.md`, `auth/authn.feature`, `auth/invites--td.md`) in lockstep with the new arch chapters, reconciling every divergence found during derivation in this change so no stale or contradictory material is left behind; each TD stays at its current path and keeps its scope (feature/technical design, not architecture)
+
+- Pros: no stale material remains after the change merges; readers cannot land on contradictory information depending on which file they open; the derivation work that surfaces the divergence happens at the same time as the reconciliation, avoiding context loss between two separate changes
+- Cons: significantly widens the change's blast radius; TD revision requires the `uspecs-fd` / `uspecs-td` skills in addition to the arch derivation skills; risks the change growing too large to review in one pass
+- Confidence: user-provided
+
+Alternatives:
+
+1. Add a one-line "See also" pointer at the top of each of the three TD files; list any contradictions found in a follow-up section of `change.md` (or a separate follow-up issue) rather than fixing them in this change
+   - Pros: zero risk of scope creep on TD content; readers get a clear "newer reference exists" signal; contradictions are surfaced rather than silently propagated
+   - Cons: introduces a tiny content edit to files this change otherwise leaves alone; contradictions remain in storage until separate change requests address them
+   - Confidence: high
+2. Leave the three TD files completely untouched and log any divergence found in `change.md` under a "Follow-ups" section, to be addressed by separate change requests later
+   - Pros: smallest possible footprint on existing files; cleanest separation between "derive arch" and "reconcile TDs"
+   - Cons: leaves TDs as silent contradictions with no in-file pointer to the newer material; readers may continue citing stale TDs indefinitely
+   - Confidence: medium
+
+## Inconsistency: `## Why` does not motivate three of the deliverables in `## What`
+
+Decision: Expand `## Why` with three additional sentences so every `## What` deliverable is traceable to a stated motivation — (i) the absence of a Context Architecture overview that ties the four subsystems together, (ii) the absence of any arch coverage for principal token issue/refresh (not just validation), (iii) the risk of stale TDs diverging from the new arch chapters as derivation surfaces contradictions, requiring lockstep reconciliation
+
+- Pros: every What deliverable is traceable to a stated Why; reviewers see one justification per scope item; the four-subsystem split in What is anchored in the gap list in Why; locks in the three previous clarification decisions (overview rewrite, token lifecycle scope, TD lockstep) at the motivation level
+- Cons: lengthens `## Why` from one paragraph to four sentences; risks Why duplicating What if the wording drifts
+- Confidence: user-provided
+
+Alternatives:
+
+1. Narrow `## What` instead of expanding `## Why` — drop the context overview rewrite, drop token issue/refresh from the tokens chapter, drop the TD lockstep deliverable
+   - Pros: tightest scope; Why and What stay aligned at the smallest possible footprint
+   - Cons: reverses three previous decisions in this clarification session; leaves the auth context without an overview, the tokens chapter without lifecycle, and the TDs unreconciled
+   - Confidence: low
+2. Leave `## Why` as a high-level motivation and accept that some What deliverables are structural/hygiene work that does not need a per-item Why entry
+   - Pros: smallest diff
+   - Cons: violates the implicit traceability between Why and What; reviewers have to infer the rationale for the unmotivated deliverables
+   - Confidence: medium
+
+## Inconsistency: token management chapter wrongly describes the verified-value payload as "shared by the authentication and authorization subsystems"
+
+Decision: Drop the verified-value payload from the token management chapter scope and move it to the authentication chapter as the verifier sub-flow (issue and consume verified-value tokens for email verification and password reset); the tokens chapter keeps only the principal payload contract (which is genuinely shared between authn issuer and authz validator); `domain.md`'s listing of "Verified Value Token" as an auth-context vocabulary term stays unchanged — verified-value remains an auth concept, just owned by the authn subsystem instead of the tokens subsystem; the authn exclusion list is narrowed from "token issue/refresh" to "principal token issue/refresh" so that verified-value token issuance is not excluded from the authn chapter
+
+- Pros: removes the incorrect "shared by authn and authz" claim; aligns chapter ownership with actual code consumers (`pkg/registry/impl_resetpassword.go` and the sign-up flow are the only verified-value consumers, and both are authn flows); keeps the tokens chapter focused on the one payload that is genuinely cross-subsystem
+- Cons: the tokens chapter no longer covers all auth-context token types in one place, so a reader looking for "all token contracts" has to also open the authn chapter; introduces an explicit exclusion note in the tokens bullet
+- Confidence: user-provided
+
+Alternatives:
+
+1. Split the two payload contracts in the bullet, naming the correct consumer set for each
+   - Pros: matches actual consumer relationships in code; makes cross-subsystem contracts explicit
+   - Cons: longest bullet variant; pairs two payloads with very different lifecycles inside a single chapter
+   - Confidence: high
+2. Keep both payloads in the tokens chapter but drop the "shared by…" qualifier from the bullet
+   - Pros: minimal fix to the inconsistency without expanding the bullet
+   - Cons: loses the architectural fact (which payload is shared with what) at the level where a reader scanning `change.md` would benefit from it most
+   - Confidence: medium
+
+## Ambiguity: `arch.md` overview chapter scope does not list the cross-cutting concepts that need a single home
+
+Decision: Add a `## What` bullet that names the four cross-cutting auth-context concepts to be introduced once in `arch.md` and cross-linked from the subsystem chapters that produce or consume them — Principal Token (authn/tokens producer → authz consumer), the subjects doc (membership producer → authz consumer), the login record (authn producer → tokens consumer), and the `pkg/iauthnz` apps→auth enforcement boundary (used at every enforcement point in the apps context processors); per-subsystem chapters reference the shared definition rather than restating it
+
+- Pros: matches the apps precedent (`arch.md` line 24: "Introduce the app partitions engine once in `arch.md` as a shared component"); eliminates duplication risk across the four subsystem chapters; gives readers a single landing page for the cross-cutting vocabulary; all four concepts are code-verified producer-consumer pairs
+- Cons: lengthens `## What` by one bullet; commits the implementer to a specific shared-concepts list before derivation has surfaced what the right set actually is
+- Confidence: user-provided
+
+Alternatives:
+
+1. Add a softer bullet that names the constraint without listing the concepts ("introduce any cross-cutting auth-context concepts once in `arch.md` and cross-link them from the subsystem chapters")
+   - Pros: smaller commitment up front; lets derivation determine the exact list
+   - Cons: leaves the implementer with full discretion over what counts as "cross-cutting", which may produce inconsistent results across reviewers
+   - Confidence: medium
+2. Leave the overview chapter scope as-is and let the implementer decide what goes in `arch.md` vs subsystem chapters during derivation
+   - Pros: smallest diff to `change.md`
+   - Cons: diverges from the apps precedent; risks duplication across multiple chapters with no single source of truth
+   - Confidence: low
+
+## Ambiguity: Login Alias feature is not explicitly placed in any subsystem chapter scope
+
+Decision: Expand the authentication chapter scope to explicitly cover login-alias set/update/clear and sign-in by alias, and expand the token management chapter scope to call out the alias snapshot carried by the principal payload contract at token-issue time and its immunity to subsequent alias changes; the `authn.feature` alias scenarios (set/replace/clear under System Principal Token, sign-in by original login while alias is active, sign-in by active alias, rejection of previous or cleared aliases, alias snapshot retention in existing principal tokens) drive the derivation in both chapters
+
+- Pros: makes the Login Alias feature a first-class concern with a clear home in two chapters rather than an implicit detail; matches the existing `authn.feature` coverage so derivation will not omit it; keeps the alias-as-data (authn write/read) separate from alias-as-token-payload (tokens) following the same producer-consumer split used elsewhere
+- Cons: lengthens two `## What` bullets; pairs alias management with login creation in the same chapter scope even though alias is set via System Principal Token (a privileged path), which may warrant its own sub-section during derivation
+- Confidence: user-provided
+
+Alternatives:
+
+1. Put Login Alias entirely in the authentication chapter and only reference the alias snapshot from the tokens chapter without listing it as token-payload concern
+   - Pros: single owner for the feature; shortest change to `## What`
+   - Cons: hides the fact that the principal payload carries an alias snapshot with specific immutability semantics, which is a token-contract concern that survives alias changes
+   - Confidence: medium
+2. Leave both chapter scopes as-is and rely on derivation to pick up the alias scenarios from `authn.feature` without explicit mention in `## What`
+   - Pros: smallest diff
+   - Cons: relies on the implementer to remember a non-trivial feature not named in scope; risks splitting alias coverage inconsistently between chapters
+   - Confidence: low
+
+## Inconsistency: `arch-tokens.md` and `arch-authz.md` disagree about whether API tokens emit the `AuthenticatedUser` role
+
+Decision: Fix `arch-tokens.md` to match `arch-authz.md` and `pkg/iauthnzimpl/impl.go`; the `IsAPIToken=true` bullet now states that principal composition emits `AuthenticatedUser` and `Roles` filtered to `RequestWSID`, and omits `Host`, `GlobalRoles`, the `WorkspaceOwner`/`ProfileOwner`/`WorkspaceDevice` derivations, the `System` short-circuit, and the `[(cdoc.sys.Subject)]` read
+
+- Pros: aligns the token chapter with the authoritative source (`pkg/iauthnzimpl/impl.go` lines 53-75) and with the authz chapter; smallest, most local fix; preserves the at-a-glance composition summary in the token chapter
+- Cons: none material
+- Confidence: user-provided
+
+Alternatives:
+
+1. Fix `arch-authz.md` to match `arch-tokens.md`: state `AuthenticatedUser` is also omitted for API tokens
+   - Pros: would not require touching the tokens chapter
+   - Cons: contradicts the codebase; would make the spec wrong about observable behavior; ACL rules that gate API-token endpoints with `AuthenticatedUser` would be described as inaccessible even though they are reachable
+   - Confidence: low
+2. Reframe the bullet in `arch-tokens.md` to defer all composition semantics to `arch-authz.md` and only state that `IsAPIToken` is a payload flag the token subsystem owns
+   - Pros: cleanest DRY split — token chapter owns the payload shape, authz chapter owns the rules driven by the flag
+   - Cons: removes a useful at-a-glance summary from the token chapter; readers must jump to `arch-authz.md` for any composition detail
+   - Confidence: medium
+
+## Inconsistency: `arch-authz.md` Scenarios overview omits the `Host` principal for anonymous and non-API-token branches
+
+Decision: Add `Host` to both Scenarios overview bullets — the anonymous bullet now lists Guest, Anonymous, Host, and matching Subject rows; the user/device bullet now lists AuthenticatedUser, Host, all four role sources, and the workspace-derived roles
+
+- Pros: aligns the overview with `pkg/iauthnzimpl/impl.go` lines 20-27 (deferred `Host` emission whenever `!IsAPIToken`) and with the chapter's own detailed Scenarios block (lines 108, 124); readers scanning the overview no longer miss a principal that ACL rules may key off
+- Cons: lengthens two bullets by one principal each
+- Confidence: user-provided
+
+Alternatives:
+
+1. Drop the explicit principal enumeration from the overview entirely and have each bullet say "emits the principal set defined in the Scenarios block below"
+   - Pros: removes the redundancy that caused the divergence; single source of truth
+   - Cons: overview becomes less informative; readers have to scroll to the detailed scenario for any principal-set question
+   - Confidence: medium
+2. Add a single up-front line in the Scenarios overview: "`Host` is emitted for every branch except `IsAPIToken=true`", and keep the per-branch bullets focused on the branch-specific principals
+   - Pros: factors out the cross-branch invariant; both bullets stay short
+   - Cons: introduces a fourth structural element to the overview; readers of a single bullet still might miss the cross-cutting line
+   - Confidence: medium
+
+## Inconsistency: the "four sources of effective roles" enumeration differs across `change.md`, `arch.md`, and `arch-authz.md`
+
+Decision: Adopt a hybrid origin-perspective vocabulary across all three docs — invite-granted, token-carried, request-context, anonymous-grants — and rewrite `arch-authz.md`'s `Role sources` section to use the same labels with per-source origin + composition notes; VSQL role inheritance expansion is documented as an ACL-engine-evaluation concern, not as a composition source; `change.md` ## What and `arch.md` Scenarios overview are updated to match
+
+- Pros: single vocabulary across the three docs; ends the double-count of "invite-granted vs subjects doc" (subjects doc is the persistence boundary for invite-granted, not a separate source); ends the over-split of "principal token" into per-app vs global at the top level (both are token-carried, snapshotted at the same point); origin perspective is easier for product readers to scan; per-source notes inside each bullet preserve the per-app vs global filtering rules that the previous `Token roles` / `Global roles` split made visible
+- Cons: requires coordinated edits to `change.md`, `arch.md`, and `arch-authz.md` (plus the layers diagram and the Authenticate-request scenario block in arch-authz.md); supersedes the earlier "four role sources" wording in `decisions.md` (the entry "Authorization chapter's 'role resolution from VSQL' wording does not cover invite-granted roles" above)
+- Confidence: user-provided
+
+Alternatives:
+
+1. Align `change.md` and `arch.md` to the previous arch-authz.md model (Token / Global / Subject / Contextual) instead of changing all three to a new vocabulary
+   - Pros: aligns spec deliverable wording with code-grounded model; smaller scope (arch-authz.md unchanged)
+   - Cons: keeps the per-app/global split as top-level sources; less accessible for product readers; "Subject" label hides that the rows are invite-produced
+   - Confidence: high
+2. Align `arch-authz.md` to the change.md model (invite-granted / subjects doc / principal token / contextual)
+   - Pros: smallest diff to change.md
+   - Cons: makes arch-authz.md less precise; readers must mentally reconcile "Subject roles" with "Invite-granted roles" since they are the same rows
+   - Confidence: low
+
+## Inconsistency: `change.md` ## What and `decisions.md` describe the deactivated-profile error path inaccurately
+
+Decision: Adopt hybrid wording across `change.md` ## What and `decisions.md` — preserve the "treated as a missing login" narrative from the original ticket while explicitly naming the actual user-facing response (`errLoginOrPasswordIsIncorrect`, HTTP 401) and the correct propagation path (`InitiateDeactivateWorkspace` → `c.sys.OnChildWorkspaceDeactivated` → `cdoc.registry.Login.IsActive=false` → `GetCDocLogin` treats as missing → `IssuePrincipalToken` returns the shared error); the earlier entry "Ambiguity: whether profile workspace lifecycle is inside the auth chapter scope" above is rewritten in place to reflect this; `arch-authn.md` already states the correct error and remains unchanged
+
+- Pros: preserves the original ticket framing ("treated as missing") that makes the security intent clear; replaces the inaccurate `errLoginDoesNotExist` citation with the actual `errLoginOrPasswordIsIncorrect` response that `IssuePrincipalToken` returns; documents the full propagation chain so readers can verify the claim end-to-end; aligns `change.md` ## What with `arch-authn.md` line 73 which already had it right; preserves the enumeration-prevention property as a stated security claim
+- Cons: longer wording in both files (each line grows from a single clause to a propagation chain); two entries in `decisions.md` now describe the same login-lifecycle behavior (the original ambiguity entry plus this inconsistency entry)
+- Confidence: user-provided
+
+Alternatives:
+
+1. Fix `change.md` ## What line 25 and `decisions.md` line 47 to cite `errLoginOrPasswordIsIncorrect` directly without keeping the "treated as missing" framing
+   - Pros: shortest precise wording; single error name everywhere
+   - Cons: loses the conceptual reason (the login is intentionally indistinguishable from a missing one); reader has to infer the enumeration-prevention motivation
+   - Confidence: high
+2. Fix `arch-authn.md` to match the original `change.md`/`decisions.md` wording (`errLoginDoesNotExist`)
+   - Pros: would not require touching change.md or decisions.md
+   - Cons: contradicts `pkg/registry/impl_issueprincipaltoken.go` lines 65-66; would document an error that the sign-in endpoint never returns
+   - Confidence: low

--- a/uspecs/changes/archive/2606/2606051419-derive-auth-context-architecture/issue-AIR-4185.md
+++ b/uspecs/changes/archive/2606/2606051419-derive-auth-context-architecture/issue-AIR-4185.md
@@ -1,0 +1,16 @@
+# voedger: derive architecture from auth context
+
+- URL: https://untill.atlassian.net/browse/AIR-4185
+- ID: AIR-4185
+- State: in-progress
+- Author: Denis Gribanov
+- Assignees: Denis Gribanov
+- Labels: none
+
+## Why
+
+missing architecture for Auth context mentioned in [domain.md](https://github.com/voedger/voedger/blob/main/uspecs/specs/prod/domain.md)
+
+## What
+
+derive architeture from Auth context considering exisitng documentation and codebase.

--- a/uspecs/changes/archive/2606/2606051419-derive-auth-context-architecture/issue-AIR-4185.md
+++ b/uspecs/changes/archive/2606/2606051419-derive-auth-context-architecture/issue-AIR-4185.md
@@ -13,4 +13,4 @@ missing architecture for Auth context mentioned in [domain.md](https://github.co
 
 ## What
 
-derive architeture from Auth context considering exisitng documentation and codebase.
+derive architecture from Auth context considering existing documentation and codebase.

--- a/uspecs/specs/prod/auth/arch-authn.md
+++ b/uspecs/specs/prod/auth/arch-authn.md
@@ -1,0 +1,162 @@
+# Context subsystem architecture: prod/auth/authn
+
+Authentication subsystem architecture covering login creation (including login-alias set/update/clear), sign-in by login or by active alias, password lifecycle, the verifier sub-flow that issues and consumes verified-value tokens, and the profile workspace readiness gate seen by sign-in. Context-level overview and shared concepts: [arch.md](./arch.md). Token issue, refresh, validation, and the principal payload contract used at the end of sign-in: [arch-tokens.md](./arch-tokens.md).
+
+## External actors
+
+Roles:
+
+- `@Client`
+  - Caller signing in, creating logins, changing or resetting passwords, and running the verifier flow.
+
+- `@System`
+  - Caller with a System Principal Token that manages login aliases and global roles on behalf of trusted backend systems.
+
+## Scenarios overview
+
+- **`Create login`**
+  - `@Client` calls `[c.registry.CreateLogin]` (user) or `[c.registry.CreateEmailLogin]` (email) with a `[Verified-value token]` and credentials; a `[(registry.Login)]` is persisted, `[(view.LoginIdx)]` is updated, and the profile workspace creation is started by the registry projector.
+
+- **`Sign in by login or by active alias`**
+  - `@Client` calls `[q.registry.IssuePrincipalToken]` with a sign-in identifier; `[(registry.Login)]` is resolved either directly or via `[(registry.LoginAlias)]`, the password hash is checked, the `Profile workspace readiness gate` is enforced, and a [Principal Token](./arch-tokens.md) is issued.
+
+- **`Run verifier sub-flow`**
+  - `@Client` calls `[q.sys.InitiateEmailVerification]` to receive a verification code by email, then `[q.sys.IssueVerifiedValueToken]` to redeem the code for a `[Verified-value token]` that downstream commands (login creation, password reset) consume as proof of value ownership.
+
+- **`Change or reset password`**
+  - `@Client` calls `[c.registry.ChangePassword]` with the current password or `[c.registry.ResetPassword]` with a `[Verified-value token]`; the `[(registry.Login)]` password hash is updated in place.
+
+- **`Manage login alias`**
+  - `@System` calls `[c.registry.InitiateSetLoginAlias]`; the registry projector emits `[c.registry.PutLoginAliasIndex]` and `[c.registry.DeactivateLoginAliasIndex]` to publish or retire `[(registry.LoginAlias)]` records and updates the alias snapshot on `[(registry.Login)]`.
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- @Client
+    +-- @System
+    |
+    v
+Sign-in and lifecycle queries/commands
+    |
+    +-- [q.registry.IssuePrincipalToken]
+    +-- [c.registry.CreateLogin]
+    +-- [c.registry.CreateEmailLogin]
+    +-- [c.registry.ChangePassword]
+    +-- [c.registry.ResetPassword]
+    +-- [c.registry.InitiateSetLoginAlias]
+    +-- [c.registry.PutLoginAliasIndex]
+    +-- [c.registry.DeactivateLoginAliasIndex]
+    +-- [c.registry.UpdateGlobalRoles]
+    |
+    v
+Verifier sub-flow
+    |
+    +-- [q.sys.InitiateEmailVerification]
+    +-- [q.sys.IssueVerifiedValueToken]
+    +-- [Verified-value token]
+    |
+    v
+Registry records and indexes
+    |
+    +-- [(registry.Login)]
+    +-- [(registry.LoginAlias)]
+    +-- [(view.LoginIdx)]
+```
+
+### Sign-in and lifecycle queries/commands
+
+- `[q.registry.IssuePrincipalToken]`
+  - Resolves the sign-in identifier against `[(registry.Login)]` directly, then against `[(registry.LoginAlias)]` if the direct lookup misses; verifies the password hash, enforces the `Profile workspace readiness gate`, builds `PrincipalPayload` (with the alias snapshot captured at issue time) and delegates token issuance to [Token management](./arch-tokens.md). Returns the same `errLoginOrPasswordIsIncorrect` for missing login, deactivated login, missing alias, and wrong password to prevent enumeration.
+  - impl: [pkg/registry/impl_issueprincipaltoken.go#provideIssuePrincipalTokenExec](../../../../pkg/registry/impl_issueprincipaltoken.go)
+
+- `[c.registry.CreateLogin]`, `[c.registry.CreateEmailLogin]`
+  - Validate the request, consume a `[Verified-value token]` when required, write `[(registry.Login)]`, and trigger profile workspace creation through the registry projector. A deactivated `[(registry.Login)]` with the same login name does not block creation; a fresh `[(registry.Login)]` and profile workspace are produced.
+  - impl: [pkg/registry/impl_createlogin.go](../../../../pkg/registry/impl_createlogin.go)
+
+- `[c.registry.ChangePassword]`, `[c.registry.ResetPassword]`
+  - Update the password hash on `[(registry.Login)]`. Reset consumes a `[Verified-value token]` issued by the verifier sub-flow in place of the current password.
+  - impl: [pkg/registry/impl_changepassword.go](../../../../pkg/registry/impl_changepassword.go), [pkg/registry/impl_resetpassword.go](../../../../pkg/registry/impl_resetpassword.go)
+
+- `[c.registry.InitiateSetLoginAlias]`, `[c.registry.PutLoginAliasIndex]`, `[c.registry.DeactivateLoginAliasIndex]`
+  - Authority-gated by `@System` only. `Initiate` updates the alias snapshot on `[(registry.Login)]`; the registry projector emits `Put`/`Deactivate` to maintain `[(registry.LoginAlias)]` so that the next sign-in either resolves to the new alias or fails to resolve the retired one. Alias and primary login share the same uniqueness namespace.
+  - impl: [pkg/registry/impl_setloginalias.go](../../../../pkg/registry/impl_setloginalias.go)
+
+- `[c.registry.UpdateGlobalRoles]`
+  - Authority-gated by `@System`. Writes the comma-separated `GlobalRoles` field on `[(registry.Login)]` so that the next `[q.registry.IssuePrincipalToken]` snapshots them into `PrincipalPayload.GlobalRoles`. Consumed on every request by [Authorization](./arch-authz.md).
+  - impl: [pkg/registry/impl_updateglobalroles.go](../../../../pkg/registry/impl_updateglobalroles.go)
+
+### Verifier sub-flow
+
+- `[q.sys.InitiateEmailVerification]`, `[q.sys.IssueVerifiedValueToken]`
+  - Two-step exchange that turns proof of email control into a short-lived `[Verified-value token]` bound to a specific field value. Email delivery is performed asynchronously by `applySendEmailVerificationCode`.
+  - impl: [pkg/sys/verifier/provide.go](../../../../pkg/sys/verifier/provide.go), [pkg/sys/verifier/impl.go](../../../../pkg/sys/verifier/impl.go)
+
+- `[Verified-value token]`
+  - Bearer token whose claims prove a verification flow has succeeded for one named value. Consumed at most once by the downstream command that requires the proof.
+  - decl: [pkg/sys/verifier/consts.go](../../../../pkg/sys/verifier/consts.go)
+
+### Registry records and indexes
+
+- `[(registry.Login)]`
+  - Shared concept; see [arch.md#shared-concepts](./arch.md#shared-concepts).
+
+- `[(registry.LoginAlias)]`
+  - Per-alias CDoc used during sign-in to resolve an alias identifier to its `[(registry.Login)]`. Inactive entries (cleared or replaced aliases) are skipped by the resolver, making the retired identifier unreachable on the next sign-in.
+  - decl: [pkg/registry/appws.vsql#LoginAlias](../../../../pkg/registry/appws.vsql)
+
+- `[(view.LoginIdx)]`
+  - Sync-projector-maintained index used to enforce uniqueness on login creation and to locate `[(registry.Login)]` by name within the registry app workspace.
+  - decl: [pkg/registry/appws.vsql](../../../../pkg/registry/appws.vsql)
+  - impl: [pkg/registry/utils.go](../../../../pkg/registry/utils.go)
+
+## Scenarios
+
+### Sign in by login or by active alias
+
+```text
+@Client POST q.registry.IssuePrincipalToken (login | alias, password, appName, ttl)
+  -> [q.registry.IssuePrincipalToken]
+       -> [(view.LoginIdx)] / [(registry.Login)] direct lookup
+       -> on miss: [(registry.LoginAlias)] -> [(registry.Login)]
+       -> checkPasswordHash
+       -> Profile workspace readiness gate: if ProfileWSID == 0 or WSError != "" return error result
+       -> build PrincipalPayload(Login, Alias, SubjectKind, ProfileWSID, GlobalRoles)
+       -> [Token management].IssueToken (see arch-tokens.md)
+  -> @Client: principalToken, profileWSID
+```
+
+The `Profile workspace readiness gate` returns the same error result for deactivated logins, missing logins, and inactive aliases; the principal token is never issued for a deactivated `[(registry.Login)]`, and a recreated login of the same name resolves to its fresh `[(registry.Login)]` and fresh profile.
+
+### Create login with verifier sub-flow
+
+```text
+@Client q.sys.InitiateEmailVerification(email)
+  -> [q.sys.InitiateEmailVerification] -> async send code by email
+@Client q.sys.IssueVerifiedValueToken(email, code)
+  -> [q.sys.IssueVerifiedValueToken] -> [Verified-value token]
+@Client c.registry.CreateLogin(verifiedEmailToken, password, displayName)
+  -> [c.registry.CreateLogin]
+       -> consume [Verified-value token]
+       -> [(view.LoginIdx)] uniqueness check
+       -> persist [(registry.Login)] (Active=true, password hash)
+       -> registry projector triggers profile workspace creation
+```
+
+### Manage login alias
+
+```text
+@System c.registry.InitiateSetLoginAlias(login, newAlias?)
+  -> [c.registry.InitiateSetLoginAlias]
+       -> update alias snapshot on [(registry.Login)]
+  -> registry projector
+       -> [c.registry.DeactivateLoginAliasIndex] on previous alias (if any)
+       -> [c.registry.PutLoginAliasIndex] on new alias (if any)
+```
+
+## Notes
+
+The verifier sub-flow lives in `pkg/sys/verifier` rather than `pkg/registry`; the authentication subsystem consumes its `[Verified-value token]` output but does not own the email-delivery side. Roles and ACL evaluation of the `@System` caller for alias and global-role commands are owned by [arch-authz.md](./arch-authz.md).

--- a/uspecs/specs/prod/auth/arch-authn.md
+++ b/uspecs/specs/prod/auth/arch-authn.md
@@ -15,7 +15,7 @@ Roles:
 ## Scenarios overview
 
 - **`Create login`**
-  - `@Client` calls `[c.registry.CreateLogin]` (user) or `[c.registry.CreateEmailLogin]` (email) with a `[Verified-value token]` and credentials; a `[(registry.Login)]` is persisted, `[(view.LoginIdx)]` is updated, and the profile workspace creation is started by the registry projector.
+  - `@Client` calls `[c.registry.CreateEmailLogin]` (user by verified email) with a `[Verified-value token]` and credentials, or `[c.registry.CreateLogin]` (device) with credentials; a `[(registry.Login)]` is persisted, `[(view.LoginIdx)]` is updated, and the profile workspace creation is started by the registry projector.
 
 - **`Sign in by login or by active alias`**
   - `@Client` calls `[q.registry.IssuePrincipalToken]` with a sign-in identifier; `[(registry.Login)]` is resolved either directly or via `[(registry.LoginAlias)]`, the password hash is checked, the `Profile workspace readiness gate` is enforced, and a [Principal Token](./arch-tokens.md) is issued.
@@ -129,7 +129,7 @@ Registry records and indexes
   -> @Client: principalToken, profileWSID
 ```
 
-The `Profile workspace readiness gate` returns the same error result for deactivated logins, missing logins, and inactive aliases; the principal token is never issued for a deactivated `[(registry.Login)]`, and a recreated login of the same name resolves to its fresh `[(registry.Login)]` and fresh profile.
+The login resolution phase (before the readiness gate) returns the same error result for deactivated logins, missing logins, and inactive aliases; the principal token is never issued for a deactivated `[(registry.Login)]`, and a recreated login of the same name resolves to its fresh `[(registry.Login)]` and fresh profile.
 
 ### Create login with verifier sub-flow
 
@@ -138,8 +138,8 @@ The `Profile workspace readiness gate` returns the same error result for deactiv
   -> [q.sys.InitiateEmailVerification] -> async send code by email
 @Client q.sys.IssueVerifiedValueToken(email, code)
   -> [q.sys.IssueVerifiedValueToken] -> [Verified-value token]
-@Client c.registry.CreateLogin(verifiedEmailToken, password, displayName)
-  -> [c.registry.CreateLogin]
+@Client c.registry.CreateEmailLogin(verifiedEmailToken, password, displayName)
+  -> [c.registry.CreateEmailLogin]
        -> consume [Verified-value token]
        -> [(view.LoginIdx)] uniqueness check
        -> persist [(registry.Login)] (Active=true, password hash)

--- a/uspecs/specs/prod/auth/arch-authz.md
+++ b/uspecs/specs/prod/auth/arch-authz.md
@@ -1,0 +1,150 @@
+# Context subsystem architecture: prod/auth/authz
+
+Authorization subsystem architecture covering runtime ACL evaluation, the enforcement points exposed to other contexts, and the four sources of effective roles composed for every request. Context-level overview and shared concepts: [arch.md](./arch.md). Identity payload contract consumed at validation time: [arch-tokens.md](./arch-tokens.md). Origin of the subjects doc and joined-workspace records consumed during composition: [arch-membership.md](./arch-membership.md).
+
+## External actors
+
+Roles:
+
+- `@Client`
+  - Caller whose request flows through `[Auth boundary]` at every authnz enforcement point in command, query, and actualizer processors.
+
+Systems:
+
+- `*apps`
+  - The `apps` context (command, query, and actualizer processors) is the only programmatic consumer of `[Auth boundary]`; it calls `Authenticate` before invoking the ACL engine. See [../apps/arch.md](../apps/arch.md).
+
+## Scenarios overview
+
+- **`Authenticate request`**
+  - `*apps` calls `[Auth boundary].Authenticate(ctx, app, appTokens, AuthnRequest{Host, RequestWSID, Token})`; the subsystem validates the token via [Token management](./arch-tokens.md), composes principals from the four role sources, and returns `(principals, profileWSID)` for ACL evaluation.
+
+- **`Compose principals - anonymous`**
+  - When the request has no token, the `Guest` user, the `Anonymous` role, the `Host` principal, and any `[(cdoc.sys.Subject)]` rows that match `sys.Guest` in `RequestWSID` are emitted.
+
+- **`Compose principals - API token`**
+  - When `PrincipalPayload.IsAPIToken=true`, principal composition uses only `Roles` filtered to `RequestWSID` plus `AuthenticatedUser`; no Host, no Subject, no derived workspace roles.
+
+- **`Compose principals - user or device token`**
+  - When `IsAPIToken=false`, the subsystem emits `AuthenticatedUser`, the `Host` principal, all four role sources, and the workspace-derived roles (`ProfileOwner` / `WorkspaceOwner` / `WorkspaceDevice`) appropriate to the `RequestWSID`.
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- @Client (indirectly via *apps)
+    +-- *apps
+    |
+    v
+Boundary
+    |
+    +-- [Auth boundary] (IAuthenticator)
+    |
+    v
+Composition
+    |
+    +-- [Token validator]
+    +-- [Subjects reader]
+    +-- [Workspace role deriver]
+    +-- [Role inheritance map]
+    |
+    v
+Role sources
+    |
+    +-- [Invite-granted]    (cdoc.sys.Subject in RequestWSID)
+    +-- [Token-carried]     (PrincipalPayload.Roles + GlobalRoles)
+    +-- [Request-context]   (Host, AuthenticatedUser, ProfileOwner, WorkspaceOwner, WorkspaceDevice, System)
+    +-- [Anonymous-grants]  (Anonymous, Guest + sys.Guest subjects-doc rows)
+```
+
+### Boundary
+
+- `[Auth boundary]`
+  - Shared concept; see [arch.md#shared-concepts](./arch.md#shared-concepts). The single programmatic surface exposed to `*apps`; implemented by `implIAuthenticator.Authenticate`.
+
+### Composition
+
+- `[Token validator]`
+  - When `Token` is non-empty, calls `[IAppTokens].ValidateToken(token, &PrincipalPayload)` (see [arch-tokens.md](./arch-tokens.md)). Failures short-circuit composition with the validation error.
+  - impl: [pkg/iauthnzimpl/impl.go#Authenticate](../../../../pkg/iauthnzimpl/impl.go)
+
+- `[Subjects reader]`
+  - Reads `[(cdoc.sys.Subject)]` from `RequestWSID` for the resolved login (or `sys.Guest` when anonymous) through the injected `subjectRolesGetter`, and emits one `Principal{Kind: Role, WSID: RequestWSID, QName: role}` per matched role.
+  - impl: [pkg/iauthnzimpl/impl.go#rolesFromSubjects](../../../../pkg/iauthnzimpl/impl.go)
+
+- `[Workspace role deriver]`
+  - Reads the workspace descriptor (`appdef.QNameCDocWorkspaceDescriptor`) for `RequestWSID`, compares its `OwnerWSID` against `ProfileWSID`, and emits `ProfileOwner` (same), `WorkspaceOwner` (user owner match), or `WorkspaceDevice` (device, per app's `isDeviceAllowed`); always emits `Host` (unless API token) and `AuthenticatedUser` (when token is present).
+  - impl: [pkg/iauthnzimpl/impl.go#Authenticate](../../../../pkg/iauthnzimpl/impl.go)
+
+- `[Role inheritance map]`
+  - Static map (`ProfileOwner -> WorkspaceOwner`, `WorkspaceDevice -> WorkspaceOwner`, `RoleWorkspaceOwner -> WorkspaceOwner`) applied during ACL evaluation so that a single emitted role grants its parent role's privileges.
+  - decl: [pkg/iauthnz/authn-types.go#rolesInheritance](../../../../pkg/iauthnz/authn-types.go)
+
+### Role sources
+
+Four sources by origin contribute to a request's principal set; each is enumerated below with the read path used by `[Workspace role deriver]`.
+
+- `[Invite-granted]`
+  - Origin: `[[Workspace membership]]` writes `[(cdoc.sys.Subject)]` rows in the inviting workspace as part of the join flow; see [arch-membership.md](./arch-membership.md).
+  - Composition: `[Subjects reader]` reads `[(cdoc.sys.Subject)]` rows in `RequestWSID` matching the resolved login and emits one `Principal{Kind: Role, WSID: RequestWSID, QName: role}` per matched role.
+
+- `[Token-carried]`
+  - Origin: `[[Authentication]]` snapshots roles into `PrincipalPayload` at sign-in (per-app `Roles` from the registry login record) and `[c.registry.UpdateGlobalRoles]` updates the `GlobalRoles` field consumed at the next sign-in; see [arch-authn.md](./arch-authn.md).
+  - Composition: `PrincipalPayload.Roles []{WSID, QName}` is filtered to `RequestWSID` for API tokens, or to `OwnerWSID` of `RequestWSID` and re-keyed to `RequestWSID` for user/device tokens; `PrincipalPayload.GlobalRoles []QName` is emitted in any workspace as `Principal{Kind: Role, WSID: RequestWSID, QName: role}` when `IsAPIToken=false`.
+
+- `[Request-context]`
+  - Origin: computed at composition time from request state (`RequestWSID`, `Host`, token presence, `ProfileWSID`, workspace descriptor's `OwnerWSID`, app-supplied `isDeviceAllowed`), not from any persisted record.
+  - Composition: `Host` (unless API token), `AuthenticatedUser` (when token is present), `ProfileOwner` (when `RequestWSID==ProfileWSID`), `WorkspaceOwner` (user, descriptor's `OwnerWSID==ProfileWSID`), `WorkspaceDevice` (device, `isDeviceAllowed` true), and the `System` short-circuit (when the token carries `WorkspaceOwner.System` or when `ProfileWSID==NullWSID`).
+
+- `[Anonymous-grants]`
+  - Origin: emitted when no token is presented; combines the reserved `Anonymous` role and the `Guest` user (`sys.Guest @ GuestWSID`) defined in [pkg/iauthnz/authn-types.go](../../../../pkg/iauthnz/authn-types.go) with any `[(cdoc.sys.Subject)]` rows in `RequestWSID` that match `sys.Guest`.
+  - Composition: `Anonymous` and `Guest` are added unconditionally on the no-token branch; the `[Subjects reader]` is invoked with the `sys.Guest` login so any guest-bound role grants persisted by `[[Workspace membership]]` apply.
+
+VSQL role inheritance (e.g., `ProfileOwner -> WorkspaceOwner`) is expanded later by the ACL engine, not during composition; see `[Role inheritance map]` above.
+
+## Scenarios
+
+### Authenticate request and compose principals
+
+```text
+*apps (command/query/actualizer processor)
+  -> [Auth boundary].Authenticate(ctx, app, appTokens, AuthnRequest{Host, RequestWSID, Token})
+       -> if Token == "":
+            emit [Anonymous-grants]: User(sys.Guest @ GuestWSID), Role(Anonymous)
+            emit [Anonymous-grants] via [Subjects reader] for sys.Guest in RequestWSID
+            emit [Request-context]: Host
+            return (principals, NullWSID)
+       -> [Token validator]: appTokens.ValidateToken(Token, &PrincipalPayload)
+       -> emit [Request-context]: Role(AuthenticatedUser @ RequestWSID)
+       -> if PrincipalPayload.IsAPIToken:
+            emit [Token-carried] PrincipalPayload.Roles filtered to RequestWSID
+            return (principals, NullWSID)
+       -> emit [Token-carried] PrincipalPayload.GlobalRoles in RequestWSID
+       -> emit [Invite-granted] via [Subjects reader] for PrincipalPayload.Login in RequestWSID
+       -> profileWSID = PrincipalPayload.ProfileWSID
+       -> if Role(System) already in principals: return
+       -> emit User|Device principal at profileWSID
+       -> read cdoc.WorkspaceDescriptor in RequestWSID
+       -> emit [Request-context]: ProfileOwner (if RequestWSID==profileWSID), WorkspaceOwner (user, OwnerWSID==profileWSID), WorkspaceDevice (device, app's isDeviceAllowed)
+       -> emit [Token-carried] PrincipalPayload.Roles filtered to OwnerWSID of RequestWSID
+       -> emit [Request-context]: Host
+       -> return (principals, profileWSID)
+```
+
+### ACL evaluation by \*apps
+
+```text
+*apps (command/query processor)
+  -> [Auth boundary].Authenticate -> principals
+  -> appdef ACL engine: evaluate rule.AllowedRoles vs principals (applying [Role inheritance map])
+  -> on deny: 403; on allow: proceed to extension
+```
+
+## Notes
+
+The `System` short-circuit (line ~119 of `pkg/iauthnzimpl/impl.go`) returns immediately when the token carries `WorkspaceOwner.System` in `Roles`: a system caller is not augmented with subject or workspace-owner roles. The `profileWSID == NullWSID` short-circuit additionally emits `System` for any user-kind subject with no profile (used by registry-app internal flows).
+
+`Anonymous`, `Guest`, `Everyone`, and `AuthenticatedUser` come from `pkg/iauthnz/authn-types.go` and are reserved names; ACL rules in `apps` reference these QNames to express coverage levels.

--- a/uspecs/specs/prod/auth/arch-authz.md
+++ b/uspecs/specs/prod/auth/arch-authz.md
@@ -97,7 +97,7 @@ Four sources by origin contribute to a request's principal set; each is enumerat
 
 - `[Request-context]`
   - Origin: computed at composition time from request state (`RequestWSID`, `Host`, token presence, `ProfileWSID`, workspace descriptor's `OwnerWSID`, app-supplied `isDeviceAllowed`), not from any persisted record.
-  - Composition: `Host` (unless API token), `AuthenticatedUser` (when token is present), `ProfileOwner` (when `RequestWSID==ProfileWSID`), `WorkspaceOwner` (user, descriptor's `OwnerWSID==ProfileWSID`), `WorkspaceDevice` (device, `isDeviceAllowed` true), and the `System` short-circuit (when the token carries `WorkspaceOwner.System` or when `ProfileWSID==NullWSID`).
+  - Composition: `Host` (unless API token), `AuthenticatedUser` (when token is present), `ProfileOwner` (when `RequestWSID==ProfileWSID`), `WorkspaceOwner` (user, descriptor's `OwnerWSID==ProfileWSID`), `WorkspaceDevice` (device, `isDeviceAllowed` true), and the `System` short-circuit (when principals already include `role.sys.System` or when `ProfileWSID==NullWSID`).
 
 - `[Anonymous-grants]`
   - Origin: emitted when no token is presented; combines the reserved `Anonymous` role and the `Guest` user (`sys.Guest @ GuestWSID`) defined in [pkg/iauthnz/authn-types.go](../../../../pkg/iauthnz/authn-types.go) with any `[(cdoc.sys.Subject)]` rows in `RequestWSID` that match `sys.Guest`.
@@ -126,6 +126,7 @@ VSQL role inheritance (e.g., `ProfileOwner -> WorkspaceOwner`) is expanded later
        -> emit [Invite-granted] via [Subjects reader] for PrincipalPayload.Login in RequestWSID
        -> profileWSID = PrincipalPayload.ProfileWSID
        -> if Role(System) already in principals: return
+       -> if profileWSID == NullWSID: emit Role(System), return
        -> emit User|Device principal at profileWSID
        -> read cdoc.WorkspaceDescriptor in RequestWSID
        -> emit [Request-context]: ProfileOwner (if RequestWSID==profileWSID), WorkspaceOwner (user, OwnerWSID==profileWSID), WorkspaceDevice (device, app's isDeviceAllowed)
@@ -145,6 +146,6 @@ VSQL role inheritance (e.g., `ProfileOwner -> WorkspaceOwner`) is expanded later
 
 ## Notes
 
-The `System` short-circuit (line ~119 of `pkg/iauthnzimpl/impl.go`) returns immediately when the token carries `WorkspaceOwner.System` in `Roles`: a system caller is not augmented with subject or workspace-owner roles. The `profileWSID == NullWSID` short-circuit additionally emits `System` for any user-kind subject with no profile (used by registry-app internal flows).
+The `System` short-circuit (line ~118 of `pkg/iauthnzimpl/impl.go`) returns immediately when the already-composed principals contain `role.sys.System` (sourced from the token's `GlobalRoles` or from roles read from `[(cdoc.sys.Subject)]` of the request workspace): a system caller is not augmented with subject or workspace-owner roles. The `profileWSID == NullWSID` short-circuit additionally emits `role.sys.System` for any user-kind subject with no profile (used by registry-app internal flows). API tokens are unaffected by either branch: their per-app `Roles` are applied in a dedicated loop that returns earlier (line ~74).
 
 `Anonymous`, `Guest`, `Everyone`, and `AuthenticatedUser` come from `pkg/iauthnz/authn-types.go` and are reserved names; ACL rules in `apps` reference these QNames to express coverage levels.

--- a/uspecs/specs/prod/auth/arch-membership.md
+++ b/uspecs/specs/prod/auth/arch-membership.md
@@ -1,0 +1,155 @@
+# Context subsystem architecture: prod/auth/membership
+
+Workspace membership subsystem architecture covering the invite lifecycle, the subjects doc, joined-workspace records, role updates, and member removal. Context-level overview and shared concepts: [arch.md](./arch.md). Consumer of the subjects doc on every request: [arch-authz.md](./arch-authz.md). Profile workspace creation that is the prerequisite for any user joining a workspace: see the `apps` context [../apps/arch.md](../apps/arch.md).
+
+## External actors
+
+Roles:
+
+- `@WorkspaceOwner`
+  - Caller acting in the inviting workspace; sends and cancels invites, updates roles, removes members.
+
+- `@Invitee`
+  - Caller named in an invite (by email at invite time, by login after first sign-in); joins or leaves the workspace.
+
+## Scenarios overview
+
+- **`Send invite by email`**
+  - `@WorkspaceOwner` calls `[c.sys.InitiateInvitationByEMail]`; an `[(cdoc.sys.Invite)]` is created in `State_ToBeInvited`, the async invite-events projector enqueues an email with a verification code via `[Send invite email]`, and the invite transitions to `State_Invited`.
+
+- **`Join workspace`**
+  - `@Invitee` calls `[c.sys.InitiateJoinWorkspace]` with the verification code from the email; `[ap.sys.ApplyInviteEvents]` persists `[(cdoc.sys.Subject)]` in the inviting workspace with the granted roles, calls `[c.sys.CreateJoinedWorkspace]` in the invitee's profile (creates `[(cdoc.sys.JoinedWorkspace)]`), and writes `State_Joined` on `[(cdoc.sys.Invite)]`.
+
+- **`Update roles`**
+  - `@WorkspaceOwner` calls `[c.sys.InitiateUpdateInviteRoles]`; `[ap.sys.ApplyInviteEvents]` rewrites the role list on `[(cdoc.sys.Subject)]` and on the invitee's `[(cdoc.sys.JoinedWorkspace)]` via `[c.sys.UpdateJoinedWorkspaceRoles]`. `[(cdoc.sys.Invite)]` remains in `State_Joined`.
+
+- **`Cancel sent invite`**
+  - `@WorkspaceOwner` calls `[c.sys.CancelSentInvite]`; `[ap.sys.ApplyInviteEvents]` writes `State_Cancelled` on `[(cdoc.sys.Invite)]`. No `[(cdoc.sys.Subject)]` exists yet, so no further cleanup is required.
+
+- **`Cancel accepted invite (remove member)`**
+  - `@WorkspaceOwner` calls `[c.sys.InitiateCancelAcceptedInvite]`; `[ap.sys.ApplyInviteEvents]` deactivates `[(cdoc.sys.Subject)]` in the inviting workspace, calls `[c.sys.DeactivateJoinedWorkspace]` in the invitee's profile, and writes `State_Cancelled` on `[(cdoc.sys.Invite)]`.
+
+- **`Leave workspace`**
+  - `@Invitee` calls `[c.sys.InitiateLeaveWorkspace]` from its own profile; `[ap.sys.ApplyInviteEvents]` deactivates `[(cdoc.sys.Subject)]` and `[(cdoc.sys.JoinedWorkspace)]` the same way the cancel flow does, and writes `State_Left` on `[(cdoc.sys.Invite)]`.
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- @WorkspaceOwner
+    +-- @Invitee
+    |
+    v
+Invite lifecycle commands
+    |
+    +-- [c.sys.InitiateInvitationByEMail]
+    +-- [c.sys.InitiateJoinWorkspace]
+    +-- [c.sys.InitiateUpdateInviteRoles]
+    +-- [c.sys.InitiateCancelAcceptedInvite]
+    +-- [c.sys.InitiateLeaveWorkspace]
+    +-- [c.sys.CancelSentInvite]
+    |
+    v
+Membership write commands (projector-emitted)
+    |
+    +-- [c.sys.CreateJoinedWorkspace]
+    +-- [c.sys.UpdateJoinedWorkspaceRoles]
+    +-- [c.sys.DeactivateJoinedWorkspace]
+    |
+    v
+Async invite-events projector
+    |
+    +-- [ap.sys.ApplyInviteEvents]
+    +-- [Send invite email]
+    |
+    v
+Records and indexes
+    |
+    +-- [(cdoc.sys.Invite)]
+    +-- [(cdoc.sys.JoinedWorkspace)]
+    +-- [(cdoc.sys.Subject)]
+    +-- [(view.sys.InviteIndexView)]
+    +-- [(view.sys.JoinedWorkspaceIndexView)]
+    +-- [(view.sys.ViewSubjectsIdx)]
+```
+
+### Invite lifecycle commands
+
+- `[c.sys.InitiateInvitationByEMail]`, `[c.sys.InitiateJoinWorkspace]`, `[c.sys.InitiateUpdateInviteRoles]`, `[c.sys.InitiateCancelAcceptedInvite]`, `[c.sys.InitiateLeaveWorkspace]`, `[c.sys.CancelSentInvite]`
+  - Owner-side and invitee-side state-transition commands on `[(cdoc.sys.Invite)]`. Allowed transitions are gated by `inviteValidStates` (per command) and `reInviteAllowedForState` (re-invite on cancelled/left/etc). Records stuck in `ToBe*` legacy states are tolerated to allow recovery on old data.
+  - impl: [pkg/sys/invite/provide.go](../../../../pkg/sys/invite/provide.go), [pkg/sys/invite/consts.go#inviteValidStates](../../../../pkg/sys/invite/consts.go)
+
+### Membership write commands
+
+- `[c.sys.CreateJoinedWorkspace]`, `[c.sys.UpdateJoinedWorkspaceRoles]`, `[c.sys.DeactivateJoinedWorkspace]`
+  - Emitted by `[ap.sys.ApplyInviteEvents]` running in the invitee's profile workspace. Maintain the invitee-side view of which workspaces they belong to.
+  - impl: [pkg/sys/invite/provide.go](../../../../pkg/sys/invite/provide.go)
+
+### Async invite-events projector
+
+- `[ap.sys.ApplyInviteEvents]`
+  - Reacts to invite state transitions and: (1) sends the invitation email via `[Send invite email]` when entering `State_ToBeInvited`, (2) writes `[(cdoc.sys.Subject)]` in the inviting workspace on join, (3) calls the invitee-profile `Create/Update/Deactivate JoinedWorkspace` commands on join/role-update/leave/cancel.
+  - impl: [pkg/sys/invite/impl_applyinviteevents.go](../../../../pkg/sys/invite/impl_applyinviteevents.go)
+
+- `[Send invite email]`
+  - SMTP-backed side effect performed by `[ap.sys.ApplyInviteEvents]`; renders the email with `EmailTemplatePlaceholder_*` placeholders defined in `pkg/sys/invite/consts.go`.
+
+### Records and indexes
+
+- `[(cdoc.sys.Invite)]`
+  - Per-invitation record in the inviting workspace; carries `State`, `Email`, `Login`, `Roles`, `InviteeProfileWSID`, `SubjectID`, `JoinedWorkspaceID`, `Updated`, `Created`, `ExpireDatetime`.
+  - decl: [pkg/sys/invite/consts.go#QNameCDocInvite](../../../../pkg/sys/invite/consts.go)
+
+- `[(cdoc.sys.JoinedWorkspace)]`
+  - Per-membership record in the invitee's profile workspace; carries the WSID of the inviting workspace, the granted roles, and an active flag.
+  - decl: [pkg/sys/invite/consts.go#QNameCDocJoinedWorkspace](../../../../pkg/sys/invite/consts.go)
+
+- `[(cdoc.sys.Subject)]`
+  - Shared concept; see [arch.md#shared-concepts](./arch.md#shared-concepts). Workspace-scoped role-grant record consumed on every request by `[Subjects reader]` in [arch-authz.md](./arch-authz.md).
+
+- `[(view.sys.InviteIndexView)]`, `[(view.sys.JoinedWorkspaceIndexView)]`, `[(view.sys.ViewSubjectsIdx)]`
+  - Sync-projector-maintained lookup views (by email, by inviting WSID, by login) used by the invite lifecycle commands and by `[Subjects reader]`.
+  - decl: [pkg/sys/invite/consts.go](../../../../pkg/sys/invite/consts.go)
+
+## Scenarios
+
+### Send invite, join, update, leave
+
+```text
+@WorkspaceOwner -> [c.sys.InitiateInvitationByEMail] -> [(cdoc.sys.Invite)] State_ToBeInvited
+  -> [ap.sys.ApplyInviteEvents] -> [Send invite email] -> State_Invited
+@Invitee -> [c.sys.InitiateJoinWorkspace](code)
+  -> [ap.sys.ApplyInviteEvents]
+       -> @inviting WSID: persist [(cdoc.sys.Subject)] with granted roles
+       -> @invitee profile: [c.sys.CreateJoinedWorkspace] -> [(cdoc.sys.JoinedWorkspace)] active
+       -> [(cdoc.sys.Invite)] State_Joined
+@WorkspaceOwner -> [c.sys.InitiateUpdateInviteRoles]
+  -> [ap.sys.ApplyInviteEvents]
+       -> @inviting WSID: rewrite roles on [(cdoc.sys.Subject)]
+       -> @invitee profile: [c.sys.UpdateJoinedWorkspaceRoles] -> rewrite roles on [(cdoc.sys.JoinedWorkspace)]
+       -> [(cdoc.sys.Invite)] State_Joined (unchanged)
+@Invitee -> [c.sys.InitiateLeaveWorkspace]
+  -> [ap.sys.ApplyInviteEvents]
+       -> @inviting WSID: deactivate [(cdoc.sys.Subject)]
+       -> @invitee profile: [c.sys.DeactivateJoinedWorkspace]
+       -> [(cdoc.sys.Invite)] State_Left
+```
+
+### Cancel sent or accepted invite
+
+```text
+@WorkspaceOwner -> [c.sys.CancelSentInvite]
+  -> [ap.sys.ApplyInviteEvents] -> [(cdoc.sys.Invite)] State_Cancelled (no Subject exists)
+@WorkspaceOwner -> [c.sys.InitiateCancelAcceptedInvite]
+  -> [ap.sys.ApplyInviteEvents]
+       -> @inviting WSID: deactivate [(cdoc.sys.Subject)]
+       -> @invitee profile: [c.sys.DeactivateJoinedWorkspace]
+       -> [(cdoc.sys.Invite)] State_Cancelled
+```
+
+## Notes
+
+`[(cdoc.sys.Subject)]` and `[(cdoc.sys.JoinedWorkspace)]` are written by separate flows in different workspaces; the authoritative source of "member role at request time" consumed by [arch-authz.md](./arch-authz.md) is `[(cdoc.sys.Subject)]` in the request's `RequestWSID`, not `[(cdoc.sys.JoinedWorkspace)]`. The joined-workspace records exist for the invitee's own listing UI and for deactivation symmetry; ACL evaluation does not read them.

--- a/uspecs/specs/prod/auth/arch-tokens.md
+++ b/uspecs/specs/prod/auth/arch-tokens.md
@@ -1,0 +1,124 @@
+# Context subsystem architecture: prod/auth/tokens
+
+Token management subsystem architecture covering principal token issue, refresh, and validation, and the principal payload contract shared by authentication and authorization. Context-level overview and shared concepts: [arch.md](./arch.md). Producers of `PrincipalPayload`: [arch-authn.md](./arch-authn.md). Consumer that composes principals from a validated token: [arch-authz.md](./arch-authz.md).
+
+## External actors
+
+Roles:
+
+- `@Client`
+  - Caller obtaining or refreshing a principal token through the registry and sys APIs.
+
+- `@System`
+  - Caller issuing tokens with API-token semantics (`IsAPIToken=true`) for backend integrations and trusted internal callers.
+
+## Scenarios overview
+
+- **`Issue principal token`**
+  - At the end of sign-in (see [arch-authn.md](./arch-authn.md#sign-in-by-login-or-by-active-alias)) the authentication subsystem builds `PrincipalPayload` and calls `[ITokens].IssueToken(appQName, ttl, &payload)` to mint a `[Principal Token]`. The `Alias` field captures the active alias snapshot at issue time and is immune to any subsequent change to `[(registry.Login)]` or `[(registry.LoginAlias)]`.
+
+- **`Refresh principal token`**
+  - `@Client` calls `[q.sys.RefreshPrincipalToken]` with the current `[Principal Token]`; the payload is decoded, the same identity (including the captured `Alias`) is re-encoded with the same TTL/AppQName by `[ITokens].IssueToken`, and the new token is returned. Refresh never re-resolves the login or alias and never updates the alias snapshot.
+
+- **`Validate principal token`**
+  - On every request the authorization subsystem calls `[IAppTokens].ValidateToken(token, &payload)` (via `[Auth boundary]`) to verify the signature, audience, and expiry and to decode `PrincipalPayload` for principal composition (see [arch-authz.md](./arch-authz.md)).
+
+## Components
+
+### Layers
+
+```text
+External actors
+    |
+    +-- @Client
+    +-- @System
+    |
+    v
+Token endpoints
+    |
+    +-- [q.sys.RefreshPrincipalToken]
+    |
+    v
+Token primitives
+    |
+    +-- [ITokens]
+    +-- [IAppTokens]
+    |
+    v
+Payload contract
+    |
+    +-- [PrincipalPayload]
+    +-- [Principal Token]
+```
+
+### Token endpoints
+
+- `[q.sys.RefreshPrincipalToken]`
+  - Reads the bearer token from request state via `storages.GetPrincipalTokenFromState`, decodes `PrincipalPayload` through `payloads.GetPayloadRegistry`, and re-issues a token for the same AppQName, duration, and payload. The decoded `Alias` is preserved verbatim, so the snapshot taken at the original issue time survives the refresh; alias changes performed in the registry between issue and refresh have no effect on the refreshed token.
+  - impl: [pkg/sys/authnz/impl_refreshprincipaltoken.go#provideRefreshPrincipalTokenExec](../../../../pkg/sys/authnz/impl_refreshprincipaltoken.go)
+
+### Token primitives
+
+- `[ITokens]`
+  - VVM-level token signer and validator that turns any payload-by-reference into a JWT and back. Audience is derived from the payload type. Returns `ErrTokenExpired`, `ErrInvalidToken`, `ErrInvalidAudience` from `ValidateToken`. Also exposes `CryptoHash256` used by the verifier sub-flow.
+  - decl: [pkg/itokens/interface.go#ITokens](../../../../pkg/itokens/interface.go)
+
+- `[IAppTokens]`
+  - Per-app facade over `[ITokens]` produced by `payloads.implIAppTokensFactory`. Bind a token to a specific `AppQName` so that `ValidateToken` rejects cross-app reuse. Used by `[Auth boundary]` on every authn enforcement.
+  - impl: [pkg/itokens-payloads/types.go#implIAppTokens](../../../../pkg/itokens-payloads/types.go)
+
+### Payload contract
+
+- `[PrincipalPayload]`
+  - Identity payload carried by `[Principal Token]`:
+    - `Login` - canonical login resolved at issue time
+    - `Alias` - snapshot of the active alias at issue time; never re-read on refresh
+    - `SubjectKind` - `User` or `Device`
+    - `ProfileWSID` - profile workspace of the subject (`NullWSID` for system-only tokens)
+    - `Roles []{WSID, QName}` - workspace-scoped roles emitted on every request; for `IsAPIToken=true` these are the only persisted-role source (alongside the implicit `AuthenticatedUser`)
+    - `GlobalRoles []QName` - global roles to be applied in any workspace; emitted by `[[Authorization]]` on every request when `IsAPIToken=false`
+    - `IsAPIToken` - when true, principal composition emits only `AuthenticatedUser` and `Roles` filtered to `RequestWSID`, and omits the `Host` principal, `GlobalRoles`, the `WorkspaceOwner`/`ProfileOwner`/`WorkspaceDevice` derivations, the `System` short-circuit, and the `[(cdoc.sys.Subject)]` read
+  - decl: [pkg/itokens-payloads/types.go#PrincipalPayload](../../../../pkg/itokens-payloads/types.go)
+
+- `[Principal Token]`
+  - Shared concept; see [arch.md#shared-concepts](./arch.md#shared-concepts).
+
+## Scenarios
+
+### Issue principal token (end of sign-in)
+
+```text
+[q.registry.IssuePrincipalToken] (see arch-authn.md)
+  -> build PrincipalPayload{Login, Alias=loginForSignIn.alias (snapshot), SubjectKind, ProfileWSID, GlobalRoles}
+  -> [ITokens].IssueToken(appQName, ttl, &payload)
+  -> @Client: principalToken, profileWSID
+```
+
+### Refresh principal token
+
+```text
+@Client POST q.sys.RefreshPrincipalToken (Authorization: Bearer <current token>)
+  -> [q.sys.RefreshPrincipalToken]
+       -> storages.GetPrincipalTokenFromState(state) -> current token
+       -> payloads.GetPayloadRegistry([ITokens], token, &payload) -> decode + appQName + ttl
+       -> [ITokens].IssueToken(appQName, ttl, &payload)
+  -> @Client: principalToken (new), Alias unchanged from original issue
+```
+
+The Alias field is taken verbatim from the decoded payload and is not re-resolved against `[(registry.Login)]` or `[(registry.LoginAlias)]`. A login whose alias was set, replaced, or cleared after the original issue continues to refresh with the snapshotted alias until the next sign-in. To pick up a new alias the caller must sign in again rather than refresh.
+
+### Validate principal token
+
+```text
+[Auth boundary] (see arch.md)
+  -> [IAppTokens].ValidateToken(token, &payload)
+       -> verify signature, audience (AppQName), expiry
+       -> decode PrincipalPayload
+  -> return to [[Authorization]] for principal composition (see arch-authz.md)
+```
+
+## Notes
+
+`DefaultPrincipalTokenExpiration = 1h` is defined in `pkg/sys/authnz/consts.go`; `[q.registry.IssuePrincipalToken]` rejects TTLs above `maxTokenTTLHours`. The TTL is preserved across refresh: each refresh extends the bearer-token wall-clock lifetime by the same duration that the original issue requested.
+
+The `IsAPIToken` branch of principal composition is documented in [arch-authz.md](./arch-authz.md); the token subsystem owns only the flag's presence on `PrincipalPayload`, not the composition rules driven by it.

--- a/uspecs/specs/prod/auth/arch.md
+++ b/uspecs/specs/prod/auth/arch.md
@@ -74,7 +74,7 @@ Shared concepts
 ### Shared concepts
 
 - `[(registry.Login)]`
-  - Registry CDoc holding the primary sign-in identifier, password hash, subject kind, profile workspace fields, alias snapshot, and active flag. Produced by `[[Authentication]]`, consumed by `[[Token management]]` during sign-in.
+  - Registry CDoc holding the primary sign-in identifier, password hash, subject kind, profile workspace fields, alias snapshot, and active flag. Produced and consumed by `[[Authentication]]` during sign-in.
   - decl: [pkg/registry/appws.vsql#Login](../../../../pkg/registry/appws.vsql)
   - impl: [pkg/registry/impl_createlogin.go#createLogin](../../../../pkg/registry/impl_createlogin.go)
 

--- a/uspecs/specs/prod/auth/arch.md
+++ b/uspecs/specs/prod/auth/arch.md
@@ -1,7 +1,6 @@
 # Context architecture: prod/auth
 
-Auth context architecture for authenticating users and devices, issuing principal
-tokens, and maintaining credential lifecycle.
+Auth context architecture for authenticating subjects, issuing and validating principal tokens, evaluating authorization decisions, and maintaining workspace membership.
 
 ## External actors
 
@@ -11,227 +10,136 @@ Roles:
   - External application or caller using Voedger HTTP APIs.
 
 - `@System`
-  - Trusted backend caller using a System Principal Token for internal authn operations.
+  - Trusted backend caller using a System Principal Token for internal auth operations.
 
 ## Scenarios overview
 
-- **`Create login`**
-  - Client creates a user or device login in the registry and starts profile workspace creation.
+- **`Authenticate`**
+  - Subject establishes an authenticated identity and receives a principal token, including sign-in by login or by active alias and the verifier sub-flow for password reset.
 
-- **`Sign in`**
-  - Client exchanges login credentials for a principal token once the profile workspace is ready.
+- **`Authorize`**
+  - Request processing composes a principal set from four origin-perspective sources — invite-granted roles (`[(cdoc.sys.Subject)]` rows written by `[[Workspace membership]]`), token-carried roles (`PrincipalPayload.Roles` and `GlobalRoles` snapshotted by `[[Authentication]]`), request-context roles (derived at composition time from request state), and anonymous-grants (when no token is presented) — and evaluates ACL rules against it.
 
-- **`Manage login alias`**
-  - System sets, updates, or clears a user alias used as an alternative sign-in identifier.
+- **`Manage tokens`**
+  - Principal tokens are issued, refreshed, and validated; refresh preserves the identity payload including the alias snapshot captured at issue time.
 
-- **`Refresh token`**
-  - Client exchanges a valid principal token for a new token with the same authn identity payload.
-
-- **`Manage password`**
-  - Client changes or resets user credentials through registry-backed flows.
+- **`Manage membership`**
+  - Invite lifecycle creates subjects doc and joined-workspace records, updates roles, and removes members.
 
 ## Components
 
 ### Layers
 
 ```text
-External callers
+External actors
     |
     +-- @Client
+    +-- @System
     |
     v
-HTTP API
+Auth subsystems
     |
-    +-- [API v2 auth routes]
-    |
-    v
-Authn processing
-    |
-    +-- [Auth login handler]
-    +-- [Auth refresh handler]
-    +-- [User login handler]
-    +-- [Device login handler]
-    +-- [Password handler]
+    +-- [[Authentication]]
+    +-- [[Authorization]]
+    +-- [[Token management]]
+    +-- [[Workspace membership]]
     |
     v
-Registry and tokens
-    |
-    +-- [Registry login commands]
-    +-- [Registry alias commands]
-    +-- [Alias index projector]
-    +-- [Registry principal token query]
-    +-- [Registry password commands]
-    +-- [Registry reset password flow]
-    +-- [Token service]
-    |
-    v
-State and workspace lifecycle
+Shared concepts
     |
     +-- [(registry.Login)]
-    +-- [(registry.LoginIdx)]
-    +-- [(registry.LoginAlias)]
-    +-- [[Profile workspace lifecycle]]
+    +-- [(cdoc.sys.Subject)]
+    +-- [Principal Token]
+    +-- [Auth boundary]
 ```
 
-### HTTP API
+### Auth subsystems
 
-- `[API v2 auth routes]`
-  - Exposes login creation, device creation, password change, sign-in, and token refresh routes.
-  - Path to file: [pkg/router/impl_apiv2.go](../../../../pkg/router/impl_apiv2.go)
+- `[[Authentication]]`
+  - Login creation (including login-alias set/update/clear), sign-in by login or by active alias, password lifecycle, the verifier sub-flow that issues and consumes verified-value tokens, and the profile workspace readiness gate seen by sign-in.
+  - Path to file: [arch-authn.md](./arch-authn.md)
 
-### Authn processing
+- `[[Authorization]]`
+  - Runtime ACL evaluation, principal composition from the four sources of effective roles, and the enforcement points exposed to other contexts.
+  - Path to file: [arch-authz.md](./arch-authz.md)
 
-- `[Auth login handler]`
-  - Converts `/auth/login` request body into a registry principal token query and maps registry readiness into API responses.
-  - Path to file: [pkg/processors/query2/impl_auth_login_handler.go](../../../../pkg/processors/query2/impl_auth_login_handler.go)
+- `[[Token management]]`
+  - Principal token issue, refresh, and validation, and the principal payload contract shared by authentication and authorization.
+  - Path to file: [arch-tokens.md](./arch-tokens.md)
 
-- `[Auth refresh handler]`
-  - Requires an existing principal token, calls the app refresh query, validates the new token, and returns the refreshed response fields.
-  - Path to file: [pkg/processors/query2/impl_auth_refresh_handler.go](../../../../pkg/processors/query2/impl_auth_refresh_handler.go)
+- `[[Workspace membership]]`
+  - Invite lifecycle, the subjects doc, joined-workspace records, role updates, and member removal.
+  - Path to file: [arch-membership.md](./arch-membership.md)
 
-- `[User login handler]`
-  - Validates the verified email token and forwards user login creation to the registry.
-  - Path to file: [pkg/router/impl_apiv2.go](../../../../pkg/router/impl_apiv2.go)
-
-- `[Device login handler]`
-  - Generates device credentials and forwards device login creation to the registry.
-  - Path to file: [pkg/router/impl_apiv2.go](../../../../pkg/router/impl_apiv2.go)
-
-- `[Password handler]`
-  - Converts public password-change requests into registry password commands.
-  - Path to file: [pkg/router/impl_apiv2.go](../../../../pkg/router/impl_apiv2.go)
-
-### Registry and tokens
-
-- `[Registry login commands]`
-  - Create `registry.Login` records, validate login shape and app workspace placement, hash passwords, and reject duplicate logins or collisions with active aliases.
-  - Path to file: [pkg/registry/impl_createlogin.go](../../../../pkg/registry/impl_createlogin.go)
-
-- `[Registry alias commands]`
-  - System-authorized commands that initiate alias changes, write active alias indexes, and deactivate previous alias indexes across pseudo-workspaces.
-  - Path to file: [pkg/registry/impl_setloginalias.go](../../../../pkg/registry/impl_setloginalias.go)
-
-- `[Alias index projector]`
-  - Applies login alias intents asynchronously, drives cross-workspace alias index writes, records alias errors, and commits the active alias snapshot on `registry.Login`.
-  - Path to file: [pkg/registry/impl_setloginalias.go](../../../../pkg/registry/impl_setloginalias.go)
-
-- `[Registry principal token query]`
-  - Resolves sign-in by primary login or active alias, validates credentials, checks profile workspace readiness, and issues principal tokens.
-  - Path to file: [pkg/registry/impl_issueprincipaltoken.go](../../../../pkg/registry/impl_issueprincipaltoken.go)
-
-- `[Registry password commands]`
-  - Validate current password and update stored password hashes.
-  - Path to file: [pkg/registry/impl_changepassword.go](../../../../pkg/registry/impl_changepassword.go)
-
-- `[Registry reset password flow]`
-  - Initiates email verification, verifies reset codes, and applies password reset with a verified value token.
-  - Path to file: [pkg/registry/impl_resetpassword.go](../../../../pkg/registry/impl_resetpassword.go)
-
-- `[Token service]`
-  - Issues and validates app-scoped tokens carrying principal and verified-value payloads.
-  - Path to file: [pkg/itokens-payloads/types.go](../../../../pkg/itokens-payloads/types.go)
-
-### State and workspace lifecycle
+### Shared concepts
 
 - `[(registry.Login)]`
-  - Registry record holding login app, subject kind, password hash, profile cluster, profile workspace fields, initialization data, and active alias state.
-  - Path to file: [pkg/registry/impl_createlogin.go](../../../../pkg/registry/impl_createlogin.go)
+  - Registry CDoc holding the primary sign-in identifier, password hash, subject kind, profile workspace fields, alias snapshot, and active flag. Produced by `[[Authentication]]`, consumed by `[[Token management]]` during sign-in.
+  - decl: [pkg/registry/appws.vsql#Login](../../../../pkg/registry/appws.vsql)
+  - impl: [pkg/registry/impl_createlogin.go#createLogin](../../../../pkg/registry/impl_createlogin.go)
 
-- `[(registry.LoginIdx)]`
-  - Registry view used to resolve login records by application workspace and login hash.
-  - Path to file: [pkg/registry/impl_createlogin.go](../../../../pkg/registry/impl_createlogin.go)
+- `[(cdoc.sys.Subject)]`
+  - Workspace-scoped CDoc that grants a login a set of roles in a specific workspace. Produced by `[[Workspace membership]]`, consumed by `[[Authorization]]` on every request.
+  - decl: [pkg/sys/invite/consts.go#QNameCDocSubject](../../../../pkg/sys/invite/consts.go)
+  - impl: [pkg/sys/invite/impl_applyinviteevents.go](../../../../pkg/sys/invite/impl_applyinviteevents.go)
 
-- `[(registry.LoginAlias)]`
-  - Active alias lookup index that maps an alternative sign-in identifier to the source `registry.Login` record and snapshots the primary login string.
-  - Path to file: [pkg/registry/impl_setloginalias.go](../../../../pkg/registry/impl_setloginalias.go)
+- `[Principal Token]`
+  - Bearer token carrying `PrincipalPayload(Login, Alias, SubjectKind, ProfileWSID, Roles, GlobalRoles, IsAPIToken)`. Produced by `[[Authentication]]` and `[[Token management]]`, consumed by `[[Authorization]]` on every request.
+  - decl: [pkg/itokens-payloads/types.go#PrincipalPayload](../../../../pkg/itokens-payloads/types.go)
 
-- `[[Profile workspace lifecycle]]`
-  - Asynchronous workspace creation path triggered by login records and reflected back to the login profile fields.
-  - Path to file: [pkg/sys/workspace/impl.go](../../../../pkg/sys/workspace/impl.go)
+- `[Auth boundary]`
+  - The `pkg/iauthnz` interface that the `apps` context calls at every enforcement point to authenticate a request and obtain its principal set; the only programmatic surface that the `auth` context exposes to other contexts.
+  - decl: [pkg/iauthnz/authn-interface.go#IAuthenticator](../../../../pkg/iauthnz/authn-interface.go)
+  - impl: [pkg/iauthnzimpl/impl.go](../../../../pkg/iauthnzimpl/impl.go)
 
 ## Scenarios
 
-### Create login
+### Authenticate
 
 ```text
 @Client
-  -> [API v2 auth routes]
-  -> [User login handler] or [Device login handler]
-  -> [Registry login commands]
+  -> [[Authentication]]: sign-in by login or alias
   -> [(registry.Login)]
-  -> [(registry.LoginIdx)]
-  -> [[Profile workspace lifecycle]]
-```
-
-### Sign in
-
-```text
-@Client
-  -> [API v2 auth routes]
-  -> [Auth login handler]
-  -> [Registry principal token query]: resolve primary login or active alias
-  -> [(registry.Login)]
-  -> [(registry.LoginAlias)]: alias path only
-  -> [Token service]
+  -> [[Token management]]: issue [Principal Token]
   -> @Client: principalToken, expiresInSeconds, profileWSID
 ```
 
-### Manage login alias
+Details: [arch-authn.md](./arch-authn.md), [arch-tokens.md](./arch-tokens.md).
 
-```text
-@System
-  -> [Registry alias commands]: initiate set, update, or clear
-  -> [(registry.Login)]: mark alias operation in progress
-  -> [Alias index projector]
-  -> [Registry alias commands]: put new alias index in pseudoWSID(alias)
-  -> [Registry alias commands]: deactivate previous alias index in pseudoWSID(old alias)
-  -> [(registry.LoginAlias)]
-  -> [(registry.Login)]: commit Alias, AliasInProc, AliasError
-```
-
-### Refresh token
+### Authorize
 
 ```text
 @Client
-  -> [API v2 auth routes]
-  -> [Auth refresh handler]
-  -> [Token service]: validate existing token and issue replacement
-  -> @Client: principalToken, expiresInSeconds, profileWSID
+  -> [Auth boundary]: AuthnRequest(token, requestWSID)
+  -> [[Authorization]]: validate [Principal Token], compose principals from token + [(cdoc.sys.Subject)] + ACL-engine-emitted contextual roles
+  -> @Client: principals, profileWSID
 ```
 
-### Manage password
+Details: [arch-authz.md](./arch-authz.md).
+
+### Manage membership
 
 ```text
-@Client
-  -> [API v2 auth routes]
-  -> [Password handler]
-  -> [Registry password commands] or [Registry reset password flow]
-  -> [(registry.Login)]
+@Client (workspace owner) or @Client (invitee)
+  -> [[Workspace membership]]: invite, join, update roles, leave, cancel
+  -> [(cdoc.sys.Subject)]: roles in the inviting workspace
 ```
+
+Details: [arch-membership.md](./arch-membership.md).
 
 ## Cross-cutting concerns
 
+### Context dependencies
+
+- The `apps` context calls `[Auth boundary]` at every authnz enforcement point in command, query, and actualizer processors; see [../apps/arch.md](../apps/arch.md).
+- The `storage` context persists `[(registry.Login)]`, `[(cdoc.sys.Subject)]`, and joined-workspace records through `istructs.IAppStructs`.
+- Profile workspace lifecycle (creation, profile-fields write-back) is owned by the `apps` context; `[[Authentication]]` only observes the readiness gate.
+
 ### Security
 
-- Every Component in `Authn processing` must treat credentials and verified value tokens as request secrets and must not expose password values in response bodies.
-- Every Component in `Registry and tokens` must keep password evidence stored only as salted password hashes.
-- Every `[Token service]` issue must be app-scoped and validated through the application token API.
-- Authorization policy, ACL evaluation, role resolution, and invite membership are downstream concerns and are not owned by authn architecture.
-
-Token payloads may contain fields later consumed by authorization, but authn owns only identity establishment, token issue/refresh behavior, and identity payload production.
-
-### Error handling and resilience
-
-- Every Component in `Authn processing` maps malformed public request bodies to `400 Bad Request`.
-- `[Auth login handler]` maps profile workspace not-ready state to `409 Conflict`.
-- `[Auth refresh handler]` maps missing bearer token to `401 Unauthorized`.
-- `[Auth login handler]` uses retried federation for principal token issue to tolerate transient local startup failures.
-
-### Consistency
-
-- `[[Profile workspace lifecycle]]` is asynchronous; login creation can succeed before sign-in can issue a usable principal token.
-- `[(registry.LoginIdx)]` must be consistent with active `[(registry.Login)]` records for sign-in, password change, and reset lookup.
+- Every Component in `Auth subsystems` MUST treat passwords, bearer tokens, verification tokens, and verified-value tokens as request secrets and MUST NOT expose password values in response bodies.
+- Every `[Principal Token]` MUST be app-scoped and validated through the application token API.
 
 ### Testing
 
-- Every externally observable scenario in this architecture must be covered by integration tests or feature scenarios before implementation behavior is changed.
+- Every externally observable scenario in `Auth subsystems` MUST be covered by integration tests or feature scenarios before behavior changes.

--- a/uspecs/specs/prod/auth/authn--td.md
+++ b/uspecs/specs/prod/auth/authn--td.md
@@ -1,6 +1,6 @@
 # Feature technical design: authn
 
-Technical design for the authentication feature: login creation, sign-in, principal token issue and refresh, profile workspace readiness, and password lifecycle flows.
+Technical design for the authentication feature: login creation, sign-in, principal token issue and refresh, profile workspace readiness, and password lifecycle flows. The subsystem architecture for the same scope is in [arch-authn.md](./arch-authn.md); the principal payload contract and refresh semantics (including the alias snapshot captured at issue time) are owned by [arch-tokens.md](./arch-tokens.md); shared concepts (`[(registry.Login)]`, `[Principal Token]`, `[Auth boundary]`) are defined in [arch.md](./arch.md#shared-concepts). This document only adds the HTTP-side surface (routes, handlers, status-code mapping) that is unique to the public authn feature.
 
 ## External actors
 
@@ -197,9 +197,7 @@ State and workspace lifecycle
 ### Token and verification operations
 
 - `[Token service]`
-  - Issues and validates app-scoped principal, verification, and verified value tokens.
-  - decl: [pkg/itokens-payloads/types.go#PrincipalPayload](../../../../pkg/itokens-payloads/types.go)
-  - impl: [pkg/itokens-payloads/utils.go#GetPayload](../../../../pkg/itokens-payloads/utils.go)
+  - Token primitives and `PrincipalPayload` are owned by [arch-tokens.md](./arch-tokens.md#token-primitives); referenced here as the layer that issues and validates the tokens carried by the authn HTTP flows.
 
 - `[/q.sys.RefreshPrincipalToken/]`
   - Issues a replacement principal token from the existing principal token payload and duration, preserving identity fields including alias.
@@ -219,19 +217,15 @@ State and workspace lifecycle
 ### State and workspace lifecycle
 
 - `[(registry.Login)]`
-  - Registry CDoc that stores login app, subject kind, login hash, password hash, profile workspace fields, workspace error, initialization data, alias in-progress state (`AliasInProc`), active alias snapshot (`Alias`), and last alias failure (`AliasError`).
-  - decl: [pkg/registry/appws.vsql#Login](../../../../pkg/registry/appws.vsql)
-  - impl: [pkg/registry/impl_createlogin.go#createLogin](../../../../pkg/registry/impl_createlogin.go)
+  - Shared concept; see [arch.md#shared-concepts](./arch.md#shared-concepts). The `AliasInProc` / `Alias` / `AliasError` fields used by the alias commands of this feature are described in [arch-authn.md](./arch-authn.md#sign-in-and-lifecycle-queriescommands).
 
 - `[(registry.LoginIdx)]`
-  - Registry view that resolves active login records by application workspace and login hash.
+  - Sync-projector-maintained registry view that resolves active login records by application workspace and login hash; produced and consumed by the registry operations of this feature. See [arch-authn.md](./arch-authn.md#registry-records-and-indexes) for the architectural role.
   - decl: [pkg/registry/appws.vsql#LoginIdx](../../../../pkg/registry/appws.vsql)
   - impl: [pkg/registry/impl_createlogin.go#projectorLoginIdx](../../../../pkg/registry/impl_createlogin.go)
 
 - `[(registry.LoginAlias)]`
-  - Registry CDoc used as the active alias lookup index, snapshotting `(AppName, SourceAppWSID, CDocLoginID, Login, Alias)` and enforcing active-row uniqueness by `(AppName, Alias)`; inactive rows may be reactivated when the same alias value is assigned again.
-  - decl: [pkg/registry/appws.vsql#LoginAlias](../../../../pkg/registry/appws.vsql)
-  - impl: [pkg/registry/impl_setloginalias.go#execCmdPutLoginAliasIndex](../../../../pkg/registry/impl_setloginalias.go)
+  - Per-alias registry CDoc used as the alias lookup index. Its uniqueness and reactivation semantics are owned by [arch-authn.md](./arch-authn.md#registry-records-and-indexes); referenced here as the record consumed during sign-in by alias and written by `[/c.registry.PutLoginAliasIndex/]` / `[/c.registry.DeactivateLoginAliasIndex/]`.
 
 - `[[Profile workspace lifecycle]]`
   - Asynchronous profile workspace creation path triggered by login records and reflected back into `[(registry.Login)]` readiness fields.

--- a/uspecs/specs/prod/auth/authn.feature
+++ b/uspecs/specs/prod/auth/authn.feature
@@ -18,10 +18,17 @@ Feature: Authentication
       And the response contains generated device login and password
       And the device profile workspace creation is started
 
-    Scenario: Login creation rejects duplicate login
-      Given a login already exists
+    Scenario: Login creation rejects an active duplicate login
+      Given an active login already exists
       When Client creates the same login again
       Then the response status is "409 Conflict"
+
+    Scenario: Login creation succeeds for a deactivated login name
+      Given a login was previously created and is now deactivated
+      When Client creates a login with the same name again
+      Then the response status is "201 Created"
+      And a new login is accepted with a fresh profile workspace
+      And the previously deactivated login is no longer reachable for sign-in or token issue
 
     Scenario: Login creation rejects an existing active alias
       Given a login exists with an active login alias
@@ -228,6 +235,12 @@ Feature: Authentication
     Scenario: Sign-in rejects unknown login or wrong password
       When Client signs in with unknown login or wrong password
       Then the response status is "401 Unauthorized"
+
+    Scenario: Sign-in rejects a deactivated login as unknown
+      Given a login exists but is deactivated
+      When Client signs in with that login and password
+      Then the response status is "401 Unauthorized"
+      And the response indicates the login does not exist
 
     Scenario: Principal token refresh requires an existing token
       Given Client has no principal token

--- a/uspecs/specs/prod/auth/authn.feature
+++ b/uspecs/specs/prod/auth/authn.feature
@@ -236,11 +236,11 @@ Feature: Authentication
       When Client signs in with unknown login or wrong password
       Then the response status is "401 Unauthorized"
 
-    Scenario: Sign-in rejects a deactivated login as unknown
+    Scenario: Sign-in rejects a deactivated login with the same error as a missing login
       Given a login exists but is deactivated
       When Client signs in with that login and password
       Then the response status is "401 Unauthorized"
-      And the response indicates the login does not exist
+      And the response indicates the login or password is incorrect
 
     Scenario: Principal token refresh requires an existing token
       Given Client has no principal token

--- a/uspecs/specs/prod/auth/invites--td.md
+++ b/uspecs/specs/prod/auth/invites--td.md
@@ -1,6 +1,6 @@
 # Feature technical design: Invites
 
-Invite users/devices to workspaces
+Invite users/devices to workspaces. The subsystem architecture for invite lifecycle, the subjects doc, joined-workspace records, role updates, and member removal is in [arch-membership.md](./arch-membership.md); how the resulting `[(cdoc.sys.Subject)]` is consumed on every request is in [arch-authz.md](./arch-authz.md); shared concepts (`[(cdoc.sys.Subject)]`, `[(registry.Login)]`) are defined in [arch.md](./arch.md#shared-concepts). This document only adds the projector-as-sole-writer design, the `Version` discriminator, dead-state handling, and decisions that are unique to this feature.
 
 ## Use cases
 
@@ -14,43 +14,7 @@ Invite users/devices to workspaces
 
 ## Overview
 
-Roles and permissions (from VSQL):
-
-- `WorkspaceOwner`: manages invitations, roles, and membership (WorkspaceOwnerFuncTag)
-- `AuthenticatedUser`: can join and leave workspaces (AllowedToAuthenticatedTag)
-
-Key documents:
-
-- `cdoc.sys.Invite`: tracks invitation status and metadata
-- `cdoc.sys.Subject`: represents an invited user/device in the workspace
-- `cdoc.sys.JoinedWorkspace`: records workspace membership in invitee's profile
-
-Invitation management:
-
-- `c.sys.InitiateInvitationByEMail`: creates new invitation (WorkspaceOwner)
-  - Params: Email, Roles, ExpireDatetime, EmailTemplate, EmailSubject
-- `c.sys.InitiateJoinWorkspace`: processes invite acceptance (AuthenticatedUser)
-  - Params: InviteID, VerificationCode
-
-Role management:
-
-- `c.sys.InitiateUpdateInviteRoles`: updates member permissions (WorkspaceOwner)
-  - Params: InviteID, Roles, EmailTemplate, EmailSubject
-
-Membership termination:
-
-- `c.sys.InitiateCancelAcceptedInvite`: owner removes joined member (WorkspaceOwner)
-  - Params: InviteID
-- `c.sys.InitiateLeaveWorkspace`: member voluntarily leaves (AuthenticatedUser)
-  - No params (invite found by login from auth token)
-- `c.sys.CancelSentInvite`: cancels pending invitation (WorkspaceOwner)
-  - Params: InviteID
-
-Internal commands (called by projectors via Federation):
-
-- `c.sys.CreateJoinedWorkspace`: creates JoinedWorkspace record in invitee's profile
-- `c.sys.UpdateJoinedWorkspaceRoles`: updates roles in invitee's JoinedWorkspace
-- `c.sys.DeactivateJoinedWorkspace`: deactivates JoinedWorkspace when member removed
+Roles, documents, and commands of the invite lifecycle (owner-side and invitee-side commands, projector-emitted internal commands, `[(cdoc.sys.Invite)]` / `[(cdoc.sys.Subject)]` / `[(cdoc.sys.JoinedWorkspace)]`) are catalogued in [arch-membership.md](./arch-membership.md#components). This document does not repeat them; the parameter lists and ACL bindings (`WorkspaceOwnerFuncTag`, `AllowedToAuthenticatedTag`) are kept inline with the corresponding VSQL in `pkg/sys/sys.vsql`.
 
 ---
 


### PR DESCRIPTION
```yaml
change_id: 2606050903-derive-auth-context-architecture
type: docs
issue_url: https://untill.atlassian.net/browse/AIR-4185
domains: [prod]
```
## Why

The `auth` context listed in `uspecs/specs/prod/domain.md` covers authentication, authorization, token management, and workspace membership, but the existing `uspecs/specs/prod/auth/arch.md` covers only the authentication (authn) flows; authorization, principal token validation on request processing, and invite-based workspace membership have no Context Architecture or Context Subsystem Architecture reference. There is also no Context Architecture overview that ties the four subsystems together, so a reader cannot see how authn, authz, token management, and membership compose into a single context. Principal token issue and refresh have no arch coverage either — only validation is implicitly described inside the existing authn material. Finally, the existing `authn--td.md`, `authn.feature`, and `invites--td.md` were written before the four-subsystem split was made explicit in `domain.md` and may diverge from the new arch chapters as derivation surfaces contradictions, so they must be reconciled in the same change.

## What

Add architecture specifications for the `auth` context, derived from scratch from the current codebase across the entire repository:

- Add a Context Architecture summary at `uspecs/specs/prod/auth/arch.md` that overviews the full `auth` context (authn, authz, token management, workspace membership) and links to its subsystem architectures, replacing the current narrow authn-only content at the same path
- Add a Context Subsystem Architecture for authentication at `uspecs/specs/prod/auth/arch-authn.md` covering login creation (including login-alias set/update/clear), sign-in (by login or by active alias), password lifecycle, the verifier sub-flow that issues and consumes verified-value tokens (email verification, password reset), and the profile workspace readiness gate seen by sign-in (excluding principal token issue/refresh, which belongs to the token management chapter, and excluding profile workspace lifecycle itself, which stays owned by the `apps` context)
- The authentication chapter must explicitly document two login-lifecycle behaviors observable to clients:
  - when a profile workspace is deactivated, the deactivation propagates to `[(registry.Login)].IsActive=false` via `c.sys.OnChildWorkspaceDeactivated`; the deactivated login is treated as a missing login by subsequent `[q.registry.IssuePrincipalToken]` calls, which return the shared `errLoginOrPasswordIsIncorrect` response (HTTP 401, "login or password is incorrect") — the same response used for missing logins and wrong passwords to prevent enumeration
  - re-creating a login with the same name creates a new login with a fresh profile workspace; the previously deactivated login and its profile workspace remain in storage but become unreachable
- Add a Context Subsystem Architecture for authorization at `uspecs/specs/prod/auth/arch-authz.md` covering runtime ACL evaluation and the enforcement points exposed to other contexts (notably the `apps` context processors); VSQL schema parsing of role and grant declarations stays owned by the `apps` context, and the management of the subjects doc and joined-workspace records stays owned by the workspace membership chapter
- The authorization chapter must enumerate the four sources of a principal's effective roles by origin:
  - invite-granted roles — `[(cdoc.sys.Subject)]` rows in the request workspace, produced by the workspace membership subsystem
  - token-carried roles — `PrincipalPayload.Roles` (per-app) and `PrincipalPayload.GlobalRoles` (cross-workspace), snapshotted at sign-in by the authentication subsystem
  - request-context roles — derived at composition time from request state: `role.sys.ProfileOwner` when the request workspace is the principal's own profile, `role.sys.WorkspaceOwner` when the principal owns the request works

---
Content omitted. See change.md for full details.
