### PR TITLE
ci(dev): Review feedback trigger policy

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -133,9 +133,10 @@ Scripts called from `https://raw.githubusercontent.com/untillpro/ci-action/main/
 2. Runs manual reviews on PR `issue_comment` `created` events when the trimmed comment body starts with `/review` as a command.
 3. Treats GitHub permissions `write`, `maintain`, and `admin` as Writer; all other commenters are NonWriters, receive a feedback comment, and do not trigger a review.
 4. Passes text after `/review` as extra review instructions.
-5. Posts a PR comment when automatic or Writer-requested review starts, and posts a failure comment with the GitHub Actions run URL if review automation fails.
-6. Successful review results remain ReviewProvider pull request reviews; no success status comment is posted.
-7. Calls `augmentcode/review-pr@v0.2.0` with:
+5. Posts a PR comment when automatic or Writer-requested review starts. The automatic start comment tells Writers they can request another review with `/review` or `/review <extra instructions>`.
+6. Posts a failure comment with the GitHub Actions run URL if review automation fails.
+7. Successful review results remain ReviewProvider pull request reviews; no success status comment is posted.
+8. Calls `augmentcode/review-pr@v0.2.0` with:
    - `AUGMENT_SESSION_AUTH`
    - `GITHUB_TOKEN`
    - pull request number
@@ -143,8 +144,8 @@ Scripts called from `https://raw.githubusercontent.com/untillpro/ci-action/main/
    - `.augment/rules/ar-common-develop.md`
    - `.augment/rules/ar-golang.md`
    - `.augment/rules/ar-markdown.md`
-8. Uses `contents: read`, `pull-requests: write`, and `issues: write` permissions.
-9. Serializes review runs per pull request with the `pr-review-{number}` concurrency group.
+9. Uses `contents: read`, `pull-requests: write`, and `issues: write` permissions.
+10. Serializes review runs per pull request with the `pr-review-{number}` concurrency group.
 
 ### Daily Tests (ci-full.yml)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -129,13 +129,13 @@ Scripts called from `https://raw.githubusercontent.com/untillpro/ci-action/main/
 
 1. Runs automatic reviews on `pull_request_target` events:
    - `opened`
-   - `synchronize`
-   - `reopened`
    - `ready_for_review`
 2. Runs manual reviews on PR `issue_comment` `created` events when the trimmed comment body starts with `/review` as a command.
 3. Treats GitHub permissions `write`, `maintain`, and `admin` as Writer; all other commenters are NonWriters, receive a feedback comment, and do not trigger a review.
 4. Passes text after `/review` as extra review instructions.
-5. Calls `augmentcode/review-pr@v0.2.0` with:
+5. Posts a PR comment when automatic or Writer-requested review starts, and posts a failure comment with the GitHub Actions run URL if review automation fails.
+6. Successful review results remain ReviewProvider pull request reviews; no success status comment is posted.
+7. Calls `augmentcode/review-pr@v0.2.0` with:
    - `AUGMENT_SESSION_AUTH`
    - `GITHUB_TOKEN`
    - pull request number
@@ -143,8 +143,8 @@ Scripts called from `https://raw.githubusercontent.com/untillpro/ci-action/main/
    - `.augment/rules/ar-common-develop.md`
    - `.augment/rules/ar-golang.md`
    - `.augment/rules/ar-markdown.md`
-6. Uses `contents: read`, `pull-requests: write`, and `issues: write` permissions.
-7. Serializes review runs per pull request with the `pr-review-{number}` concurrency group.
+8. Uses `contents: read`, `pull-requests: write`, and `issues: write` permissions.
+9. Serializes review runs per pull request with the `pr-review-{number}` concurrency group.
 
 ### Daily Tests (ci-full.yml)
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -47,12 +47,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          body=$(cat <<EOF
-          ⚠️ Automated review failed.
-
-          Details: ${RUN_URL}
-          EOF
-          )
+          body=$(printf '⚠️ Automated review failed.\n\nDetails: %s' "$RUN_URL")
           gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             -f body="$body"
 
@@ -141,11 +136,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          body=$(cat <<EOF
-          ⚠️ Automated review failed.
-
-          Details: ${RUN_URL}
-          EOF
-          )
+          body=$(printf '⚠️ Automated review failed.\n\nDetails: %s' "$RUN_URL")
           gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
             -f body="$body"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -4,8 +4,6 @@ on:
   pull_request_target:
     types:
       - opened
-      - synchronize
-      - reopened
       - ready_for_review
   issue_comment:
     types:
@@ -24,7 +22,16 @@ jobs:
       group: pr-review-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     steps:
+      - name: Comment review started
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            -f body='👀 Automated review started.'
+
       - name: Review pull request
+        id: review
         uses: augmentcode/review-pr@v0.2.0
         with:
           augment_session_auth: ${{ secrets.AUGMENT_SESSION_AUTH }}
@@ -32,6 +39,22 @@ jobs:
           pull_number: ${{ github.event.pull_request.number }}
           repo_name: ${{ github.repository }}
           rules: '[".augment/rules/ar-common-develop.md",".augment/rules/ar-golang.md",".augment/rules/ar-markdown.md"]'
+
+      - name: Comment review failure
+        if: failure() && steps.review.outcome == 'failure'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          body=$(cat <<EOF
+          ⚠️ Automated review failed.
+
+          Details: ${RUN_URL}
+          EOF
+          )
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            -f body="$body"
 
   comment-review:
     if: github.repository == 'voedger/voedger' && github.event_name == 'issue_comment' && github.event.issue.pull_request
@@ -88,10 +111,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
-            -f body='Only Writer can request an automated review with `/review`.'
+            -f body='🔒 Only Writer can request an automated review with `/review`.'
+
+      - name: Comment review started
+        if: steps.review_command.outputs.is_review_command == 'true' && steps.commenter_permission.outputs.is_writer == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f body='👀 Automated review started.'
 
       - name: Review pull request
         if: steps.review_command.outputs.is_review_command == 'true' && steps.commenter_permission.outputs.is_writer == 'true'
+        id: review
         uses: augmentcode/review-pr@v0.2.0
         with:
           augment_session_auth: ${{ secrets.AUGMENT_SESSION_AUTH }}
@@ -100,3 +133,19 @@ jobs:
           repo_name: ${{ github.repository }}
           custom_guidelines: ${{ steps.review_command.outputs.extra_instructions }}
           rules: '[".augment/rules/ar-common-develop.md",".augment/rules/ar-golang.md",".augment/rules/ar-markdown.md"]'
+
+      - name: Comment review failure
+        if: failure() && steps.review.outcome == 'failure' && steps.review_command.outputs.is_review_command == 'true' && steps.commenter_permission.outputs.is_writer == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          body=$(cat <<EOF
+          ⚠️ Automated review failed.
+
+          Details: ${RUN_URL}
+          EOF
+          )
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f body="$body"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -27,8 +27,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          body=$(printf '👀 Automated review started.\n\nWriters can request another review with `/review` or `/review <extra instructions>`.')
           gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            -f body='👀 Automated review started.'
+            -f body="$body"
 
       - name: Review pull request
         id: review

--- a/uspecs/changes/archive/2606/2606090956-review-feedback-trigger-policy/change.md
+++ b/uspecs/changes/archive/2606/2606090956-review-feedback-trigger-policy/change.md
@@ -1,0 +1,69 @@
+---
+change_id: 2606090922-review-feedback-trigger-policy
+type: ci
+domains: [devops]
+scope: [dev]
+---
+
+# Change request: Review feedback trigger policy
+
+## Why
+
+The automated PR review workflow should balance timely feedback with noise and review-provider cost. Reviewers need PR-thread acknowledgement when automatic or manual review automation starts, and a clear PR-thread signal when review automation fails.
+
+## What
+
+Adjust PR review automation behavior in the `devops` `dev` context:
+
+- Automatic reviews run only on `pull_request_target` `opened` and `ready_for_review` events; `opened` covers draft and non-draft pull requests, and `ready_for_review` covers draft pull requests becoming ready
+- New commits and reopened pull requests rely on Writer-requested `/review` reruns instead of automatic reruns
+- Automatic and Writer-requested reviews create a PR comment indicating that automated review has started
+- Failed automatic and Writer-requested reviews create a PR comment with the GitHub Actions run URL
+- Successful reviews remain visible as ReviewProvider pull request reviews; status comments do not replace review results
+- NonWriter `/review` requests continue to be rejected with a clear PR comment
+
+Expected PR comments:
+
+```text
+👀 Automated review started.
+```
+
+```text
+⚠️ Automated review failed.
+
+Details: <run-url>
+```
+
+```text
+🔒 Only Writer can request an automated review with `/review`.
+```
+
+## Functional design
+
+- [x] update: [devops/dev/pr-reviews.feature](../../../../specs/devops/dev/pr-reviews.feature)
+  - remove: automatic review scenarios for `synchronize` and `reopened`
+  - add: scenarios for start comments on automatic and Writer-requested reviews
+  - add: scenarios for failure comments with the GitHub Actions run URL
+  - add: scenario or assertion that successful review results remain ReviewProvider pull request reviews
+  - update: NonWriter denial scenario to expect the `🔒` denial comment text
+
+## Technical design
+
+- [x] update: [devops/dev/arch.md](../../../../specs/devops/dev/arch.md)
+  - align automatic review trigger handling with `opened` and `ready_for_review`
+  - document start comments, failure comments, and ReviewProvider pull request review results
+
+## Provisioning and configuration
+
+- [x] update: [.github/workflows/pr-review.yml](../../../../../.github/workflows/pr-review.yml)
+  - remove: `synchronize` and `reopened` from automatic `pull_request_target` activity types
+  - add: PR status comment before automatic and Writer-requested review starts
+  - add: failure PR status comment with the GitHub Actions run URL for automatic and Writer-requested reviews
+  - preserve: no success status comment; successful results remain ReviewProvider pull request reviews
+  - update: NonWriter denial comment to the expected `🔒` text
+
+## Construction
+
+- [x] update: [.github/workflows/README.md](../../../../../.github/workflows/README.md)
+  - align documented PR review workflow triggers with `opened` and `ready_for_review`
+  - document start comments, failure comments, and ReviewProvider pull request review results

--- a/uspecs/changes/archive/2606/2606090956-review-feedback-trigger-policy/change.md
+++ b/uspecs/changes/archive/2606/2606090956-review-feedback-trigger-policy/change.md
@@ -17,12 +17,19 @@ Adjust PR review automation behavior in the `devops` `dev` context:
 
 - Automatic reviews run only on `pull_request_target` `opened` and `ready_for_review` events; `opened` covers draft and non-draft pull requests, and `ready_for_review` covers draft pull requests becoming ready
 - New commits and reopened pull requests rely on Writer-requested `/review` reruns instead of automatic reruns
-- Automatic and Writer-requested reviews create a PR comment indicating that automated review has started
+- Automatic reviews create a PR comment indicating that automated review has started and telling Writers how to request another review
+- Writer-requested reviews create a PR comment indicating that automated review has started
 - Failed automatic and Writer-requested reviews create a PR comment with the GitHub Actions run URL
 - Successful reviews remain visible as ReviewProvider pull request reviews; status comments do not replace review results
 - NonWriter `/review` requests continue to be rejected with a clear PR comment
 
 Expected PR comments:
+
+```text
+👀 Automated review started.
+
+Writers can request another review with `/review` or `/review <extra instructions>`.
+```
 
 ```text
 👀 Automated review started.
@@ -42,7 +49,7 @@ Details: <run-url>
 
 - [x] update: [devops/dev/pr-reviews.feature](../../../../specs/devops/dev/pr-reviews.feature)
   - remove: automatic review scenarios for `synchronize` and `reopened`
-  - add: scenarios for start comments on automatic and Writer-requested reviews
+  - add: scenarios for automatic start comments with `/review` instructions and Writer-requested start comments
   - add: scenarios for failure comments with the GitHub Actions run URL
   - add: scenario or assertion that successful review results remain ReviewProvider pull request reviews
   - update: NonWriter denial scenario to expect the `🔒` denial comment text
@@ -51,13 +58,13 @@ Details: <run-url>
 
 - [x] update: [devops/dev/arch.md](../../../../specs/devops/dev/arch.md)
   - align automatic review trigger handling with `opened` and `ready_for_review`
-  - document start comments, failure comments, and ReviewProvider pull request review results
+  - document automatic start comments with `/review` instructions, Writer-requested start comments, failure comments, and ReviewProvider pull request review results
 
 ## Provisioning and configuration
 
 - [x] update: [.github/workflows/pr-review.yml](../../../../../.github/workflows/pr-review.yml)
   - remove: `synchronize` and `reopened` from automatic `pull_request_target` activity types
-  - add: PR status comment before automatic and Writer-requested review starts
+  - add: PR status comment before automatic and Writer-requested review starts, with `/review` instructions on the automatic start comment
   - add: failure PR status comment with the GitHub Actions run URL for automatic and Writer-requested reviews
   - preserve: no success status comment; successful results remain ReviewProvider pull request reviews
   - update: NonWriter denial comment to the expected `🔒` text
@@ -66,4 +73,4 @@ Details: <run-url>
 
 - [x] update: [.github/workflows/README.md](../../../../../.github/workflows/README.md)
   - align documented PR review workflow triggers with `opened` and `ready_for_review`
-  - document start comments, failure comments, and ReviewProvider pull request review results
+  - document automatic start comments with `/review` instructions, Writer-requested start comments, failure comments, and ReviewProvider pull request review results

--- a/uspecs/changes/archive/2606/2606090956-review-feedback-trigger-policy/decisions.md
+++ b/uspecs/changes/archive/2606/2606090956-review-feedback-trigger-policy/decisions.md
@@ -1,0 +1,68 @@
+# Decisions: Review feedback trigger policy
+
+## Ambiguity: automatic review trigger scope
+
+Decision: Automatic reviews run only on `pull_request_target` `opened` and `ready_for_review`; `opened` applies to draft and non-draft pull requests, and `ready_for_review` applies when a draft pull request is marked ready.
+
+- Pros: matches GitHub Actions event vocabulary; reduces review-provider cost and PR-thread noise; preserves early review for both draft and non-draft PR openings; keeps a second automatic review for draft PRs when they become ready
+- Cons: new commits and reopened pull requests require a Writer to request `/review`
+- Confidence: high
+
+Alternatives:
+
+1. Keep `synchronize` and `reopened` automatic reviews
+   - Pros: maximizes automatic coverage after new commits and reopened work
+   - Cons: noisier and more expensive on active PRs; duplicates the manual `/review` rerun path
+   - Confidence: medium
+2. Run automatic reviews only on `ready_for_review`
+   - Pros: minimizes review-provider usage
+   - Cons: non-draft PRs opened ready for review would not receive initial automatic feedback
+   - Confidence: low
+
+## Vagueness: where successful review results appear
+
+Decision: Successful reviews remain visible as ReviewProvider pull request reviews; PR status comments only announce start, failure, or authorization denial.
+
+- Pros: keeps review findings in GitHub's native review UI; avoids adding duplicate success comments; clarifies that comments are operational status, not review output
+- Cons: users must distinguish the status comment from the review result
+- Confidence: high
+
+Alternatives:
+
+1. Add a success comment after every completed review
+   - Pros: makes completion visible in the PR conversation
+   - Cons: duplicates the review result and increases comment noise
+   - Confidence: medium
+
+## Vagueness: PR-thread status comment text
+
+Decision: Use concise PR comments:
+
+```text
+👀 Automated review started.
+```
+
+```text
+⚠️ Automated review failed.
+
+Details: <run-url>
+```
+
+```text
+🔒 Only Writer can request an automated review with `/review`.
+```
+
+- Pros: gives users immediate feedback; failure comments include the GitHub Actions run URL for diagnosis; emojis make status comments scannable without long text
+- Cons: emojis are slightly less formal than plain status text
+- Confidence: user-provided
+
+Alternatives:
+
+1. Use plain text without emojis
+   - Pros: most formal and consistent with engineering prose
+   - Cons: less visually distinct in a busy PR thread
+   - Confidence: medium
+2. Include trigger details in every start comment
+   - Pros: explains why the review started
+   - Cons: exposes implementation detail and makes normal comments longer
+   - Confidence: medium

--- a/uspecs/changes/archive/2606/2606090956-review-feedback-trigger-policy/decisions.md
+++ b/uspecs/changes/archive/2606/2606090956-review-feedback-trigger-policy/decisions.md
@@ -36,7 +36,13 @@ Alternatives:
 
 ## Vagueness: PR-thread status comment text
 
-Decision: Use concise PR comments:
+Decision: Use concise PR comments, with `/review` instructions only in the automatic review start comment:
+
+```text
+👀 Automated review started.
+
+Writers can request another review with `/review` or `/review <extra instructions>`.
+```
 
 ```text
 👀 Automated review started.
@@ -52,8 +58,8 @@ Details: <run-url>
 🔒 Only Writer can request an automated review with `/review`.
 ```
 
-- Pros: gives users immediate feedback; failure comments include the GitHub Actions run URL for diagnosis; emojis make status comments scannable without long text
-- Cons: emojis are slightly less formal than plain status text
+- Pros: gives users immediate feedback; the first automatic comment tells Writers how to request another review; failure comments include the GitHub Actions run URL for diagnosis; emojis make status comments scannable without long text
+- Cons: emojis are slightly less formal than plain status text; the automatic start comment is longer than Writer-requested start comments
 - Confidence: user-provided
 
 Alternatives:
@@ -62,7 +68,7 @@ Alternatives:
    - Pros: most formal and consistent with engineering prose
    - Cons: less visually distinct in a busy PR thread
    - Confidence: medium
-2. Include trigger details in every start comment
-   - Pros: explains why the review started
-   - Cons: exposes implementation detail and makes normal comments longer
+2. Include `/review` instructions in every start comment
+   - Pros: keeps the manual rerun command visible on every review start
+   - Cons: repeats guidance after Writer-requested reviews and increases comment noise
    - Confidence: medium

--- a/uspecs/specs/devops/dev/arch.md
+++ b/uspecs/specs/devops/dev/arch.md
@@ -67,7 +67,7 @@ Provider integration
 ### Trigger handling
 
 - `[Automatic review job]`
-  - Runs only for `pull_request_target` events in `voedger/voedger` when a pull request is opened, synchronized, reopened, or marked ready for review. It sends the pull request number and repository name to `[Review action]`.
+  - Runs only for `pull_request_target` events in `voedger/voedger` when a pull request is opened or marked ready for review. It posts a start comment, sends the pull request number and repository name to `[Review action]`, and posts a failure comment with the GitHub Actions run URL if `[Review action]` fails.
   - impl: [.github/workflows/pr-review.yml#jobs.automatic-review](../../../../.github/workflows/pr-review.yml)
 
 - `[Comment review job]`
@@ -91,7 +91,7 @@ Provider integration
 ### Provider integration
 
 - `[Review action]`
-  - Calls `augmentcode/review-pr@v0.2.0` with `[(Augment session secret)]`, `GITHUB_TOKEN`, pull request number, repository name, and `[Repository rules]`. Manual reviews also pass extracted extra instructions as custom guidelines.
+  - Calls `augmentcode/review-pr@v0.2.0` with `[(Augment session secret)]`, `GITHUB_TOKEN`, pull request number, repository name, and `[Repository rules]`. Manual reviews also pass extracted extra instructions as custom guidelines. Successful results remain ReviewProvider pull request reviews; status comments do not replace review results.
   - impl: [.github/workflows/pr-review.yml#uses.augmentcode/review-pr@v0.2.0](../../../../.github/workflows/pr-review.yml)
 
 - `[Repository rules]`
@@ -111,6 +111,7 @@ Provider integration
 *GitHub
   -> [[PR review workflow]] (pull_request_target event)
   -> [Automatic review job]
+  -> *GitHub (PR start comment)
   -> [Review action]
   -> [(Augment session secret)]
   -> [Repository rules]
@@ -127,6 +128,7 @@ Provider integration
   -> [Comment review job]
   -> [Review command parser] extracts extra instructions
   -> [Writer permission check] resolves write-or-higher permission
+  -> *GitHub (PR start comment)
   -> [Review action]
   -> [(Augment session secret)]
   -> [Repository rules]

--- a/uspecs/specs/devops/dev/arch.md
+++ b/uspecs/specs/devops/dev/arch.md
@@ -67,7 +67,7 @@ Provider integration
 ### Trigger handling
 
 - `[Automatic review job]`
-  - Runs only for `pull_request_target` events in `voedger/voedger` when a pull request is opened or marked ready for review. It posts a start comment, sends the pull request number and repository name to `[Review action]`, and posts a failure comment with the GitHub Actions run URL if `[Review action]` fails.
+  - Runs only for `pull_request_target` events in `voedger/voedger` when a pull request is opened or marked ready for review. It posts a start comment that tells Writers how to request another review, sends the pull request number and repository name to `[Review action]`, and posts a failure comment with the GitHub Actions run URL if `[Review action]` fails.
   - impl: [.github/workflows/pr-review.yml#jobs.automatic-review](../../../../.github/workflows/pr-review.yml)
 
 - `[Comment review job]`
@@ -111,7 +111,7 @@ Provider integration
 *GitHub
   -> [[PR review workflow]] (pull_request_target event)
   -> [Automatic review job]
-  -> *GitHub (PR start comment)
+  -> *GitHub (PR start comment with `/review` instructions)
   -> [Review action]
   -> [(Augment session secret)]
   -> [Repository rules]

--- a/uspecs/specs/devops/dev/pr-reviews.feature
+++ b/uspecs/specs/devops/dev/pr-reviews.feature
@@ -4,18 +4,33 @@ Feature: Pull request reviews
 
   Rule: Automatic reviews
 
-    Scenario Outline: Pull request lifecycle event creates an automated review
+    Scenario Outline: Pull request lifecycle event starts an automated review
       Given Pull Request "AIR-4201" is "<state>"
       When GitHub reports that the pull request is "<event>"
       Then Pull Request "AIR-4201" has an automated review
       And the review uses repository review rules
+      And Pull Request "AIR-4201" has comment "👀 Automated review started."
 
       Examples:
-        | state     | event             |
-        | draft     | opened            |
-        | non-draft | synchronize       |
-        | non-draft | reopened          |
-        | draft     | ready for review  |
+        | state     | event            |
+        | draft     | opened           |
+        | non-draft | opened           |
+        | draft     | ready for review |
+
+    Scenario Outline: Pull request lifecycle event does not start an automated review
+      Given Pull Request "AIR-4201" is "non-draft"
+      When GitHub reports that the pull request is "<event>"
+      Then Pull Request "AIR-4201" has no new automated review
+
+      Examples:
+        | event       |
+        | synchronize |
+        | reopened    |
+
+    Scenario: Automatic review fails
+      Given Pull Request "AIR-4201" exists
+      When automatic review of Pull Request "AIR-4201" fails in GitHub Actions run "https://github.com/voedger/voedger/actions/runs/42"
+      Then Pull Request "AIR-4201" has comment "⚠️ Automated review failed.\n\nDetails: https://github.com/voedger/voedger/actions/runs/42"
 
   Rule: Manual review requests
 
@@ -25,18 +40,31 @@ Feature: Pull request reviews
       Then Pull Request "AIR-4201" has a new automated review
       And the review uses repository review rules
       And the review uses "after latest changes" as extra review instructions
+      And Pull Request "AIR-4201" has comment "👀 Automated review started."
 
     Scenario: Writer requests another review without extra instructions
       Given Pull Request "AIR-4201" exists
       When Writer comments "/review" on Pull Request "AIR-4201"
       Then Pull Request "AIR-4201" has a new automated review
       And the review has no extra review instructions
+      And Pull Request "AIR-4201" has comment "👀 Automated review started."
+
+    Scenario: Writer-requested review fails
+      Given Pull Request "AIR-4201" exists
+      When Writer-requested review of Pull Request "AIR-4201" fails in GitHub Actions run "https://github.com/voedger/voedger/actions/runs/42"
+      Then Pull Request "AIR-4201" has comment "⚠️ Automated review failed.\n\nDetails: https://github.com/voedger/voedger/actions/runs/42"
+
+    Scenario: Successful review result remains a pull request review
+      Given Pull Request "AIR-4201" exists
+      When Pull Request "AIR-4201" has a successful automated review
+      Then Pull Request "AIR-4201" has a ReviewProvider pull request review
+      And Pull Request "AIR-4201" has no comment "Automated review succeeded."
 
     Scenario: NonWriter requests another review
       Given Pull Request "AIR-4201" exists
       When NonWriter comments "/review" on Pull Request "AIR-4201"
       Then Pull Request "AIR-4201" has no new automated review
-      And NonWriter is told that only Writer can request an automated review
+      And Pull Request "AIR-4201" has comment "🔒 Only Writer can request an automated review with `/review`."
 
   Rule: Ignored comments
 
@@ -46,10 +74,10 @@ Feature: Pull request reviews
       Then Pull Request "AIR-4201" has no new automated review
 
       Examples:
-        | comment                    |
-        | Please run /review         |
-        | I reviewed this manually   |
-        | /reviewed by reviewer      |
+        | comment                  |
+        | Please run /review       |
+        | I reviewed this manually |
+        | /reviewed by reviewer    |
 
     Scenario Outline: Existing comment change does not trigger review
       Given Pull Request "AIR-4201" exists

--- a/uspecs/specs/devops/dev/pr-reviews.feature
+++ b/uspecs/specs/devops/dev/pr-reviews.feature
@@ -9,7 +9,12 @@ Feature: Pull request reviews
       When GitHub reports that the pull request is "<event>"
       Then Pull Request "AIR-4201" has an automated review
       And the review uses repository review rules
-      And Pull Request "AIR-4201" has comment "👀 Automated review started."
+      And Pull Request "AIR-4201" has comment:
+        """
+        👀 Automated review started.
+
+        Writers can request another review with `/review` or `/review <extra instructions>`.
+        """
 
       Examples:
         | state     | event            |

--- a/uspecs/specs/devops/dev/pr-reviews.feature
+++ b/uspecs/specs/devops/dev/pr-reviews.feature
@@ -30,7 +30,12 @@ Feature: Pull request reviews
     Scenario: Automatic review fails
       Given Pull Request "AIR-4201" exists
       When automatic review of Pull Request "AIR-4201" fails in GitHub Actions run "https://github.com/voedger/voedger/actions/runs/42"
-      Then Pull Request "AIR-4201" has comment "⚠️ Automated review failed.\n\nDetails: https://github.com/voedger/voedger/actions/runs/42"
+      Then Pull Request "AIR-4201" has comment:
+        """
+        ⚠️ Automated review failed.
+
+        Details: https://github.com/voedger/voedger/actions/runs/42
+        """
 
   Rule: Manual review requests
 
@@ -52,7 +57,12 @@ Feature: Pull request reviews
     Scenario: Writer-requested review fails
       Given Pull Request "AIR-4201" exists
       When Writer-requested review of Pull Request "AIR-4201" fails in GitHub Actions run "https://github.com/voedger/voedger/actions/runs/42"
-      Then Pull Request "AIR-4201" has comment "⚠️ Automated review failed.\n\nDetails: https://github.com/voedger/voedger/actions/runs/42"
+      Then Pull Request "AIR-4201" has comment:
+        """
+        ⚠️ Automated review failed.
+
+        Details: https://github.com/voedger/voedger/actions/runs/42
+        """
 
     Scenario: Successful review result remains a pull request review
       Given Pull Request "AIR-4201" exists


### PR DESCRIPTION
```yaml
change_id: 2606090922-review-feedback-trigger-policy
type: ci
domains: [devops]
scope: [dev]
```
## Why

The automated PR review workflow should balance timely feedback with noise and review-provider cost. Reviewers need PR-thread acknowledgement when automatic or manual review automation starts, and a clear PR-thread signal when review automation fails.

## What

Adjust PR review automation behavior in the `devops` `dev` context:

- Automatic reviews run only on `pull_request_target` `opened` and `ready_for_review` events; `opened` covers draft and non-draft pull requests, and `ready_for_review` covers draft pull requests becoming ready
- New commits and reopened pull requests rely on Writer-requested `/review` reruns instead of automatic reruns
- Automatic and Writer-requested reviews create a PR comment indicating that automated review has started
- Failed automatic and Writer-requested reviews create a PR comment with the GitHub Actions run URL
- Successful reviews remain visible as ReviewProvider pull request reviews; status comments do not replace review results
- NonWriter `/review` requests continue to be rejected with a clear PR comment

Expected PR comments:

```text
👀 Automated review started.
```

```text
⚠️ Automated review failed.

Details: <run-url>
```

```text
🔒 Only Writer can request an automated review with `/review`.
```

## Functional design

- [x] update: `[devops/dev/pr-reviews.feature](/specs/devops/dev/pr-reviews.feature)`


---
Content omitted. See change.md for full details.
