### PR TITLE
ci(dev): Automated reviews for pull requests [review-pr]

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,19 +2,20 @@
 
 ## Workflows Overview
 
-| Workflow                     | Trigger                           | Purpose                            |
-| ---------------------------- | --------------------------------- | ---------------------------------- |
-| `ci.yml`                     | Push to main (excl. pkg/istorage) | Run CI tests, build Docker image   |
-| `ci_pr.yml`                  | PR (excl. pkg/istorage)           | Run CI tests                       |
-| `ci-full.yml`                | Daily 5 AM UTC / manual           | Full test suite with race detector |
-| `ci-pkg-storage.yml`         | Push/PR to pkg/istorage paths     | Run storage backend tests          |
-| `ci_cas.yml`                 | Called by ci-pkg-storage          | Cassandra/ScyllaDB tests           |
-| `ci_amazon.yml`              | Called by ci-pkg-storage          | Amazon DynamoDB tests              |
-| `cp.yml`                     | Reusable workflow                 | Cherry pick commits                |
-| `linkIssue.yml`              | Issue closed                      | Link issue to milestone            |
-| `unlinkIssue.yml`            | Issue reopened                    | Unlink issue from milestone        |
-| `cd-voedger.yml`             | Reusable workflow                 | Build and push Docker image        |
-| `ctool-integration-test.yml` | Manual                            | Integration tests for ctool        |
+| Workflow                     | Trigger                             | Purpose                            |
+| ---------------------------- | ----------------------------------- | ---------------------------------- |
+| `ci.yml`                     | Push to main (excl. pkg/istorage)   | Run CI tests, build Docker image   |
+| `ci_pr.yml`                  | PR (excl. pkg/istorage)             | Run CI tests                       |
+| `pr-review.yml`              | pull_request_target / issue_comment | Automated pull request reviews     |
+| `ci-full.yml`                | Daily 5 AM UTC / manual             | Full test suite with race detector |
+| `ci-pkg-storage.yml`         | Push/PR to pkg/istorage paths       | Run storage backend tests          |
+| `ci_cas.yml`                 | Called by ci-pkg-storage            | Cassandra/ScyllaDB tests           |
+| `ci_amazon.yml`              | Called by ci-pkg-storage            | Amazon DynamoDB tests              |
+| `cp.yml`                     | Reusable workflow                   | Cherry pick commits                |
+| `linkIssue.yml`              | Issue closed                        | Link issue to milestone            |
+| `unlinkIssue.yml`            | Issue reopened                      | Unlink issue from milestone        |
+| `cd-voedger.yml`             | Reusable workflow                   | Build and push Docker image        |
+| `ctool-integration-test.yml` | Manual                              | Integration tests for ctool        |
 
 ---
 
@@ -123,6 +124,27 @@ Scripts called from `https://raw.githubusercontent.com/untillpro/ci-action/main/
 ### PR (ci_pr.yml)
 
 1. Calls `untillpro/ci-action/.github/workflows/ci_pr.yml@main`
+
+### PR review (pr-review.yml)
+
+1. Runs automatic reviews on `pull_request_target` events:
+   - `opened`
+   - `synchronize`
+   - `reopened`
+   - `ready_for_review`
+2. Runs manual reviews on PR `issue_comment` `created` events when the trimmed comment body starts with `/review` as a command.
+3. Treats GitHub permissions `write`, `maintain`, and `admin` as Writer; all other commenters are NonWriters, receive a feedback comment, and do not trigger a review.
+4. Passes text after `/review` as extra review instructions.
+5. Calls `augmentcode/review-pr@v0.2.0` with:
+   - `AUGMENT_SESSION_AUTH`
+   - `GITHUB_TOKEN`
+   - pull request number
+   - repository name
+   - `.augment/rules/ar-common-develop.md`
+   - `.augment/rules/ar-golang.md`
+   - `.augment/rules/ar-markdown.md`
+6. Uses `contents: read`, `pull-requests: write`, and `issues: write` permissions.
+7. Serializes review runs per pull request with the `pr-review-{number}` concurrency group.
 
 ### Daily Tests (ci-full.yml)
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,102 @@
+name: PR review
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  automatic-review:
+    if: github.repository == 'voedger/voedger' && github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Review pull request
+        uses: augmentcode/review-pr@v0.2.0
+        with:
+          augment_session_auth: ${{ secrets.AUGMENT_SESSION_AUTH }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pull_number: ${{ github.event.pull_request.number }}
+          repo_name: ${{ github.repository }}
+          rules: '[".augment/rules/ar-common-develop.md",".augment/rules/ar-golang.md",".augment/rules/ar-markdown.md"]'
+
+  comment-review:
+    if: github.repository == 'voedger/voedger' && github.event_name == 'issue_comment' && github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-review-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Parse review command
+        id: review_command
+        shell: bash
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import uuid
+
+          body = os.environ["COMMENT_BODY"].strip()
+          is_review_command = body == "/review" or (body.startswith("/review") and body[len("/review")].isspace())
+          extra_instructions = body[len("/review"):].strip() if is_review_command else ""
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"is_review_command={'true' if is_review_command else 'false'}\n")
+              delimiter = f"EOF_{uuid.uuid4().hex}"
+              output.write(f"extra_instructions<<{delimiter}\n")
+              output.write(extra_instructions)
+              output.write(f"\n{delimiter}\n")
+          PY
+
+      - name: Check commenter permission
+        if: steps.review_command.outputs.is_review_command == 'true'
+        id: commenter_permission
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+        run: |
+          permission=$(gh api "repos/${{ github.repository }}/collaborators/${COMMENT_AUTHOR}/permission" --jq .permission 2>/dev/null || echo none)
+
+          case "$permission" in
+            admin|maintain|write)
+              echo "is_writer=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "is_writer=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Reply to NonWriter
+        if: steps.review_command.outputs.is_review_command == 'true' && steps.commenter_permission.outputs.is_writer != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f body='Only Writer can request an automated review with `/review`.'
+
+      - name: Review pull request
+        if: steps.review_command.outputs.is_review_command == 'true' && steps.commenter_permission.outputs.is_writer == 'true'
+        uses: augmentcode/review-pr@v0.2.0
+        with:
+          augment_session_auth: ${{ secrets.AUGMENT_SESSION_AUTH }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pull_number: ${{ github.event.issue.number }}
+          repo_name: ${{ github.repository }}
+          custom_guidelines: ${{ steps.review_command.outputs.extra_instructions }}
+          rules: '[".augment/rules/ar-common-develop.md",".augment/rules/ar-golang.md",".augment/rules/ar-markdown.md"]'

--- a/uspecs/changes/archive/2606/2606090846-augment-pr-review-workflow/change.md
+++ b/uspecs/changes/archive/2606/2606090846-augment-pr-review-workflow/change.md
@@ -1,0 +1,90 @@
+---
+change_id: 2606090756-augment-pr-review-workflow
+type: ci
+issue_url: https://github.com/augmentcode/review-pr
+domains: [devops]
+scope: [dev]
+---
+
+# Change request: Automated reviews for pull requests
+
+## Why
+
+Pull requests should receive fast automated review feedback before human review starts. Repository automation is part of the engineering operations domain rather than the Voedger production runtime, so the intended behavior should be captured in a dedicated `devops` specification before the workflow is added. The repository already carries review guidance for human developers and AI agents, so the PR review automation should reuse the same project guidance instead of relying only on generic review criteria.
+
+## What
+
+Introduce specified automated PR review behavior for repository participants:
+
+- The `devops` domain describes Voedger engineering operations, including repository automation used by NonWriters and Writers
+- The `dev` context contains the `pr-reviews` feature, which defines when automated reviews are created and who can request them
+- Every draft or non-draft pull request receives an automated review when it is opened, updated, reopened, or marked ready for review
+- Writer can request another review by creating a PR comment whose trimmed body starts with `/review` as a command
+- Manual comment-triggered reviews are ignored on non-PR issues, edited or deleted comments, comments where `/review` is not the leading command, command-prefix lookalikes such as `/reviewed`, and comments from NonWriters
+- Reviews use the repository's existing development, Go, and Markdown guidance
+- The workflow uses a repository secret for review-provider authentication and keeps GitHub token permissions limited to reading contents, writing pull request reviews, and writing command feedback comments
+
+## How
+
+Decisions:
+
+- Add the `devops` domain and place `pr-reviews` under the `dev` context before adding workflow automation
+- Add a `dev` context architecture document to describe PR review workflow boundaries, triggers, permissions, and ReviewProvider integration
+- Add a standalone PR review workflow instead of modifying existing CI workflows
+- Use `pull_request_target` for automatic PR reviews and `issue_comment` `created` events for the `/review` command
+- Use `augmentcode/review-pr@v0.2.0` with `AUGMENT_SESSION_AUTH`, `GITHUB_TOKEN`, and the repository's Augment rule files
+- Keep workflow permissions to `contents: read`, `pull-requests: write`, and `issues: write` for command feedback comments; serialize review runs per pull request
+
+Out of scope:
+
+- Replacing required human review or changing branch protection
+- Changing existing CI test, lint, storage, or deployment workflows
+- Managing the lifecycle of the personal Augment session credential outside GitHub secrets
+
+References (internal):
+
+- [workflow overview](../../../../../.github/workflows/README.md)
+- [current PR workflow trigger pattern](../../../../../.github/workflows/ci_pr.yml)
+- [storage PR workflow trigger pattern](../../../../../.github/workflows/ci-pkg-storage.yml)
+- [common Augment development rules](../../../../../.augment/rules/ar-common-develop.md)
+- [Go Augment rules](../../../../../.augment/rules/ar-golang.md)
+- [Markdown Augment rules](../../../../../.augment/rules/ar-markdown.md)
+
+References (external):
+
+- [Augment PR review action v0.2.0](https://raw.githubusercontent.com/augmentcode/review-pr/v0.2.0/action.yml)
+- [GitHub `pull_request_target` event](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target)
+- [GitHub `issue_comment` event](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#issue_comment)
+
+## Domain specifications
+
+- [x] create: [devops/domain.md](../../../../specs/devops/domain.md)
+  - Domain Specification for Voedger engineering operations: actors, core concepts, and the `dev` context for repository development automation
+
+## Functional design
+
+- [x] create: [devops/dev/pr-reviews.feature](../../../../specs/devops/dev/pr-reviews.feature)
+  - Feature specification with scenarios for automatic PR reviews and authorized `/review` comment-triggered reruns
+
+## Provisioning and configuration
+
+- [x] configure: GitHub repository secret `AUGMENT_SESSION_AUTH`
+  - Store Augment session JSON credentials from `auggie tokens print` or `~/.augment/session.json` as a GitHub Actions repository secret
+
+- [x] create: [.github/workflows/pr-review.yml](../../../../../.github/workflows/pr-review.yml)
+  - Add standalone PR review workflow for `pull_request_target` pull request lifecycle events and `issue_comment` `created` events
+  - Use `augmentcode/review-pr@v0.2.0` for automated review generation with `AUGMENT_SESSION_AUTH`, `GITHUB_TOKEN`, pull request number, repository name, and repository rule files
+  - Gate `/review` comment-triggered reviews to Writer and return a clear message for NonWriter requests
+  - Keep workflow token permissions scoped to `contents: read`, `pull-requests: write`, and `issues: write` for user-facing command feedback
+  - Serialize review runs per pull request
+
+## Technical design
+
+- [x] create: [devops/dev/arch.md](../../../../specs/devops/dev/arch.md)
+  - Context Architecture: PR review workflow boundaries, trigger routing, Writer authorization, command feedback, concurrency, and ReviewProvider integration
+
+## Construction
+
+- [x] update: [.github/workflows/README.md](../../../../../.github/workflows/README.md)
+  - add `pr-review.yml` to the workflow overview table with `pull_request_target` and `issue_comment` triggers
+  - add workflow details for automatic reviews, Writer `/review` requests, NonWriter feedback, repository rules, and ReviewProvider integration

--- a/uspecs/changes/archive/2606/2606090846-augment-pr-review-workflow/change.md
+++ b/uspecs/changes/archive/2606/2606090846-augment-pr-review-workflow/change.md
@@ -18,7 +18,7 @@ Introduce specified automated PR review behavior for repository participants:
 
 - The `devops` domain describes Voedger engineering operations, including repository automation used by NonWriters and Writers
 - The `dev` context contains the `pr-reviews` feature, which defines when automated reviews are created and who can request them
-- Every draft or non-draft pull request receives an automated review when it is opened, updated, reopened, or marked ready for review
+- Every draft or non-draft pull request receives an automated review when it is opened, synchronized, reopened, or marked ready for review
 - Writer can request another review by creating a PR comment whose trimmed body starts with `/review` as a command
 - Manual comment-triggered reviews are ignored on non-PR issues, edited or deleted comments, comments where `/review` is not the leading command, command-prefix lookalikes such as `/reviewed`, and comments from NonWriters
 - Reviews use the repository's existing development, Go, and Markdown guidance

--- a/uspecs/changes/archive/2606/2606090846-augment-pr-review-workflow/decisions.md
+++ b/uspecs/changes/archive/2606/2606090846-augment-pr-review-workflow/decisions.md
@@ -25,7 +25,7 @@ Alternatives:
 
 ## Ambiguity: whether automatic reviews include draft pull requests
 
-Decision: Review both draft and non-draft pull requests when they are opened, updated, reopened, or marked ready for review.
+Decision: Review both draft and non-draft pull requests when they are opened, synchronized, reopened, or marked ready for review.
 
 - Pros: matches the requested "all PRs" scope; gives early feedback before a draft is ready for human review; `pull_request_target` supports the selected activity types
 - Cons: may spend review-provider quota on work that is still incomplete

--- a/uspecs/changes/archive/2606/2606090846-augment-pr-review-workflow/decisions.md
+++ b/uspecs/changes/archive/2606/2606090846-augment-pr-review-workflow/decisions.md
@@ -1,0 +1,66 @@
+# Decisions: Automated reviews for pull requests
+
+## Vagueness: the `pr-reviews` feature has no owning context
+
+Decision: Place `pr-reviews` in a generalized `dev` context inside the `devops` domain.
+
+- Pros: keeps the domain focused on engineering operations while giving development automation a stable bounded context; leaves room for future development workflow features beyond pull request review and future review providers beyond the current implementation
+- Cons: the context is broader than the initial PR review feature and will need discipline to avoid becoming a catch-all
+- Confidence: user-provided
+
+Alternatives:
+
+1. Place `pr-reviews` directly under the `devops` domain without a context
+   - Pros: fewer folders and less structure for the first devops specification
+   - Cons: does not follow the uspecs model where features belong to exactly one context; creates a layout that would need reshaping as more devops features appear
+   - Confidence: low
+2. Place `pr-reviews` in a dedicated `pull-requests` context
+   - Pros: precise fit for the initial feature and its lifecycle events
+   - Cons: too narrow if the devops domain is expected to group broader development workflows under one context
+   - Confidence: high
+3. Place `pr-reviews` under a broader `repository` context
+   - Pros: could cover issues, branches, releases, and repository settings later
+   - Cons: less focused on the development workflow and more likely to mix unrelated repository administration concerns
+   - Confidence: medium
+
+## Ambiguity: whether automatic reviews include draft pull requests
+
+Decision: Review both draft and non-draft pull requests when they are opened, updated, reopened, or marked ready for review.
+
+- Pros: matches the requested "all PRs" scope; gives early feedback before a draft is ready for human review; `pull_request_target` supports the selected activity types
+- Cons: may spend review-provider quota on work that is still incomplete
+- Confidence: high
+
+Alternatives:
+
+1. Skip draft pull requests until they are marked ready for review
+   - Pros: avoids reviewing intentionally incomplete work
+   - Cons: contradicts the requested "all PRs" scope; delays feedback that could help while the PR is still being shaped
+   - Confidence: low
+2. Review only opened and synchronized pull requests
+   - Pros: simpler trigger set
+   - Cons: misses explicit ready-for-review transitions and makes draft handling less visible in the spec
+   - Confidence: medium
+
+## Ambiguity: what PR comment text triggers a manual review
+
+Decision: A manual review is triggered only by a newly created PR comment from Writer whose trimmed body starts with `/review` as a command.
+
+- Pros: gives Writer a short command; aligns authorization with a domain-defined role backed by GitHub Write or higher repository permission; supports natural command comments and optional trailing text; avoids accidental triggers when the phrase is quoted or mentioned later in a discussion; excludes command-prefix lookalikes such as `/reviewed`; uses the `issue_comment` event only for PR comments
+- Cons: users must put the command at the start of the comment; edited comments will not trigger a review
+- Confidence: user-provided
+
+Alternatives:
+
+1. Trigger when the comment contains `/review` anywhere
+   - Pros: convenient for casual comments
+   - Cons: accidental triggers are likely when people quote instructions or discuss the command
+   - Confidence: low
+2. Trigger only when the entire comment is exactly `/review`
+   - Pros: maximally explicit and easy to test
+   - Cons: prevents harmless trailing context such as `/review after latest push`
+   - Confidence: medium
+3. Trigger when the trimmed body starts with `/augment review`
+   - Pros: explicit command ownership and lower chance of collision with future bots or repository automation
+   - Cons: longer to type than `/review`
+   - Confidence: high

--- a/uspecs/specs/devops/dev/arch.md
+++ b/uspecs/specs/devops/dev/arch.md
@@ -1,0 +1,182 @@
+# Context architecture: devops/dev
+
+Development workflow automation for repository pull request review feedback. The context owns GitHub event routing for automated PR reviews, Writer-authorized manual review requests, NonWriter command feedback, and ReviewProvider invocation with repository rules.
+
+## External actors
+
+Roles:
+
+- `@NonWriter`
+  - User below Write repository permission who can open and update pull requests, but cannot request automated review.
+
+- `@Writer`
+  - User with Write or higher repository permission who reviews pull requests and can request additional automated review.
+
+Systems:
+
+- `*GitHub`
+  - Hosts pull requests, comments, repository secrets, repository rules, workflow events, workflow permissions, and published pull request reviews.
+
+- `*ReviewProvider`
+  - Produces automated review feedback from pull request changes, repository context, repository rules, and optional extra review instructions.
+
+## Components
+
+### Layers
+
+```text
+External actors and systems
+    |
+    +-- @NonWriter
+    +-- @Writer
+    +-- *GitHub
+    +-- *ReviewProvider
+    |
+    v
+Workflow boundary
+    |
+    +-- [[PR review workflow]]
+    |
+    v
+Trigger handling
+    |
+    +-- [Automatic review job]
+    +-- [Comment review job]
+    |
+    v
+Command handling
+    |
+    +-- [Review command parser]
+    +-- [Writer permission check]
+    +-- [NonWriter feedback]
+    |
+    v
+Provider integration
+    |
+    +-- [Review action]
+    +-- [Repository rules]
+    +-- [(Augment session secret)]
+```
+
+### Workflow boundary
+
+- `[[PR review workflow]]`
+  - Standalone GitHub Actions workflow that owns the `dev` context's pull request review automation without modifying CI, storage, deployment, or branch-protection workflows.
+  - impl: [.github/workflows/pr-review.yml#PR review](../../../../.github/workflows/pr-review.yml)
+
+### Trigger handling
+
+- `[Automatic review job]`
+  - Runs only for `pull_request_target` events in `voedger/voedger` when a pull request is opened, synchronized, reopened, or marked ready for review. It sends the pull request number and repository name to `[Review action]`.
+  - impl: [.github/workflows/pr-review.yml#jobs.automatic-review](../../../../.github/workflows/pr-review.yml)
+
+- `[Comment review job]`
+  - Runs only for `issue_comment` `created` events in `voedger/voedger` whose issue is a pull request. It routes created PR comments through `[Review command parser]`, ignores issue comments that are not attached to pull requests, and never receives edited or deleted comments.
+  - impl: [.github/workflows/pr-review.yml#jobs.comment-review](../../../../.github/workflows/pr-review.yml)
+
+### Command handling
+
+- `[Review command parser]`
+  - Trims the PR comment body, accepts exactly `/review` or `/review` followed by whitespace as the leading command, rejects command-prefix lookalikes such as `/reviewed`, and extracts the remaining text as extra review instructions.
+  - impl: [.github/workflows/pr-review.yml#steps.Parse review command](../../../../.github/workflows/pr-review.yml)
+
+- `[Writer permission check]`
+  - Resolves the commenter permission through the GitHub collaborator permission API. `admin`, `maintain`, and `write` are treated as `@Writer`; every other permission, missing collaborator record, or API lookup failure is treated as `@NonWriter`.
+  - impl: [.github/workflows/pr-review.yml#steps.Check commenter permission](../../../../.github/workflows/pr-review.yml)
+
+- `[NonWriter feedback]`
+  - Posts a PR comment explaining that only `@Writer` can request automated review when a `@NonWriter` creates a valid `/review` command.
+  - impl: [.github/workflows/pr-review.yml#steps.Reply to NonWriter](../../../../.github/workflows/pr-review.yml)
+
+### Provider integration
+
+- `[Review action]`
+  - Calls `augmentcode/review-pr@v0.2.0` with `[(Augment session secret)]`, `GITHUB_TOKEN`, pull request number, repository name, and `[Repository rules]`. Manual reviews also pass extracted extra instructions as custom guidelines.
+  - impl: [.github/workflows/pr-review.yml#uses.augmentcode/review-pr@v0.2.0](../../../../.github/workflows/pr-review.yml)
+
+- `[Repository rules]`
+  - Versioned review guidance supplied to `*ReviewProvider`.
+  - impl: [.augment/rules/ar-common-develop.md](../../../../.augment/rules/ar-common-develop.md)
+  - impl: [.augment/rules/ar-golang.md](../../../../.augment/rules/ar-golang.md)
+  - impl: [.augment/rules/ar-markdown.md](../../../../.augment/rules/ar-markdown.md)
+
+- `[(Augment session secret)]`
+  - GitHub Actions repository secret `AUGMENT_SESSION_AUTH` containing ReviewProvider session credentials. The secret is consumed only by `[Review action]`.
+
+## Scenarios
+
+### Automatic pull request review
+
+```text
+*GitHub
+  -> [[PR review workflow]] (pull_request_target event)
+  -> [Automatic review job]
+  -> [Review action]
+  -> [(Augment session secret)]
+  -> [Repository rules]
+  -> *ReviewProvider
+  -> *GitHub (pull request review)
+```
+
+### Writer requests another review
+
+```text
+@Writer creates PR comment "/review {extra instructions}"
+  -> *GitHub
+  -> [[PR review workflow]] (issue_comment.created event)
+  -> [Comment review job]
+  -> [Review command parser] extracts extra instructions
+  -> [Writer permission check] resolves write-or-higher permission
+  -> [Review action]
+  -> [(Augment session secret)]
+  -> [Repository rules]
+  -> *ReviewProvider
+  -> *GitHub (pull request review)
+```
+
+### NonWriter requests another review
+
+```text
+@NonWriter creates PR comment "/review"
+  -> *GitHub
+  -> [[PR review workflow]] (issue_comment.created event)
+  -> [Comment review job]
+  -> [Review command parser] accepts the command
+  -> [Writer permission check] resolves below-Write permission
+  -> [NonWriter feedback]
+  -> *GitHub (PR comment)
+```
+
+### Ignored comment
+
+```text
+*GitHub
+  -> [[PR review workflow]] (issue_comment.created event)
+  -> [Comment review job]
+  -> [Review command parser] rejects non-leading command, command-prefix lookalike, or non-PR issue comment
+  -> stop without [Review action]
+```
+
+## Cross-cutting concerns
+
+### Security
+
+- Every Component in `Trigger handling` runs only in `voedger/voedger` and must not execute scripts from the pull request head.
+- Every `[Review action]` invocation receives only `contents: read`, `pull-requests: write`, and `issues: write` through `GITHUB_TOKEN`.
+- Every `[(Augment session secret)]` use passes the secret directly to `[Review action]`; no Component may print or transform the secret.
+- Every `[Writer permission check]` failure must resolve to `@NonWriter`.
+
+### Concurrency
+
+- Every Component in `Trigger handling` serializes review runs by pull request number using the `pr-review-{number}` concurrency group.
+- No review run is cancelled in progress by a newer review request for the same pull request.
+
+### Configuration
+
+- Every `[Review action]` invocation uses the same `[Repository rules]` set so automatic and Writer-requested reviews apply the same repository guidance.
+- Manual extra instructions narrow a single Writer-requested review and do not alter `[Repository rules]`.
+
+### Context dependencies
+
+- The `dev` context depends on `*GitHub` for event delivery, permission lookup, secret storage, and review/comment publication.
+- The `dev` context depends on `*ReviewProvider` for review generation; provider-specific credentials and action versioning stay behind `[Review action]`.

--- a/uspecs/specs/devops/dev/pr-reviews.feature
+++ b/uspecs/specs/devops/dev/pr-reviews.feature
@@ -13,7 +13,7 @@ Feature: Pull request reviews
       Examples:
         | state     | event             |
         | draft     | opened            |
-        | non-draft | updated           |
+        | non-draft | synchronize       |
         | non-draft | reopened          |
         | draft     | ready for review  |
 

--- a/uspecs/specs/devops/dev/pr-reviews.feature
+++ b/uspecs/specs/devops/dev/pr-reviews.feature
@@ -1,0 +1,67 @@
+Feature: Pull request reviews
+
+  NonWriters and Writers receive automated feedback on pull requests before merge.
+
+  Rule: Automatic reviews
+
+    Scenario Outline: Pull request lifecycle event creates an automated review
+      Given Pull Request "AIR-4201" is "<state>"
+      When GitHub reports that the pull request is "<event>"
+      Then Pull Request "AIR-4201" has an automated review
+      And the review uses repository review rules
+
+      Examples:
+        | state     | event             |
+        | draft     | opened            |
+        | non-draft | updated           |
+        | non-draft | reopened          |
+        | draft     | ready for review  |
+
+  Rule: Manual review requests
+
+    Scenario: Writer requests another review with extra instructions
+      Given Pull Request "AIR-4201" exists
+      When Writer comments "/review after latest changes" on Pull Request "AIR-4201"
+      Then Pull Request "AIR-4201" has a new automated review
+      And the review uses repository review rules
+      And the review uses "after latest changes" as extra review instructions
+
+    Scenario: Writer requests another review without extra instructions
+      Given Pull Request "AIR-4201" exists
+      When Writer comments "/review" on Pull Request "AIR-4201"
+      Then Pull Request "AIR-4201" has a new automated review
+      And the review has no extra review instructions
+
+    Scenario: NonWriter requests another review
+      Given Pull Request "AIR-4201" exists
+      When NonWriter comments "/review" on Pull Request "AIR-4201"
+      Then Pull Request "AIR-4201" has no new automated review
+      And NonWriter is told that only Writer can request an automated review
+
+  Rule: Ignored comments
+
+    Scenario Outline: Comment does not trigger review
+      Given Pull Request "AIR-4201" exists
+      When Writer creates a pull request comment with body "<comment>"
+      Then Pull Request "AIR-4201" has no new automated review
+
+      Examples:
+        | comment                    |
+        | Please run /review         |
+        | I reviewed this manually   |
+        | /reviewed by reviewer      |
+
+    Scenario Outline: Existing comment change does not trigger review
+      Given Pull Request "AIR-4201" exists
+      When Writer "<action>" an existing pull request comment with body "/review"
+      Then Pull Request "AIR-4201" has no new automated review
+
+      Examples:
+        | action  |
+        | edits   |
+        | deletes |
+
+    Scenario: Review command on an issue is ignored
+      Given Issue "AIR-4202" is not a pull request
+      When Writer comments "/review" on Issue "AIR-4202"
+      Then Issue "AIR-4202" has no automated review

--- a/uspecs/specs/devops/domain.md
+++ b/uspecs/specs/devops/domain.md
@@ -1,0 +1,85 @@
+# Domain: Voedger engineering operations
+
+Development, review, delivery, and maintenance workflows used to change and operate the Voedger repository.
+
+## Overview
+
+Scope:
+
+- NonWriter and Writer workflows around repository changes
+- Automated checks and review support that run before changes are merged
+- Repository automation that improves engineering feedback without changing the Voedger production runtime
+
+Key features:
+
+- Development workflow automation
+- CI and validation workflows
+- Engineering rules and guidance for human developers and AI agents
+
+## External actors
+
+Roles:
+
+- 👤NonWriter
+  - User below Write repository permission who can open and update pull requests, but cannot request automated review
+- 👤Writer
+  - User with Write or higher repository permission who reviews pull requests, requests additional automated review, and decides whether changes can be merged
+
+Systems:
+
+- ⚙️GitHub
+  - Hosts the repository, pull requests, comments, secrets, and workflow execution
+- ⚙️ReviewProvider
+  - Provides automated review of pull request changes using repository context and rules
+
+---
+
+## Concepts
+
+- `Pull Request`
+  - A proposed repository change submitted for automated and human review before merge
+
+- `Review`
+  - Feedback attached to a pull request, including summary findings and inline comments
+
+- `Review Command`
+  - A pull request comment from a user with Write or higher repository permission that requests another automated review
+
+- `Repository Rule`
+  - Versioned guidance stored in the repository and supplied to automation or agents during review
+
+- `Repository Secret`
+  - Secret value managed by GitHub Actions and used by trusted workflows without committing credentials to the repository
+
+---
+
+## Contexts
+
+- **dev**
+  - Development workflow automation, including pull request review triggers and Writer-requested review reruns
+
+### Context map
+
+```mermaid
+graph
+  dev["📦dev"]
+```
+
+### dev
+
+Relationships:
+
+```mermaid
+graph
+  dev["📦dev"]
+  NonWriter["👤NonWriter"]
+  Writer["👤Writer"]
+  GitHub["⚙️GitHub"]
+  ReviewProvider["⚙️ReviewProvider"]
+
+  NonWriter -->|opens and updates pull requests| dev
+  Writer -->|reviews and requests reruns| dev
+  GitHub -->|emits pull request and comment events| dev
+  dev -->|submits review requests| ReviewProvider
+  dev -->|publishes pull request reviews| GitHub
+```


### PR DESCRIPTION
```yaml
change_id: 2606090756-augment-pr-review-workflow
type: ci
issue_url: https://github.com/augmentcode/review-pr
domains: [devops]
scope: [dev]
```
## Why

Pull requests should receive fast automated review feedback before human review starts. Repository automation is part of the engineering operations domain rather than the Voedger production runtime, so the intended behavior should be captured in a dedicated `devops` specification before the workflow is added. The repository already carries review guidance for human developers and AI agents, so the PR review automation should reuse the same project guidance instead of relying only on generic review criteria.

## What

Introduce specified automated PR review behavior for repository participants:

- The `devops` domain describes Voedger engineering operations, including repository automation used by NonWriters and Writers
- The `dev` context contains the `pr-reviews` feature, which defines when automated reviews are created and who can request them
- Every draft or non-draft pull request receives an automated review when it is opened, updated, reopened, or marked ready for review
- Writer can request another review by creating a PR comment whose trimmed body starts with `/review` as a command
- Manual comment-triggered reviews are ignored on non-PR issues, edited or deleted comments, comments where `/review` is not the leading command, command-prefix lookalikes such as `/reviewed`, and comments from NonWriters
- Reviews use the repository's existing development, Go, and Markdown guidance
- The workflow uses a repository secret for review-provider authentication and keeps GitHub token permissions limited to reading contents, writing pull request reviews, and writing command feedback comments

## How

Decisions:

- Add the `devops` domain and place `pr-reviews` under the `dev` context before adding workflow automation
- Add a `dev` context architecture document to describe PR review workflow boundaries, triggers, permissions, and ReviewProvider integration
- Add a standalone PR review workflow instead of modifying existing CI workflows
- Use `pull_request_target` for automatic PR reviews and `issue_comment` `created` events for the `/review` command
- Use `augmentcode/review-pr@v0.2.0` with `AUGMENT_SESSION_AUTH`, `GITHUB_TOKEN`, and the repository's Augment rule files
- Keep workflow permissions to `contents: read`, `pull-requests: write`, and `issues: write` for command feedback comments; serialize review runs per pull request

Out of scope:

- Replacing required human review or changing branch protection
- Changing existing CI test, lint, storage, or deployment workflows
- Managing the lifecycle of the personal Augment session credential outside GitHub secrets



---
Content omitted. See change.md for full details.
