### PR TITLE
docs: Document EnrichPrincipalToken in auth specifications

### DIFF
--- a/uspecs/changes/archive/2606/2606121505-document-enrich-principal-token/change.md
+++ b/uspecs/changes/archive/2606/2606121505-document-enrich-principal-token/change.md
@@ -1,0 +1,56 @@
+---
+change_id: 2606121429-document-enrich-principal-token
+type: docs
+domains: [prod]
+---
+
+# Change request: Document EnrichPrincipalToken in auth specifications
+
+## Why
+
+The `q.sys.EnrichPrincipalToken` query is implemented in `pkg/sys/authnz` and used in production to snapshot the request's runtime-composed role principals into a re-issued `[Principal Token]`, yet it is absent from the auth domain specifications. It spans two subsystems — `[[Token management]]` (mints a new token via `IAppTokens.IssueToken`) and `[[Authorization]]` (the `[Token-carried]` `Roles` source acquires a second population path, beyond sign-in) — and both views are incomplete without it.
+
+## What
+
+Document `EnrichPrincipalToken` across the two auth subsystems it spans:
+
+- In the tokens architecture, add it as a fourth lifecycle scenario alongside Issue / Refresh / Validate, with the same depth of treatment as `RefreshPrincipalToken`
+- In the authorization architecture, extend the `[Token-carried]` role-source origin paragraph to record that `EnrichPrincipalToken` is a runtime snapshot path into `PrincipalPayload.Roles` (in addition to sign-in)
+- Describe inputs, the payload mutation rule (aggregate `Principal{Kind: Role}` from `processors.IProcessorWorkpiece.GetPrincipals()` into `PrincipalPayload.Roles`, deduplicated by `{WSID, QName}`), the TTL applied, and the basic-auth + `WorkspaceOwner` authorization context under which the query runs
+
+## How
+
+Decisions:
+
+- Place the primary description in `uspecs/specs/prod/auth/arch-tokens.md`: it already documents `RefreshPrincipalToken` (same package, same `IAppTokens.IssueToken` primitive), so by parallel structure the new query belongs as a fourth scenario and a new entry under `Token endpoints`
+- Add a cross-cutting note in `uspecs/specs/prod/auth/arch-authz.md` to the `[Token-carried]` role-source paragraph, since this query is the only runtime authz-driven write path into `PrincipalPayload.Roles`; this keeps the four-sources taxonomy honest without duplicating the token-lifecycle description
+- Do **not** edit `arch-authn.md` or `authn--td.md`: `EnrichPrincipalToken` is not part of sign-in or any authentication flow they own
+- Derive the documented behaviour from `pkg/sys/authnz/impl_enrichprincipaltoken.go` and its registration in `pkg/sys/authnz/provide.go`; describe the payload via the existing `PrincipalPayload` / `RoleType` concepts already named in `arch-tokens.md` and `arch-authz.md` rather than restating field-level details
+- Apply `DefaultPrincipalTokenExpiration` consistently with the other token operations, citing `pkg/sys/authnz/consts.go`
+
+Out of scope:
+
+- Any change to runtime behaviour of `EnrichPrincipalToken`, its authorization rules, or its payload shape
+- Renaming, relocating, or restructuring existing auth specs beyond the additions above
+- Documenting the VIT test helper `VIT.EnrichPrincipalToken`
+
+References:
+
+- [tokens architecture spec](../../../../../uspecs/specs/prod/auth/arch-tokens.md)
+- [authorization architecture spec](../../../../../uspecs/specs/prod/auth/arch-authz.md)
+- [EnrichPrincipalToken implementation](../../../../../pkg/sys/authnz/impl_enrichprincipaltoken.go)
+- [authnz query registration](../../../../../pkg/sys/authnz/provide.go)
+- [PrincipalPayload type](../../../../../pkg/itokens-payloads/types.go)
+- [DefaultPrincipalTokenExpiration constant](../../../../../pkg/sys/authnz/consts.go)
+
+## Technical design
+
+- [x] update: [prod/auth/arch-tokens.md](../../../../specs/prod/auth/arch-tokens.md)
+  - add: `Enrich principal token` entry to `Scenarios overview` as a fourth lifecycle scenario alongside Issue / Refresh / Validate -- `@Client` (basic auth, `WorkspaceOwner`) calls `[q.sys.EnrichPrincipalToken]`, the request's runtime-composed role principals are folded into the decoded `PrincipalPayload.Roles`, and a fresh `[Principal Token]` is minted
+  - update: `Layers` diagram to add `[q.sys.EnrichPrincipalToken]` under `Token endpoints`
+  - add: `[q.sys.EnrichPrincipalToken]` Component under `Token endpoints` with the same depth as `[q.sys.RefreshPrincipalToken]` -- reads the bearer token via `storages.GetPrincipalTokenFromState`, decodes the payload via `payloads.GetPrincipalPayload`, aggregates every `Principal{Kind: Role}` from `processors.IProcessorWorkpiece.GetPrincipals()` into `PrincipalPayload.Roles` deduplicated by `RoleType{WSID, QName}`, and re-issues through `[IAppTokens].IssueToken` with `DefaultPrincipalTokenExpiration`; cite impl `pkg/sys/authnz/impl_enrichprincipaltoken.go#provideExecQryEnrichPrincipalToken` and decl `pkg/sys/sys.vsql#EnrichPrincipalToken`
+  - add: `Enrich principal token` Scenario subsection capturing the request -> decode payload -> aggregate request roles into `Roles` -> `IssueToken` -> response flow
+  - update: `Notes` to record that enrich applies `DefaultPrincipalTokenExpiration` consistently with the other token operations
+
+- [x] update: [prod/auth/arch-authz.md](../../../../specs/prod/auth/arch-authz.md)
+  - update: `[Token-carried]` role-source `Origin` paragraph to record `[q.sys.EnrichPrincipalToken]` as a runtime snapshot path into `PrincipalPayload.Roles` (in addition to the sign-in snapshot), folding the request's composed `Principal{Kind: Role}` set into the re-issued token; cross-reference `arch-tokens.md` for the token-lifecycle detail

--- a/uspecs/specs/prod/auth/arch-authz.md
+++ b/uspecs/specs/prod/auth/arch-authz.md
@@ -92,7 +92,7 @@ Four sources by origin contribute to a request's principal set; each is enumerat
   - Composition: `[Subjects reader]` reads `[(cdoc.sys.Subject)]` rows in `RequestWSID` matching the resolved login and emits one `Principal{Kind: Role, WSID: RequestWSID, QName: role}` per matched role.
 
 - `[Token-carried]`
-  - Origin: `[[Authentication]]` snapshots roles into `PrincipalPayload` at sign-in (per-app `Roles` from the registry login record) and `[c.registry.UpdateGlobalRoles]` updates the `GlobalRoles` field consumed at the next sign-in; see [arch-authn.md](./arch-authn.md).
+  - Origin: `[[Authentication]]` snapshots roles into `PrincipalPayload` at sign-in (per-app `Roles` from the registry login record) and `[c.registry.UpdateGlobalRoles]` updates the `GlobalRoles` field consumed at the next sign-in; see [arch-authn.md](./arch-authn.md). A second runtime write path is `[q.sys.EnrichPrincipalToken]`, which folds the request's composed `Principal{Kind: Role}` set into `PrincipalPayload.Roles` and re-issues the token so those roles travel into workspaces where they would not otherwise be composed; the token-lifecycle detail lives in [arch-tokens.md](./arch-tokens.md).
   - Composition: `PrincipalPayload.Roles []{WSID, QName}` is filtered to `RequestWSID` for API tokens, or to `OwnerWSID` of `RequestWSID` and re-keyed to `RequestWSID` for user/device tokens; `PrincipalPayload.GlobalRoles []QName` is emitted in any workspace as `Principal{Kind: Role, WSID: RequestWSID, QName: role}` when `IsAPIToken=false`.
 
 - `[Request-context]`

--- a/uspecs/specs/prod/auth/arch-tokens.md
+++ b/uspecs/specs/prod/auth/arch-tokens.md
@@ -1,6 +1,6 @@
 # Context subsystem architecture: prod/auth/tokens
 
-Token management subsystem architecture covering principal token issue, refresh, and validation, and the principal payload contract shared by authentication and authorization. Context-level overview and shared concepts: [arch.md](./arch.md). Producers of `PrincipalPayload`: [arch-authn.md](./arch-authn.md). Consumer that composes principals from a validated token: [arch-authz.md](./arch-authz.md).
+Token management subsystem architecture covering principal token issue, refresh, enrich, and validation, and the principal payload contract shared by authentication and authorization. Context-level overview and shared concepts: [arch.md](./arch.md). Producers of `PrincipalPayload`: [arch-authn.md](./arch-authn.md). Consumer that composes principals from a validated token: [arch-authz.md](./arch-authz.md).
 
 ## External actors
 
@@ -20,6 +20,9 @@ Roles:
 - **`Refresh principal token`**
   - `@Client` calls `[q.sys.RefreshPrincipalToken]` with the current `[Principal Token]`; the payload is decoded, the same identity (including the captured `Alias`) is re-encoded with the same TTL/AppQName by `[ITokens].IssueToken`, and the new token is returned. Refresh never re-resolves the login or alias and never updates the alias snapshot.
 
+- **`Enrich principal token`**
+  - `@Client` (basic auth, `WorkspaceOwner`) calls `[q.sys.EnrichPrincipalToken]` with the current `[Principal Token]`; the payload is decoded, every runtime-composed `Principal{Kind: Role}` for the request is folded into `PrincipalPayload.Roles` (deduplicated by `RoleType{WSID, QName}`), and a fresh `[Principal Token]` is minted by `[IAppTokens].IssueToken` with `DefaultPrincipalTokenExpiration`. Unlike refresh, enrich rewrites the `Roles` set; the other identity fields are preserved.
+
 - **`Validate principal token`**
   - On every request the authorization subsystem calls `[IAppTokens].ValidateToken(token, &payload)` (via `[Auth boundary]`) to verify the signature, audience, and expiry and to decode `PrincipalPayload` for principal composition (see [arch-authz.md](./arch-authz.md)).
 
@@ -37,6 +40,7 @@ External actors
 Token endpoints
     |
     +-- [q.sys.RefreshPrincipalToken]
+    +-- [q.sys.EnrichPrincipalToken]
     |
     v
 Token primitives
@@ -56,6 +60,11 @@ Payload contract
 - `[q.sys.RefreshPrincipalToken]`
   - Reads the bearer token from request state via `storages.GetPrincipalTokenFromState`, decodes `PrincipalPayload` through `payloads.GetPayloadRegistry`, and re-issues a token for the same AppQName, duration, and payload. The decoded `Alias` is preserved verbatim, so the snapshot taken at the original issue time survives the refresh; alias changes performed in the registry between issue and refresh have no effect on the refreshed token.
   - impl: [pkg/sys/authnz/impl_refreshprincipaltoken.go#provideRefreshPrincipalTokenExec](../../../../pkg/sys/authnz/impl_refreshprincipaltoken.go)
+
+- `[q.sys.EnrichPrincipalToken]`
+  - Reads the bearer token from request state via `storages.GetPrincipalTokenFromState`, decodes `PrincipalPayload` through `payloads.GetPrincipalPayload`, aggregates every `Principal{Kind: Role}` exposed by `args.Workpiece.(processors.IProcessorWorkpiece).GetPrincipals()` into `PrincipalPayload.Roles` (each as `RoleType{WSID, QName}`, appended only when not already present), and re-issues through `[IAppTokens].IssueToken` with `DefaultPrincipalTokenExpiration`. Runs under basic auth with the `WorkspaceOwner` role; it snapshots the request's runtime-composed roles into the token so they survive into workspaces where they are not otherwise composed (see the `[Token-carried]` role source in [arch-authz.md](./arch-authz.md)).
+  - impl: [pkg/sys/authnz/impl_enrichprincipaltoken.go#provideExecQryEnrichPrincipalToken](../../../../pkg/sys/authnz/impl_enrichprincipaltoken.go)
+  - decl: [pkg/sys/sys.vsql#EnrichPrincipalToken](../../../../pkg/sys/sys.vsql)
 
 ### Token primitives
 
@@ -107,6 +116,19 @@ Payload contract
 
 The Alias field is taken verbatim from the decoded payload and is not re-resolved against `[(registry.Login)]` or `[(registry.LoginAlias)]`. A login whose alias was set, replaced, or cleared after the original issue continues to refresh with the snapshotted alias until the next sign-in. To pick up a new alias the caller must sign in again rather than refresh.
 
+### Enrich principal token
+
+```text
+@Client POST q.sys.EnrichPrincipalToken (Authorization: Bearer <current token>, WorkspaceOwner)
+  -> [q.sys.EnrichPrincipalToken]
+       -> storages.GetPrincipalTokenFromState(state) -> current token
+       -> payloads.GetPrincipalPayload(appTokens, token) -> decode payload
+       -> for each Principal{Kind: Role} in IProcessorWorkpiece.GetPrincipals():
+            append RoleType{WSID, QName} to payload.Roles if absent
+       -> [IAppTokens].IssueToken(DefaultPrincipalTokenExpiration, &payload)
+  -> @Client: EnrichedToken
+```
+
 ### Validate principal token
 
 ```text
@@ -119,6 +141,6 @@ The Alias field is taken verbatim from the decoded payload and is not re-resolve
 
 ## Notes
 
-`DefaultPrincipalTokenExpiration = 1h` is defined in `pkg/sys/authnz/consts.go`; `[q.registry.IssuePrincipalToken]` rejects TTLs above `maxTokenTTLHours`. The TTL is preserved across refresh: each refresh extends the bearer-token wall-clock lifetime by the same duration that the original issue requested.
+`DefaultPrincipalTokenExpiration = 1h` is defined in `pkg/sys/authnz/consts.go`; `[q.registry.IssuePrincipalToken]` rejects TTLs above `maxTokenTTLHours`. The TTL is preserved across refresh: each refresh extends the bearer-token wall-clock lifetime by the same duration that the original issue requested. Enrich does not preserve the input token's remaining lifetime; it mints with `DefaultPrincipalTokenExpiration`, consistent with a freshly issued token.
 
 The `IsAPIToken` branch of principal composition is documented in [arch-authz.md](./arch-authz.md); the token subsystem owns only the flag's presence on `PrincipalPayload`, not the composition rules driven by it.


### PR DESCRIPTION
```yaml
change_id: 2606121429-document-enrich-principal-token
type: docs
domains: [prod]
```
## Why

The `q.sys.EnrichPrincipalToken` query is implemented in `pkg/sys/authnz` and used in production to snapshot the request's runtime-composed role principals into a re-issued `[Principal Token]`, yet it is absent from the auth domain specifications. It spans two subsystems — `[[Token management]]` (mints a new token via `IAppTokens.IssueToken`) and `[[Authorization]]` (the `[Token-carried]` `Roles` source acquires a second population path, beyond sign-in) — and both views are incomplete without it.

## What

Document `EnrichPrincipalToken` across the two auth subsystems it spans:

- In the tokens architecture, add it as a fourth lifecycle scenario alongside Issue / Refresh / Validate, with the same depth of treatment as `RefreshPrincipalToken`
- In the authorization architecture, extend the `[Token-carried]` role-source origin paragraph to record that `EnrichPrincipalToken` is a runtime snapshot path into `PrincipalPayload.Roles` (in addition to sign-in)
- Describe inputs, the payload mutation rule (aggregate `Principal{Kind: Role}` from `processors.IProcessorWorkpiece.GetPrincipals()` into `PrincipalPayload.Roles`, deduplicated by `{WSID, QName}`), the TTL applied, and the basic-auth + `WorkspaceOwner` authorization context under which the query runs

## How

Decisions:

- Place the primary description in `uspecs/specs/prod/auth/arch-tokens.md`: it already documents `RefreshPrincipalToken` (same package, same `IAppTokens.IssueToken` primitive), so by parallel structure the new query belongs as a fourth scenario and a new entry under `Token endpoints`
- Add a cross-cutting note in `uspecs/specs/prod/auth/arch-authz.md` to the `[Token-carried]` role-source paragraph, since this query is the only runtime authz-driven write path into `PrincipalPayload.Roles`; this keeps the four-sources taxonomy honest without duplicating the token-lifecycle description
- Do **not** edit `arch-authn.md` or `authn--td.md`: `EnrichPrincipalToken` is not part of sign-in or any authentication flow they own
- Derive the documented behaviour from `pkg/sys/authnz/impl_enrichprincipaltoken.go` and its registration in `pkg/sys/authnz/provide.go`; describe the payload via the existing `PrincipalPayload` / `RoleType` concepts already named in `arch-tokens.md` and `arch-authz.md` rather than restating field-level details
- Apply `DefaultPrincipalTokenExpiration` consistently with the other token operations, citing `pkg/sys/authnz/consts.go`

Out of scope:

- Any change to runtime behaviour of `EnrichPrincipalToken`, its authorization rules, or its payload shape
- Renaming, relocating, or restructuring existing auth specs beyond the additions above
- Documenting the VIT test helper `VIT.EnrichPrincipalToken`

References:

- `[tokens architecture spec](/uspecs/specs/prod/auth/arch-tokens.md)`
- `[authorization architecture spec](/uspecs/specs/prod/auth/arch-authz.md)`
- `[EnrichPrincipalToken implementation](/pkg/sys/authnz/impl_enrichprincipaltoken.go)`
- `[authnz query registration](/pkg/sys/authnz/provide.go)`
- `[PrincipalPayload type](/pkg/itokens-payloads/types.go)`


---
Content omitted. See change.md for full details.
