### PR TITLE
feat(auth)!: Principal token login reflects active alias at sign-in [AIR-4270]

### DIFF
--- a/pkg/iauthnzimpl/impl.go
+++ b/pkg/iauthnzimpl/impl.go
@@ -90,11 +90,23 @@ func (i *implIAuthenticator) Authenticate(requestContext context.Context, as ist
 	}
 
 	// read roles from cdoc.sys.Subjects from the current workspace
-	rolesFromSubjects, err := i.rolesFromSubjects(requestContext, principalPayload.Login, as, req.RequestWSID)
-	if err != nil {
-		return nil, istructs.NullWSID, err
+	// resolve against both the presented and canonical logins so role assignment matches
+	// regardless of which identifier a subject was registered under
+	subjectLogins := []string{principalPayload.PresentedLogin}
+	if principalPayload.CanonicalLogin != "" && principalPayload.CanonicalLogin != principalPayload.PresentedLogin {
+		subjectLogins = append(subjectLogins, principalPayload.CanonicalLogin)
 	}
-	principals = append(principals, rolesFromSubjects...)
+	for _, subjectLogin := range subjectLogins {
+		rolesFromSubjects, err := i.rolesFromSubjects(requestContext, subjectLogin, as, req.RequestWSID)
+		if err != nil {
+			return nil, istructs.NullWSID, err
+		}
+		for _, prn := range rolesFromSubjects {
+			if !slices.Contains(principals, prn) {
+				principals = append(principals, prn)
+			}
+		}
+	}
 
 	profileWSID = principalPayload.ProfileWSID // for user and device subject kinds
 	pkt := iauthnz.PrincipalKind_NULL
@@ -102,7 +114,12 @@ func (i *implIAuthenticator) Authenticate(requestContext context.Context, as ist
 	switch principalPayload.SubjectKind {
 	case istructs.SubjectKind_User:
 		pkt = iauthnz.PrincipalKind_User
-		loginName = principalPayload.Login
+		// keep internal identity on the canonical login; fall back to the presented login
+		// for legacy tokens (no CanonicalLogin claim) and the system principal
+		loginName = principalPayload.CanonicalLogin
+		if loginName == "" {
+			loginName = principalPayload.PresentedLogin
+		}
 	case istructs.SubjectKind_Device:
 		pkt = iauthnz.PrincipalKind_Device
 	default:

--- a/pkg/iauthnzimpl/impl_test.go
+++ b/pkg/iauthnzimpl/impl_test.go
@@ -35,8 +35,8 @@ func TestBasicUsage(t *testing.T) {
 	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, timeu.NewITime())
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(istructs.AppQName_test1_app1)
 	pp := payloads.PrincipalPayload{
-		Login:       "testlogin",
-		SubjectKind: istructs.SubjectKind_User,
+		PresentedLogin: "testlogin",
+		SubjectKind:    istructs.SubjectKind_User,
 		Roles: []payloads.RoleType{
 			{
 				WSID:  42,
@@ -125,8 +125,8 @@ func TestBasicUsage(t *testing.T) {
 
 	t.Run("authenticate in the child workspace", func(t *testing.T) {
 		pp := payloads.PrincipalPayload{
-			Login:       "testlogin",
-			SubjectKind: istructs.SubjectKind_User,
+			PresentedLogin: "testlogin",
+			SubjectKind:    istructs.SubjectKind_User,
 			Roles: []payloads.RoleType{
 				{
 					WSID:  2,
@@ -169,9 +169,9 @@ func TestAuthenticate(t *testing.T) {
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(istructs.AppQName_test1_app1)
 	login := "testlogin"
 	pp := payloads.PrincipalPayload{
-		Login:       login,
-		SubjectKind: istructs.SubjectKind_User,
-		ProfileWSID: 1,
+		PresentedLogin: login,
+		SubjectKind:    istructs.SubjectKind_User,
+		ProfileWSID:    1,
 	}
 	userToken, err := appTokens.IssueToken(time.Minute, &pp)
 	require.NoError(err)
@@ -193,10 +193,10 @@ func TestAuthenticate(t *testing.T) {
 
 	notIncludedRole := appdef.NewQName("test", "non-included")
 	pp = payloads.PrincipalPayload{
-		Login:       login,
-		SubjectKind: istructs.SubjectKind_User,
-		ProfileWSID: 1,
-		Roles:       []payloads.RoleType{{WSID: 1, QName: testRole}, {WSID: 2, QName: notIncludedRole}},
+		PresentedLogin: login,
+		SubjectKind:    istructs.SubjectKind_User,
+		ProfileWSID:    1,
+		Roles:          []payloads.RoleType{{WSID: 1, QName: testRole}, {WSID: 2, QName: notIncludedRole}},
 	}
 	enrichedToken, err := appTokens.IssueToken(time.Minute, &pp)
 	require.NoError(err)
@@ -422,9 +422,9 @@ func TestErrors(t *testing.T) {
 	t.Run("unsupported subject kind", func(t *testing.T) {
 
 		pp := payloads.PrincipalPayload{
-			Login:       "testlogin",
-			SubjectKind: istructs.SubjectKind_FakeLast,
-			ProfileWSID: 1,
+			PresentedLogin: "testlogin",
+			SubjectKind:    istructs.SubjectKind_FakeLast,
+			ProfileWSID:    1,
 		}
 		token, err := appTokens.IssueToken(time.Minute, &pp)
 		require.NoError(err)

--- a/pkg/itokens-payloads/consts.go
+++ b/pkg/itokens-payloads/consts.go
@@ -13,9 +13,9 @@ import (
 
 var (
 	systemPrincipalPayload = PrincipalPayload{
-		Login:       "system",
-		SubjectKind: istructs.SubjectKind_User,
-		ProfileWSID: istructs.NullWSID,
+		PresentedLogin: "system",
+		SubjectKind:    istructs.SubjectKind_User,
+		ProfileWSID:    istructs.NullWSID,
 	}
 )
 

--- a/pkg/itokens-payloads/impl_test.go
+++ b/pkg/itokens-payloads/impl_test.go
@@ -31,9 +31,9 @@ func TestBasicUsage_PrincipalPayload(t *testing.T) {
 	signer := itokensjwt.TestTokensJWT()
 
 	srcPayload := PrincipalPayload{
-		Login:       "login",
-		SubjectKind: istructs.SubjectKind_User,
-		ProfileWSID: istructs.WSID(10),
+		PresentedLogin: "login",
+		SubjectKind:    istructs.SubjectKind_User,
+		ProfileWSID:    istructs.WSID(10),
 	}
 
 	var token string
@@ -135,9 +135,9 @@ func TestBasicUsage_IAppTokens(t *testing.T) {
 
 	t.Run("Issue token", func(t *testing.T) {
 		srcPayload := PrincipalPayload{
-			Login:       "login",
-			SubjectKind: istructs.SubjectKind_User,
-			ProfileWSID: istructs.WSID(10),
+			PresentedLogin: "login",
+			SubjectKind:    istructs.SubjectKind_User,
+			ProfileWSID:    istructs.WSID(10),
 		}
 		token, err = at.IssueToken(testDuration, &srcPayload)
 		require.NoError(err)

--- a/pkg/itokens-payloads/types.go
+++ b/pkg/itokens-payloads/types.go
@@ -16,13 +16,17 @@ import (
 // Owner is a record with {WSID, IDOfOwner} key
 // isAPIToken -> principals will be built by Roles only in authenticator
 type PrincipalPayload struct {
-	Login       string
-	Alias       string
-	SubjectKind istructs.SubjectKindType
-	ProfileWSID istructs.WSID
-	Roles       []RoleType
-	GlobalRoles []appdef.QName
-	IsAPIToken  bool
+	// PresentedLogin is the frontend-facing presented identity: the active alias snapshot at issue time,
+	// or the canonical login when no alias is set. Not to be used for internal identity, authorization,
+	// quotas, or metrics. Carries a json:"Login" tag so the wire/JWT claim key stays "Login".
+	PresentedLogin string `json:"Login"`
+	// CanonicalLogin is the immutable internal identity: the canonical primary login resolved at issue time.
+	CanonicalLogin string
+	SubjectKind    istructs.SubjectKindType
+	ProfileWSID    istructs.WSID
+	Roles          []RoleType
+	GlobalRoles    []appdef.QName
+	IsAPIToken     bool
 }
 
 type RoleType struct {

--- a/pkg/processors/command/impl_test.go
+++ b/pkg/processors/command/impl_test.go
@@ -578,9 +578,9 @@ func TestAuthnz(t *testing.T) {
 	defer tearDown(app)
 
 	pp := payloads.PrincipalPayload{
-		Login:       "testlogin",
-		SubjectKind: istructs.SubjectKind_User,
-		ProfileWSID: 1,
+		PresentedLogin: "testlogin",
+		SubjectKind:    istructs.SubjectKind_User,
+		ProfileWSID:    1,
 	}
 	token, err := app.appTokens.IssueToken(10*time.Second, &pp)
 	require.NoError(err)

--- a/pkg/processors/n10n/impl_subscribeandwatch.go
+++ b/pkg/processors/n10n/impl_subscribeandwatch.go
@@ -53,7 +53,11 @@ func (p *implIN10NProc) validateToken(ctx context.Context, n10nWP *n10nWorkpiece
 }
 
 func (p *implIN10NProc) getSubjectLogin(ctx context.Context, n10nWP *n10nWorkpiece) (err error) {
-	n10nWP.subjectLogin = istructs.SubjectLogin(n10nWP.principalPayload.Login)
+	subjectLogin := n10nWP.principalPayload.CanonicalLogin
+	if subjectLogin == "" {
+		subjectLogin = n10nWP.principalPayload.PresentedLogin
+	}
+	n10nWP.subjectLogin = istructs.SubjectLogin(subjectLogin)
 	return nil
 }
 

--- a/pkg/processors/query/impl_test.go
+++ b/pkg/processors/query/impl_test.go
@@ -1338,9 +1338,9 @@ func (m *testMetrics) Increase(string, float64) {}
 
 func getTestToken(appTokens istructs.IAppTokens, wsid istructs.WSID) string {
 	pp := payloads.PrincipalPayload{
-		Login:       "syslogin",
-		SubjectKind: istructs.SubjectKind_User,
-		ProfileWSID: wsid,
+		PresentedLogin: "syslogin",
+		SubjectKind:    istructs.SubjectKind_User,
+		ProfileWSID:    wsid,
 	}
 	token, err := appTokens.IssueToken(time.Minute, &pp)
 	if err != nil {
@@ -1351,9 +1351,9 @@ func getTestToken(appTokens istructs.IAppTokens, wsid istructs.WSID) string {
 
 func getSystemToken(appTokens istructs.IAppTokens) string {
 	pp := payloads.PrincipalPayload{
-		Login:       "syslogin",
-		SubjectKind: istructs.SubjectKind_User,
-		ProfileWSID: istructs.NullWSID,
+		PresentedLogin: "syslogin",
+		SubjectKind:    istructs.SubjectKind_User,
+		ProfileWSID:    istructs.NullWSID,
 	}
 	token, err := appTokens.IssueToken(time.Minute, &pp)
 	if err != nil {

--- a/pkg/registry/impl_issueprincipaltoken.go
+++ b/pkg/registry/impl_issueprincipaltoken.go
@@ -98,12 +98,16 @@ func provideIssuePrincipalTokenExec(itokens itokens.ITokens, federation federati
 		}
 
 		// issue principal token
+		presentedLogin := loginForSignIn.alias
+		if presentedLogin == "" {
+			presentedLogin = loginForSignIn.canonicalLogin
+		}
 		principalPayload := payloads.PrincipalPayload{
-			Login:       loginForSignIn.canonicalLogin,
-			Alias:       loginForSignIn.alias,
-			SubjectKind: istructs.SubjectKindType(loginForSignIn.subjectKind),
-			ProfileWSID: istructs.WSID(result.profileWSID), //nolint G115 since WSID is created by NewWSID()
-			GlobalRoles: globalRoles,                       // [~server.authnz.groles/cmp.c.registry.IssuePrincipalToken~impl]
+			PresentedLogin: presentedLogin,
+			CanonicalLogin: loginForSignIn.canonicalLogin,
+			SubjectKind:    istructs.SubjectKindType(loginForSignIn.subjectKind),
+			ProfileWSID:    istructs.WSID(result.profileWSID), //nolint G115 since WSID is created by NewWSID()
+			GlobalRoles:    globalRoles,                       // [~server.authnz.groles/cmp.c.registry.IssuePrincipalToken~impl]
 		}
 		ttl := time.Duration(args.ArgumentObject.AsInt32(field_TTLHours)) * time.Hour
 		if ttl == 0 {

--- a/pkg/sys/it/impl_childworkspace_test.go
+++ b/pkg/sys/it/impl_childworkspace_test.go
@@ -151,9 +151,9 @@ func TestForeignAuthorization(t *testing.T) {
 		require.NoError(err)
 		apiToken, err := iauthnzimpl.IssueAPIToken(as.AppTokens(), time.Hour, []appdef.QName{appdef.NewQName("app1pkg", "SpecialAPITokenRole")},
 			childWS.WSID, payloads.PrincipalPayload{
-				Login:       parentWS.Owner.Name,
-				SubjectKind: istructs.SubjectKind_User,
-				ProfileWSID: parentWS.Owner.ProfileWSID,
+				PresentedLogin: parentWS.Owner.Name,
+				SubjectKind:    istructs.SubjectKind_User,
+				ProfileWSID:    parentWS.Owner.ProfileWSID,
 			})
 		require.NoError(err)
 

--- a/pkg/sys/it/impl_qpv2_test.go
+++ b/pkg/sys/it/impl_qpv2_test.go
@@ -214,9 +214,9 @@ func TestQueryProcessor2_Views(t *testing.T) {
 		require.NoError(err)
 		apiToken, err := iauthnzimpl.IssueAPIToken(as.AppTokens(), time.Hour, []appdef.QName{appdef.NewQName("app1pkg", "LimitedAccessRole")},
 			ws.WSID, payloads.PrincipalPayload{
-				Login:       newLogin.Name,
-				SubjectKind: istructs.SubjectKind_User,
-				ProfileWSID: newLoginPrn.ProfileWSID,
+				PresentedLogin: newLogin.Name,
+				SubjectKind:    istructs.SubjectKind_User,
+				ProfileWSID:    newLoginPrn.ProfileWSID,
 			})
 		require.NoError(err)
 
@@ -2241,10 +2241,10 @@ func TestQueryProcessor2_Schemas(t *testing.T) {
 	t.Run("read app schema as a sys.Developer", func(t *testing.T) {
 		// Generate sys.Developer token
 		pp := payloads.PrincipalPayload{
-			Login:       "Login",
-			SubjectKind: istructs.SubjectKind_User,
-			ProfileWSID: 1,
-			GlobalRoles: []appdef.QName{appdef.QNameRoleDeveloper},
+			PresentedLogin: "Login",
+			SubjectKind:    istructs.SubjectKind_User,
+			ProfileWSID:    1,
+			GlobalRoles:    []appdef.QName{appdef.QNameRoleDeveloper},
 		}
 		tokenDeveloper, err := vit.IssueToken(istructs.AppQName_test1_app1, 100*time.Minute, &pp)
 		require.NoError(err)
@@ -2271,10 +2271,10 @@ func TestQueryProcessor2_SchemasRoles(t *testing.T) {
 	t.Run("read app workspace roles as a sys.Developer", func(t *testing.T) {
 		// Generate sys.Developer token
 		pp := payloads.PrincipalPayload{
-			Login:       "Login",
-			SubjectKind: istructs.SubjectKind_User,
-			ProfileWSID: 1,
-			GlobalRoles: []appdef.QName{appdef.QNameRoleDeveloper},
+			PresentedLogin: "Login",
+			SubjectKind:    istructs.SubjectKind_User,
+			ProfileWSID:    1,
+			GlobalRoles:    []appdef.QName{appdef.QNameRoleDeveloper},
 		}
 		tokenDeveloper, err := vit.IssueToken(istructs.AppQName_test1_app1, 100*time.Minute, &pp)
 		require.NoError(err)
@@ -2315,10 +2315,10 @@ func TestQueryProcessor2_SchemasWorkspaceRole(t *testing.T) {
 	t.Run("read app workspace role as sys.Developer", func(t *testing.T) {
 		// Generate sys.Developer token
 		pp := payloads.PrincipalPayload{
-			Login:       "Login",
-			SubjectKind: istructs.SubjectKind_User,
-			ProfileWSID: 1,
-			GlobalRoles: []appdef.QName{appdef.QNameRoleDeveloper},
+			PresentedLogin: "Login",
+			SubjectKind:    istructs.SubjectKind_User,
+			ProfileWSID:    1,
+			GlobalRoles:    []appdef.QName{appdef.QNameRoleDeveloper},
 		}
 		tokenDeveloper, err := vit.IssueToken(istructs.AppQName_test1_app1, 100*time.Minute, &pp)
 		require.NoError(err)

--- a/pkg/sys/it/impl_signupin_test.go
+++ b/pkg/sys/it/impl_signupin_test.go
@@ -244,10 +244,10 @@ func TestLoginAlias(t *testing.T) {
 		waitForLoginAlias(t, vit, login, alias1)
 
 		primaryToken := issuePrincipalToken(t, vit, login.Name, login.Pwd, appQName)
-		assertPrincipalTokenClaims(t, vit, primaryToken, login.Name, alias1)
+		assertPrincipalTokenClaims(t, vit, primaryToken, alias1, login.Name)
 
 		aliasToken := issuePrincipalToken(t, vit, alias1, login.Pwd, appQName)
-		assertPrincipalTokenClaims(t, vit, aliasToken, login.Name, alias1)
+		assertPrincipalTokenClaims(t, vit, aliasToken, alias1, login.Name)
 
 		issuePrincipalToken(t, vit, alias1, "wrong-password", appQName, it.Expect401("login or password is incorrect"))
 	})
@@ -267,18 +267,18 @@ func TestLoginAlias(t *testing.T) {
 
 		issuePrincipalToken(t, vit, alias1, login.Pwd, appQName, it.Expect401("login or password is incorrect"))
 		aliasToken := issuePrincipalToken(t, vit, alias2, login.Pwd, appQName)
-		assertPrincipalTokenClaims(t, vit, aliasToken, login.Name, alias2)
+		assertPrincipalTokenClaims(t, vit, aliasToken, alias2, login.Name)
 	})
 
 	t.Run("existing token keeps alias snapshot and refresh preserves it", func(t *testing.T) {
 		tokenBeforeClear := issuePrincipalToken(t, vit, alias2, login.Pwd, appQName)
-		assertPrincipalTokenClaims(t, vit, tokenBeforeClear, login.Name, alias2)
+		assertPrincipalTokenClaims(t, vit, tokenBeforeClear, alias2, login.Name)
 
 		initiateSetLoginAlias(t, vit, login, "", sysRegistryToken)
 		waitForLoginAlias(t, vit, login, "")
 		issuePrincipalToken(t, vit, alias2, login.Pwd, appQName, it.Expect401("login or password is incorrect"))
 
-		assertPrincipalTokenClaims(t, vit, tokenBeforeClear, login.Name, alias2)
+		assertPrincipalTokenClaims(t, vit, tokenBeforeClear, alias2, login.Name)
 
 		vit.TimeAdd(time.Minute)
 		prnWithAliasSnapshot := &it.Principal{
@@ -290,7 +290,7 @@ func TestLoginAlias(t *testing.T) {
 		resp := vit.PostProfile(prnWithAliasSnapshot, "q.sys.RefreshPrincipalToken", body)
 		refreshedToken := resp.SectionRow()[0].(string)
 		require.NotEqual(tokenBeforeClear, refreshedToken)
-		assertPrincipalTokenClaims(t, vit, refreshedToken, login.Name, alias2)
+		assertPrincipalTokenClaims(t, vit, refreshedToken, alias2, login.Name)
 	})
 
 	t.Run("clearing when no alias is set is idempotent", func(t *testing.T) {
@@ -311,7 +311,7 @@ func TestLoginAlias(t *testing.T) {
 
 		issuePrincipalToken(t, vit, alias2, login.Pwd, appQName, it.Expect401("login or password is incorrect"))
 		aliasToken := issuePrincipalToken(t, vit, alias2, reuseLogin.Pwd, appQName)
-		assertPrincipalTokenClaims(t, vit, aliasToken, reuseLogin.Name, alias2)
+		assertPrincipalTokenClaims(t, vit, aliasToken, alias2, reuseLogin.Name)
 	})
 }
 
@@ -486,15 +486,18 @@ func issuePrincipalToken(t *testing.T, vit *it.VIT, signInIdentifier, pwd string
 	return resp.SectionRow()[0].(string)
 }
 
-func assertPrincipalTokenClaims(t *testing.T, vit *it.VIT, token, expectedLogin, expectedAlias string) {
+func assertPrincipalTokenClaims(t *testing.T, vit *it.VIT, token, expectedPresentedLogin, expectedCanonicalLogin string) {
 	t.Helper()
 	payload := payloads.PrincipalPayload{}
 	_, err := vit.ITokens.ValidateToken(token, &payload)
 	require.NoError(t, err)
-	require.Equal(t, expectedLogin, payload.Login)
+	require.Equal(t, expectedPresentedLogin, payload.PresentedLogin)
 
 	claims := decodeJWTClaims(t, token)
-	require.Equal(t, expectedAlias, claims["Alias"])
+	require.Equal(t, expectedPresentedLogin, claims["Login"])
+	require.Equal(t, expectedCanonicalLogin, claims["CanonicalLogin"])
+	_, hasAlias := claims["Alias"]
+	require.False(t, hasAlias)
 }
 
 func decodeJWTClaims(t *testing.T, token string) map[string]any {

--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -586,9 +586,9 @@ func TestAuthnz(t *testing.T) {
 	require.NoError(t, err)
 	apiToken, err := iauthnzimpl.IssueAPIToken(as.AppTokens(), time.Hour, []appdef.QName{apiRole},
 		ws.WSID, payloads.PrincipalPayload{
-			Login:       ws.Owner.Name,
-			SubjectKind: istructs.SubjectKind_User,
-			ProfileWSID: ws.Owner.ProfileWSID,
+			PresentedLogin: ws.Owner.Name,
+			SubjectKind:    istructs.SubjectKind_User,
+			ProfileWSID:    ws.Owner.ProfileWSID,
 		})
 	require.NoError(t, err)
 

--- a/pkg/sys/it/impl_workspace_test.go
+++ b/pkg/sys/it/impl_workspace_test.go
@@ -340,10 +340,10 @@ func TestCreateChildOfChildWorkspace(t *testing.T) {
 	// owner of ws is not owner of child of ws so let's generate a token with a WorkspaceOwner role
 	// note: WSID the role belongs to must be ws, not newWS because iauthnz implementation compares wsid to ownerWSID
 	pp := payloads.PrincipalPayload{
-		Login:       ws.Owner.Name,
-		SubjectKind: istructs.SubjectKind_User,
-		ProfileWSID: ws.Owner.ProfileWSID,
-		Roles:       []payloads.RoleType{{WSID: ws.WSID, QName: iauthnz.QNameRoleWorkspaceOwner}},
+		PresentedLogin: ws.Owner.Name,
+		SubjectKind:    istructs.SubjectKind_User,
+		ProfileWSID:    ws.Owner.ProfileWSID,
+		Roles:          []payloads.RoleType{{WSID: ws.WSID, QName: iauthnz.QNameRoleWorkspaceOwner}},
 	}
 	tokenForChildOfChild, err := vit.IssueToken(istructs.AppQName_test1_app1, time.Minute, &pp)
 	require.NoError(t, err)

--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -594,9 +594,10 @@ func (vit *VIT) RefreshTokens() {
 		for _, prn := range appPrns {
 			// issue principal token
 			principalPayload := payloads.PrincipalPayload{
-				Login:       prn.Name,
-				SubjectKind: istructs.SubjectKind_User,
-				ProfileWSID: prn.ProfileWSID,
+				PresentedLogin: prn.Name,
+				CanonicalLogin: prn.Name,
+				SubjectKind:    istructs.SubjectKind_User,
+				ProfileWSID:    prn.ProfileWSID,
 			}
 			as, err := vit.BuiltIn(prn.AppQName)
 			require.NoError(vit.T, err) // notest

--- a/uspecs/changes/archive/2606/2606151848-token-login-reflects-alias/change.md
+++ b/uspecs/changes/archive/2606/2606151848-token-login-reflects-alias/change.md
@@ -1,0 +1,140 @@
+---
+change_id: 2606151510-token-login-reflects-alias
+type: feat
+issue_url: https://untill.atlassian.net/browse/AIR-4270
+domains: [prod]
+scope: [auth]
+breaking: true
+---
+
+# Change request: Principal token login reflects active alias at sign-in
+
+Refs:
+
+- [AIR-4270: voedger: principal token Login reflects alias used at sign-in](./issue-AIR-4270.md)
+
+## Why
+
+The frontend shows the login value carried by the principal token, but on alias sign-in that value is the canonical primary login rather than the alias the user just typed, which confuses users mid email-change. Presenting the alias the user signed in with, while keeping the canonical primary login available for backend identity, removes that confusion.
+
+## What
+
+Adjust the authentication token identity contract so a signed-in user is presented with the identifier they recognize:
+
+- After sign-in, the principal token presents the identifier the user signed in by: their active alias when one is set, otherwise their primary login
+- The canonical primary login remains available in the token alongside the presented identifier, so backend identity needs are unaffected
+- The presented identifier and the canonical login are captured at token issue time and preserved unchanged when the token is refreshed
+- Workspace authorization resolves a user's roles using both the presented identifier and the canonical login, so role assignment matches regardless of which identifier a subject was registered under
+- When the user has no alias, the token and downstream behavior are unchanged from today
+
+## How
+
+Decisions:
+
+- Rename the `PrincipalPayload.Login` Go field to `PresentedLogin` and keep the wire/JWT claim key as `Login` via a `json:"Login"` struct tag; this preserves the frontend claim contract while turning every existing backend `payload.Login` read into a compile error that must be revisited (the intended guard against reusing the presented value as internal identity)
+- Replace the `Alias` field with `CanonicalLogin` in `PrincipalPayload`; its Go field name equals the claim key, so no tag is needed and the JWT claim key changes from `Alias` to `CanonicalLogin`
+- In `q.registry.IssuePrincipalToken`, set `PresentedLogin` to the active alias snapshot and fall back to the canonical login when the alias is empty; set `CanonicalLogin` to the resolved canonical primary login, reusing the existing `signInLogin.alias` and `signInLogin.canonicalLogin` values without new resolution logic
+- In workspace authorization (`iauthnzimpl`), resolve subject roles against both `PresentedLogin` and `CanonicalLogin` (deduplicated, skipping the `CanonicalLogin` read when it is empty or equal to `PresentedLogin`) instead of `Login` alone
+- Keep the user principal's display Name and the n10n subject on the canonical primary login for stable internal identity; the alias-aware value is surfaced only through the token `Login` claim (the `PresentedLogin` field) consumed by the frontend
+- Both internal-identity consumers (display Name, n10n subject) fall back to `PresentedLogin` when `CanonicalLogin` is empty; this is a back-compat bridge for tokens issued before the deploy (which carry no `CanonicalLogin` claim and whose `Login`/`PresentedLogin` already holds the canonical login) and for the system principal, and it mirrors the empty-value guard used in role resolution; for newly issued tokens `CanonicalLogin` is always set, so the alias is never used as internal identity
+- Leave token refresh and enrich untouched: both round-trip the whole payload (enrich rewrites only `Roles`), so `PresentedLogin` and `CanonicalLogin` are preserved as an issue-time snapshot with no code change
+
+Out of scope:
+
+- Alias lifecycle management (set, update, clear) and the alias index, which are unchanged
+- Frontend work to consume the adjusted token field
+- API-token identity (`IsAPIToken`), which does not use `Login` for display
+
+References:
+
+- [principal token payload contract](../../../../../pkg/itokens-payloads/types.go)
+- [sign-in token issue](../../../../../pkg/registry/impl_issueprincipaltoken.go)
+- [sign-in login resolution helpers](../../../../../pkg/registry/impl_setloginalias.go)
+- [workspace authorization and subject role resolution](../../../../../pkg/iauthnzimpl/impl.go)
+- [token refresh and enrich preserve the payload](../../../../../pkg/sys/authnz/impl_enrichprincipaltoken.go)
+- [sign-in and token claim integration tests](../../../../../pkg/sys/it/impl_signupin_test.go)
+- [principal token contract specification](../../../../../uspecs/specs/prod/auth/arch-tokens.md)
+- [authentication sign-in specification](../../../../../uspecs/specs/prod/auth/arch-authn.md)
+
+## Functional design
+
+- [x] update: [auth/authn.feature](../../../../specs/prod/auth/authn.feature)
+  - update: "the issued principal token identifies login, alias, subject kind, and profileWSID" (sign-in by login outline) -> identifies login, canonical login, subject kind, and profileWSID
+  - update: "Principal token carries original login and alias after alias sign-in" scenario -> the token presents the active alias as the login and carries the original login as the canonical login
+  - update: "the new principalToken preserves login, alias, subject kind, and profileWSID from the input token" (refresh) -> preserves login, canonical login, subject kind, and profileWSID
+  - update: "Existing principal token keeps alias snapshot after alias changes" scenario -> the token retains the login and canonical login captured at issue time
+  - add: scenario "Principal token uses the active alias as login when signing in with the original login" asserting the issued token's login is the active alias and its canonical login is the original login
+
+## Technical design
+
+- [x] update: [auth/arch-tokens.md](../../../../specs/prod/auth/arch-tokens.md)
+  - rename: `[PrincipalPayload]` field `Alias` -> `CanonicalLogin`; redefine `Login` as the identifier the subject is known by (active alias snapshot at issue time, or the canonical login when no alias is set) and define `CanonicalLogin` as the canonical login resolved at issue time
+  - update: "Issue principal token" overview and the issue diagram so `Login` is set to the alias-or-canonical value and `CanonicalLogin` carries the canonical login snapshot
+  - update: "Refresh principal token" overview, the `[q.sys.RefreshPrincipalToken]` entry, the refresh diagram, and the refresh note to preserve `Login` and `CanonicalLogin` verbatim instead of the `Alias` snapshot
+
+- [x] update: [auth/arch.md](../../../../specs/prod/auth/arch.md)
+  - update: `[Principal Token]` shared-concept payload field list `Alias` -> `CanonicalLogin`
+  - update: "Manage tokens" overview wording from the alias snapshot to the captured `CanonicalLogin`
+
+- [x] update: [auth/arch-authn.md](../../../../specs/prod/auth/arch-authn.md)
+  - update: the `[q.registry.IssuePrincipalToken]` build step to set `Login` = active-alias snapshot with canonical fallback and `CanonicalLogin` = canonical login
+  - update: the "Sign in by login or by active alias" diagram `build PrincipalPayload(...)` to list `Login` (alias-or-canonical) and `CanonicalLogin`
+
+- [x] update: [auth/arch-authz.md](../../../../specs/prod/auth/arch-authz.md)
+  - update: the `[Subjects reader]` component and the `[Invite-granted]` role source to resolve subject roles by matching `[(cdoc.sys.Subject)]` rows against both `PrincipalPayload.Login` and `PrincipalPayload.CanonicalLogin`
+  - update: the Authenticate flow step that reads subjects to evaluate both fields in `RequestWSID`
+
+- [x] update: [auth/authn--td.md](../../../../specs/prod/auth/authn--td.md)
+  - update: the `[/q.registry.IssuePrincipalToken/]` entry and the alias sign-in scenario to snapshot `Login` (alias-or-canonical) and `CanonicalLogin`, deferring payload-field semantics to arch-tokens.md
+  - update: the "Principal token contract" scenarios (identity fields, refresh, alias-snapshot immutability) to reference `Login` and `CanonicalLogin`
+  - update: the Security cross-cutting bullet to list canonical login instead of alias
+
+## Construction
+
+### Tests
+
+- [x] update: [sys/it/impl_signupin_test.go](../../../../../pkg/sys/it/impl_signupin_test.go)
+  - update: `assertPrincipalTokenClaims` - rename its two value parameters from `(expectedLogin, expectedAlias)` to `(expectedPresentedLogin, expectedCanonicalLogin)` (their meaning flips from canonical-then-alias to presented-then-canonical); assert the Go field `payload.PresentedLogin` and the raw `Login` claim both equal the presented identifier, assert the raw `CanonicalLogin` claim equals the canonical login, and assert the legacy `Alias` claim key is absent
+  - update: all `assertPrincipalTokenClaims` call sites in `TestLoginAlias` (alias sign-in and refresh-snapshot) so the presented value is the active alias and the canonical value is the canonical primary login
+  - update: the existing `primaryToken` assertion (already signs in by the original login while an alias is active) so its presented value is the active alias and its canonical value is the original login; this site already covers the new `authn.feature` scenario, so no new case is added
+
+- [x] update: [iauthnzimpl/impl_test.go](../../../../../pkg/iauthnzimpl/impl_test.go)
+  - update: the `PrincipalPayload{Login: ...}` initializers field `Login` -> `PresentedLogin` so they compile under the rename
+
+- [x] update: [itokens-payloads/impl_test.go](../../../../../pkg/itokens-payloads/impl_test.go)
+  - update: the `PrincipalPayload{Login: ...}` initializers field `Login` -> `PresentedLogin` so they compile under the rename
+
+- [x] update: [processors/command/impl_test.go](../../../../../pkg/processors/command/impl_test.go)
+  - update: the `PrincipalPayload{Login: ...}` initializer field `Login` -> `PresentedLogin` so it compiles under the rename
+
+- [x] update: [processors/query/impl_test.go](../../../../../pkg/processors/query/impl_test.go)
+  - update: the `PrincipalPayload{Login: ...}` initializers field `Login` -> `PresentedLogin` so they compile under the rename
+
+- [x] update: [sys/it/impl_childworkspace_test.go](../../../../../pkg/sys/it/impl_childworkspace_test.go)
+  - update: the `PrincipalPayload{Login: ...}` initializer field `Login` -> `PresentedLogin` so it compiles under the rename
+
+- [x] update: [sys/it/impl_sqlquery_test.go](../../../../../pkg/sys/it/impl_sqlquery_test.go)
+  - update: the `PrincipalPayload{Login: ...}` initializer field `Login` -> `PresentedLogin` so it compiles under the rename
+
+- [x] update: [sys/it/impl_qpv2_test.go](../../../../../pkg/sys/it/impl_qpv2_test.go)
+  - update: the `PrincipalPayload{Login: ...}` initializers field `Login` -> `PresentedLogin` so they compile under the rename
+
+- [x] update: [sys/it/impl_workspace_test.go](../../../../../pkg/sys/it/impl_workspace_test.go)
+  - update: the `PrincipalPayload{Login: ...}` initializer field `Login` -> `PresentedLogin` so it compiles under the rename
+
+### Implementation
+
+- [x] update: [itokens-payloads/types.go](../../../../../pkg/itokens-payloads/types.go)
+  - rename: the `PrincipalPayload.Login` field to `PresentedLogin` with a `json:"Login"` struct tag (preserves the `Login` claim) and rename the `Alias` field to `CanonicalLogin` (no tag; the Go name equals the new claim key, so the JWT claim key changes from `Alias` to `CanonicalLogin`)
+  - add: doc comments stating `PresentedLogin` is the frontend-facing presented identity (active alias snapshot, or canonical login when no alias; not to be used for identity, authorization, quotas, or metrics) and `CanonicalLogin` is the immutable internal identity, plus a one-line note explaining why `PresentedLogin` carries a `json:"Login"` tag
+- [x] update: [itokens-payloads/consts.go](../../../../../pkg/itokens-payloads/consts.go)
+  - update: the `systemPrincipalPayload` initializer field `Login` -> `PresentedLogin` (compile-breaker from the rename); `CanonicalLogin` is left unset for the system principal
+- [x] update: [registry/impl_issueprincipaltoken.go](../../../../../pkg/registry/impl_issueprincipaltoken.go)
+  - update: the `PrincipalPayload` build so `PresentedLogin` is `loginForSignIn.alias` when non-empty and falls back to `loginForSignIn.canonicalLogin`, and `CanonicalLogin` is `loginForSignIn.canonicalLogin`
+- [x] update: [iauthnzimpl/impl.go](../../../../../pkg/iauthnzimpl/impl.go)
+  - update: `Authenticate` to read subject roles for both `principalPayload.PresentedLogin` and `principalPayload.CanonicalLogin`, deduplicating the appended role principals and skipping the `CanonicalLogin` read when it is empty or equal to `PresentedLogin`
+  - update: the user principal display `Name` (`loginName`) to come from `principalPayload.CanonicalLogin`, falling back to `PresentedLogin` when `CanonicalLogin` is empty, so internal identity stays canonical for new tokens while legacy tokens and the system principal still resolve a name
+- [x] update: [processors/n10n/impl_subscribeandwatch.go](../../../../../pkg/processors/n10n/impl_subscribeandwatch.go)
+  - update: `subjectLogin` to come from `principalPayload.CanonicalLogin`, falling back to `PresentedLogin` when `CanonicalLogin` is empty, so the notification subject identity stays canonical for new tokens and remains stable for legacy tokens
+- [x] update: [vit/impl.go](../../../../../pkg/vit/impl.go)
+  - update: the `RefreshTokens` `PrincipalPayload` initializer to set `PresentedLogin` = `prn.Name` and `CanonicalLogin` = `prn.Name`, so VIT-issued tokens keep canonical internal identity for the display `Name` and n10n subject

--- a/uspecs/changes/archive/2606/2606151848-token-login-reflects-alias/issue-AIR-4270.md
+++ b/uspecs/changes/archive/2606/2606151848-token-login-reflects-alias/issue-AIR-4270.md
@@ -1,0 +1,26 @@
+# voedger: principal token Login reflects alias used at sign-in
+
+- URL: https://untill.atlassian.net/browse/AIR-4270
+- ID: AIR-4270
+- State: in-progress
+- Author: Unknown user name (712020:89894cda-e18f-4f7e-989d-8540111610e5)
+- Labels: none
+- Parent: AIR-3968 (Grandhotel Bad Pyrmont: Change email address)
+- Assignees: Unknown user name (712020:89894cda-e18f-4f7e-989d-8540111610e5)
+
+## Why
+
+The frontend displays the Login value taken from the principal token. When a user signs in with their alias, the token currently carries the canonical primary login, so the UI shows an identifier different from the one the user just typed. This confuses the user, who expects to see the alias they signed in with.
+
+Carrying the alias (when set) in the token's Login field lets the frontend display the identifier the user recognizes, while the canonical primary login remains available separately for backend identity needs such as subject-based role resolution.
+
+## What
+
+Change the principal token identity contract so the token's Login reflects the identifier the user is known by, and the canonical primary login is carried separately.
+
+- The principal token's Login field carries the user's active alias when one exists, and falls back to the canonical primary login when no alias is set
+- The canonical primary login is always carried in a separate field (CanonicalLogin), replacing the current Alias field in the token payload
+- This applies on both sign-in paths (sign-in by primary login and sign-in by alias) and is preserved across token refresh as a snapshot taken at issue time
+- During workspace authorization both fields, Login and CanonicalLogin, are evaluated for subject-based role resolution, so a user's workspace roles are matched whether the subject was registered under the alias or the canonical primary login
+
+Behavior when no alias is set is unchanged from the caller's perspective: Login equals the primary login.

--- a/uspecs/changes/archive/2606/2606151848-token-login-reflects-alias/issue-AIR-4270.md
+++ b/uspecs/changes/archive/2606/2606151848-token-login-reflects-alias/issue-AIR-4270.md
@@ -3,10 +3,7 @@
 - URL: https://untill.atlassian.net/browse/AIR-4270
 - ID: AIR-4270
 - State: in-progress
-- Author: Unknown user name (712020:89894cda-e18f-4f7e-989d-8540111610e5)
 - Labels: none
-- Parent: AIR-3968 (Grandhotel Bad Pyrmont: Change email address)
-- Assignees: Unknown user name (712020:89894cda-e18f-4f7e-989d-8540111610e5)
 
 ## Why
 

--- a/uspecs/specs/prod/auth/arch-authn.md
+++ b/uspecs/specs/prod/auth/arch-authn.md
@@ -70,7 +70,7 @@ Registry records and indexes
 ### Sign-in and lifecycle queries/commands
 
 - `[q.registry.IssuePrincipalToken]`
-  - Resolves the sign-in identifier against `[(registry.Login)]` directly, then against `[(registry.LoginAlias)]` if the direct lookup misses; verifies the password hash, enforces the `Profile workspace readiness gate`, builds `PrincipalPayload` (with the alias snapshot captured at issue time) and delegates token issuance to [Token management](./arch-tokens.md). Returns the same `errLoginOrPasswordIsIncorrect` for missing login, deactivated login, missing alias, and wrong password to prevent enumeration.
+  - Resolves the sign-in identifier against `[(registry.Login)]` directly, then against `[(registry.LoginAlias)]` if the direct lookup misses; verifies the password hash, enforces the `Profile workspace readiness gate`, builds `PrincipalPayload` (setting `Login` to the active-alias snapshot with canonical fallback and `CanonicalLogin` to the canonical login, both captured at issue time) and delegates token issuance to [Token management](./arch-tokens.md). Returns the same `errLoginOrPasswordIsIncorrect` for missing login, deactivated login, missing alias, and wrong password to prevent enumeration.
   - impl: [pkg/registry/impl_issueprincipaltoken.go#provideIssuePrincipalTokenExec](../../../../pkg/registry/impl_issueprincipaltoken.go)
 
 - `[c.registry.CreateLogin]`, `[c.registry.CreateEmailLogin]`
@@ -124,7 +124,7 @@ Registry records and indexes
        -> on miss: [(registry.LoginAlias)] -> [(registry.Login)]
        -> checkPasswordHash
        -> Profile workspace readiness gate: if ProfileWSID == 0 or WSError != "" return error result
-       -> build PrincipalPayload(Login, Alias, SubjectKind, ProfileWSID, GlobalRoles)
+       -> build PrincipalPayload(Login=alias snapshot or canonical login, CanonicalLogin, SubjectKind, ProfileWSID, GlobalRoles)
        -> [Token management].IssueToken (see arch-tokens.md)
   -> @Client: principalToken, profileWSID
 ```

--- a/uspecs/specs/prod/auth/arch-authz.md
+++ b/uspecs/specs/prod/auth/arch-authz.md
@@ -72,7 +72,7 @@ Role sources
   - impl: [pkg/iauthnzimpl/impl.go#Authenticate](../../../../pkg/iauthnzimpl/impl.go)
 
 - `[Subjects reader]`
-  - Reads `[(cdoc.sys.Subject)]` from `RequestWSID` for the resolved login (or `sys.Guest` when anonymous) through the injected `subjectRolesGetter`, and emits one `Principal{Kind: Role, WSID: RequestWSID, QName: role}` per matched role.
+  - Reads `[(cdoc.sys.Subject)]` from `RequestWSID` for the resolved subject (or `sys.Guest` when anonymous) through the injected `subjectRolesGetter`, matching rows against both `PrincipalPayload.Login` and `PrincipalPayload.CanonicalLogin` so an invite under either identifier resolves, and emits one `Principal{Kind: Role, WSID: RequestWSID, QName: role}` per matched role.
   - impl: [pkg/iauthnzimpl/impl.go#rolesFromSubjects](../../../../pkg/iauthnzimpl/impl.go)
 
 - `[Workspace role deriver]`
@@ -89,7 +89,7 @@ Four sources by origin contribute to a request's principal set; each is enumerat
 
 - `[Invite-granted]`
   - Origin: `[[Workspace membership]]` writes `[(cdoc.sys.Subject)]` rows in the inviting workspace as part of the join flow; see [arch-membership.md](./arch-membership.md).
-  - Composition: `[Subjects reader]` reads `[(cdoc.sys.Subject)]` rows in `RequestWSID` matching the resolved login and emits one `Principal{Kind: Role, WSID: RequestWSID, QName: role}` per matched role.
+  - Composition: `[Subjects reader]` reads `[(cdoc.sys.Subject)]` rows in `RequestWSID` matching either `PrincipalPayload.Login` or `PrincipalPayload.CanonicalLogin` and emits one `Principal{Kind: Role, WSID: RequestWSID, QName: role}` per matched role.
 
 - `[Token-carried]`
   - Origin: `[[Authentication]]` snapshots roles into `PrincipalPayload` at sign-in (per-app `Roles` from the registry login record) and `[c.registry.UpdateGlobalRoles]` updates the `GlobalRoles` field consumed at the next sign-in; see [arch-authn.md](./arch-authn.md). A second runtime write path is `[q.sys.EnrichPrincipalToken]`, which folds the request's composed `Principal{Kind: Role}` set into `PrincipalPayload.Roles` and re-issues the token so those roles travel into workspaces where they would not otherwise be composed; the token-lifecycle detail lives in [arch-tokens.md](./arch-tokens.md).
@@ -123,7 +123,7 @@ VSQL role inheritance (e.g., `ProfileOwner -> WorkspaceOwner`) is expanded later
             emit [Token-carried] PrincipalPayload.Roles filtered to RequestWSID
             return (principals, NullWSID)
        -> emit [Token-carried] PrincipalPayload.GlobalRoles in RequestWSID
-       -> emit [Invite-granted] via [Subjects reader] for PrincipalPayload.Login in RequestWSID
+       -> emit [Invite-granted] via [Subjects reader] for PrincipalPayload.Login and PrincipalPayload.CanonicalLogin in RequestWSID
        -> profileWSID = PrincipalPayload.ProfileWSID
        -> if Role(System) already in principals: return
        -> if profileWSID == NullWSID: emit Role(System), return

--- a/uspecs/specs/prod/auth/arch-tokens.md
+++ b/uspecs/specs/prod/auth/arch-tokens.md
@@ -15,10 +15,10 @@ Roles:
 ## Scenarios overview
 
 - **`Issue principal token`**
-  - At the end of sign-in (see [arch-authn.md](./arch-authn.md#sign-in-by-login-or-by-active-alias)) the authentication subsystem builds `PrincipalPayload` and calls `[ITokens].IssueToken(appQName, ttl, &payload)` to mint a `[Principal Token]`. The `Alias` field captures the active alias snapshot at issue time and is immune to any subsequent change to `[(registry.Login)]` or `[(registry.LoginAlias)]`.
+  - At the end of sign-in (see [arch-authn.md](./arch-authn.md#sign-in-by-login-or-by-active-alias)) the authentication subsystem builds `PrincipalPayload` and calls `[ITokens].IssueToken(appQName, ttl, &payload)` to mint a `[Principal Token]`. The `Login` field carries the active alias snapshot at issue time, or the canonical login when no alias is set; the `CanonicalLogin` field always carries the canonical login. Both are captured at issue time and are immune to any subsequent change to `[(registry.Login)]` or `[(registry.LoginAlias)]`.
 
 - **`Refresh principal token`**
-  - `@Client` calls `[q.sys.RefreshPrincipalToken]` with the current `[Principal Token]`; the payload is decoded, the same identity (including the captured `Alias`) is re-encoded with the same TTL/AppQName by `[ITokens].IssueToken`, and the new token is returned. Refresh never re-resolves the login or alias and never updates the alias snapshot.
+  - `@Client` calls `[q.sys.RefreshPrincipalToken]` with the current `[Principal Token]`; the payload is decoded, the same identity (including the captured `Login` and `CanonicalLogin`) is re-encoded with the same TTL/AppQName by `[ITokens].IssueToken`, and the new token is returned. Refresh never re-resolves the login or alias and never updates the captured values.
 
 - **`Enrich principal token`**
   - `@Client` (basic auth, `WorkspaceOwner`) calls `[q.sys.EnrichPrincipalToken]` with the current `[Principal Token]`; the payload is decoded, every runtime-composed `Principal{Kind: Role}` for the request is folded into `PrincipalPayload.Roles` (deduplicated by `RoleType{WSID, QName}`), and a fresh `[Principal Token]` is minted by `[IAppTokens].IssueToken` with `DefaultPrincipalTokenExpiration`. Unlike refresh, enrich rewrites the `Roles` set; the other identity fields are preserved.
@@ -58,7 +58,7 @@ Payload contract
 ### Token endpoints
 
 - `[q.sys.RefreshPrincipalToken]`
-  - Reads the bearer token from request state via `storages.GetPrincipalTokenFromState`, decodes `PrincipalPayload` through `payloads.GetPayloadRegistry`, and re-issues a token for the same AppQName, duration, and payload. The decoded `Alias` is preserved verbatim, so the snapshot taken at the original issue time survives the refresh; alias changes performed in the registry between issue and refresh have no effect on the refreshed token.
+  - Reads the bearer token from request state via `storages.GetPrincipalTokenFromState`, decodes `PrincipalPayload` through `payloads.GetPayloadRegistry`, and re-issues a token for the same AppQName, duration, and payload. The decoded `Login` and `CanonicalLogin` are preserved verbatim, so the snapshot taken at the original issue time survives the refresh; alias changes performed in the registry between issue and refresh have no effect on the refreshed token.
   - impl: [pkg/sys/authnz/impl_refreshprincipaltoken.go#provideRefreshPrincipalTokenExec](../../../../pkg/sys/authnz/impl_refreshprincipaltoken.go)
 
 - `[q.sys.EnrichPrincipalToken]`
@@ -80,8 +80,8 @@ Payload contract
 
 - `[PrincipalPayload]`
   - Identity payload carried by `[Principal Token]`:
-    - `Login` - canonical login resolved at issue time
-    - `Alias` - snapshot of the active alias at issue time; never re-read on refresh
+    - `Login` - identifier the subject is known by: the active alias snapshot at issue time, or the canonical login when no alias is set; never re-read on refresh
+    - `CanonicalLogin` - canonical login resolved at issue time; never re-read on refresh
     - `SubjectKind` - `User` or `Device`
     - `ProfileWSID` - profile workspace of the subject (`NullWSID` for system-only tokens)
     - `Roles []{WSID, QName}` - workspace-scoped roles emitted on every request; for `IsAPIToken=true` these are the only persisted-role source (alongside the implicit `AuthenticatedUser`)
@@ -98,7 +98,7 @@ Payload contract
 
 ```text
 [q.registry.IssuePrincipalToken] (see arch-authn.md)
-  -> build PrincipalPayload{Login, Alias=loginForSignIn.alias (snapshot), SubjectKind, ProfileWSID, GlobalRoles}
+  -> build PrincipalPayload{Login=alias snapshot or canonical login, CanonicalLogin, SubjectKind, ProfileWSID, GlobalRoles}
   -> [ITokens].IssueToken(appQName, ttl, &payload)
   -> @Client: principalToken, profileWSID
 ```
@@ -111,10 +111,10 @@ Payload contract
        -> storages.GetPrincipalTokenFromState(state) -> current token
        -> payloads.GetPayloadRegistry([ITokens], token, &payload) -> decode + appQName + ttl
        -> [ITokens].IssueToken(appQName, ttl, &payload)
-  -> @Client: principalToken (new), Alias unchanged from original issue
+  -> @Client: principalToken (new), Login and CanonicalLogin unchanged from original issue
 ```
 
-The Alias field is taken verbatim from the decoded payload and is not re-resolved against `[(registry.Login)]` or `[(registry.LoginAlias)]`. A login whose alias was set, replaced, or cleared after the original issue continues to refresh with the snapshotted alias until the next sign-in. To pick up a new alias the caller must sign in again rather than refresh.
+The `Login` and `CanonicalLogin` fields are taken verbatim from the decoded payload and are not re-resolved against `[(registry.Login)]` or `[(registry.LoginAlias)]`. A login whose alias was set, replaced, or cleared after the original issue continues to refresh with the snapshotted `Login` until the next sign-in. To pick up a new alias the caller must sign in again rather than refresh.
 
 ### Enrich principal token
 

--- a/uspecs/specs/prod/auth/arch.md
+++ b/uspecs/specs/prod/auth/arch.md
@@ -21,7 +21,7 @@ Roles:
   - Request processing composes a principal set from four origin-perspective sources — invite-granted roles (`[(cdoc.sys.Subject)]` rows written by `[[Workspace membership]]`), token-carried roles (`PrincipalPayload.Roles` and `GlobalRoles` snapshotted by `[[Authentication]]`), request-context roles (derived at composition time from request state), and anonymous-grants (when no token is presented) — and evaluates ACL rules against it.
 
 - **`Manage tokens`**
-  - Principal tokens are issued, refreshed, and validated; refresh preserves the identity payload including the alias snapshot captured at issue time.
+  - Principal tokens are issued, refreshed, and validated; refresh preserves the identity payload including the `Login` and `CanonicalLogin` captured at issue time.
 
 - **`Manage membership`**
   - Invite lifecycle creates subjects doc and joined-workspace records, updates roles, and removes members.
@@ -84,7 +84,7 @@ Shared concepts
   - impl: [pkg/sys/invite/impl_applyinviteevents.go](../../../../pkg/sys/invite/impl_applyinviteevents.go)
 
 - `[Principal Token]`
-  - Bearer token carrying `PrincipalPayload(Login, Alias, SubjectKind, ProfileWSID, Roles, GlobalRoles, IsAPIToken)`. Produced by `[[Authentication]]` and `[[Token management]]`, consumed by `[[Authorization]]` on every request.
+  - Bearer token carrying `PrincipalPayload(Login, CanonicalLogin, SubjectKind, ProfileWSID, Roles, GlobalRoles, IsAPIToken)`. Produced by `[[Authentication]]` and `[[Token management]]`, consumed by `[[Authorization]]` on every request.
   - decl: [pkg/itokens-payloads/types.go#PrincipalPayload](../../../../pkg/itokens-payloads/types.go)
 
 - `[Auth boundary]`

--- a/uspecs/specs/prod/auth/authn--td.md
+++ b/uspecs/specs/prod/auth/authn--td.md
@@ -170,7 +170,7 @@ State and workspace lifecycle
   - impl: [pkg/registry/impl_setloginalias.go#applySetLoginAlias](../../../../pkg/registry/impl_setloginalias.go)
 
 - `[/q.registry.IssuePrincipalToken/]`
-  - Resolves sign-in by primary login or active alias, validates password and profile readiness, applies TTL policy, and issues principal tokens. On the alias path, it reads `[(registry.LoginAlias)]`, fetches the source `[(registry.Login)]` with `q.sys.GetCDoc`, validates `Login.Alias` against the submitted identifier, and snapshots login and alias into the token.
+  - Resolves sign-in by primary login or active alias, validates password and profile readiness, applies TTL policy, and issues principal tokens. On the alias path, it reads `[(registry.LoginAlias)]`, fetches the source `[(registry.Login)]` with `q.sys.GetCDoc`, validates `Login.Alias` against the submitted identifier, and snapshots the presented identifier into `Login` (the active alias, or the canonical login when none is set) and the canonical login into `CanonicalLogin`; payload-field semantics are owned by [arch-tokens.md](./arch-tokens.md).
   - decl: [pkg/registry/appws.vsql#IssuePrincipalToken](../../../../pkg/registry/appws.vsql)
   - impl: [pkg/registry/impl_issueprincipaltoken.go#provideIssuePrincipalTokenExec](../../../../pkg/registry/impl_issueprincipaltoken.go)
 
@@ -200,7 +200,7 @@ State and workspace lifecycle
   - Token primitives and `PrincipalPayload` are owned by [arch-tokens.md](./arch-tokens.md#token-primitives); referenced here as the layer that issues and validates the tokens carried by the authn HTTP flows.
 
 - `[/q.sys.RefreshPrincipalToken/]`
-  - Issues a replacement principal token from the existing principal token payload and duration, preserving identity fields including alias.
+  - Issues a replacement principal token from the existing principal token payload and duration, preserving identity fields including `Login` and `CanonicalLogin`.
   - decl: [pkg/sys/sys.vsql#RefreshPrincipalToken](../../../../pkg/sys/sys.vsql)
   - impl: [pkg/sys/authnz/impl_refreshprincipaltoken.go#provideRefreshPrincipalTokenExec](../../../../pkg/sys/authnz/impl_refreshprincipaltoken.go)
 
@@ -414,7 +414,7 @@ State and workspace lifecycle
   -> [(registry.LoginAlias)]: active alias hit
   -> [/q.sys.GetCDoc/]: read source [(registry.Login)] in SourceAppWSID
   -> [(registry.Login)]: Alias equals submitted alias; password hash matches and profileWSID is non-zero
-  -> [Token service]: issue principal token with Login and Alias
+  -> [Token service]: issue principal token with Login (active alias) and CanonicalLogin (canonical login)
   -> @Client: principalToken, expiresInSeconds, profileWSID
 ```
 
@@ -469,7 +469,7 @@ State and workspace lifecycle
   -> [Auth login handler]
   -> [/q.registry.IssuePrincipalToken/]
   -> [(registry.Login)]: login, alias, subject kind, profileWSID
-  -> [Token service]: PrincipalPayload(Login, Alias, SubjectKind, ProfileWSID)
+  -> [Token service]: PrincipalPayload(Login, CanonicalLogin, SubjectKind, ProfileWSID)
   -> @Client: principalToken
 ```
 
@@ -500,7 +500,7 @@ State and workspace lifecycle
   -> [API v2 auth routes]
   -> [Auth refresh handler]
   -> [/q.sys.RefreshPrincipalToken/]
-  -> [Token service]: validate existing token and issue replacement preserving Login, Alias, SubjectKind, ProfileWSID from the input token
+  -> [Token service]: validate existing token and issue replacement preserving Login, CanonicalLogin, SubjectKind, ProfileWSID from the input token
   -> [Auth refresh handler]
   -> @Client: new principalToken, expiresInSeconds, profileWSID
 ```
@@ -509,10 +509,10 @@ State and workspace lifecycle
 
 ```text
 @Client
-  -> [Token service]: principal token already issued with Alias = j.smith
+  -> [Token service]: principal token already issued with Login = j.smith, CanonicalLogin = jsmith
   -> @System: update or clear login alias
   -> [Token service]: existing token remains valid until normal expiration
-  -> @Client: existing token payload still carries Alias = j.smith
+  -> @Client: existing token payload still carries Login = j.smith, CanonicalLogin = jsmith
 ```
 
 ### Password lifecycle
@@ -635,7 +635,7 @@ error-handling rules from [auth architecture](./arch.md).
 
 - Every Component in `Public API endpoints` and `Authn request handlers` treats passwords, bearer tokens, verification tokens, and verified value tokens as request secrets.
 - Every Component in `Registry operations` stores password evidence only through `[(registry.Login)]` password hashes and never returns plaintext passwords except generated device credentials at creation time.
-- Every `[Token service]` principal token issue includes the authn identity fields required by this feature: login, alias, subject kind, and profile workspace ID.
+- Every `[Token service]` principal token issue includes the authn identity fields required by this feature: login, canonical login, subject kind, and profile workspace ID.
 
 ### Error handling and resilience
 

--- a/uspecs/specs/prod/auth/authn.feature
+++ b/uspecs/specs/prod/auth/authn.feature
@@ -151,7 +151,7 @@ Feature: Authentication
       Given "<subject>" login exists
       And the profile workspace for "<subject>" is ready
       When Client signs in with login and password
-      Then the issued principal token identifies login, alias, subject kind, and profileWSID
+      Then the issued principal token identifies login, canonical login, subject kind, and profileWSID
 
       Examples:
         | subject |
@@ -173,19 +173,25 @@ Feature: Authentication
       Given Client has a valid principal token
       When Client refreshes the principal token
       Then the response contains a new principalToken
-      And the new principalToken preserves login, alias, subject kind, and profileWSID from the input token
+      And the new principalToken preserves login, canonical login, subject kind, and profileWSID from the input token
 
-    Scenario: Principal token carries original login and alias after alias sign-in
+    Scenario: Principal token uses the active alias as login after alias sign-in
       Given a user login exists with an active login alias
       And the profile workspace for the user is ready
       When Client signs in with alias and password
-      Then the issued principal token identifies original login, alias, subject kind, and profileWSID
+      Then the issued principal token's login is the active alias and its canonical login is the original login
 
-    Scenario: Existing principal token keeps alias snapshot after alias changes
+    Scenario: Principal token uses the active alias as login when signing in with the original login
+      Given a user login exists with an active login alias
+      And the profile workspace for the user is ready
+      When Client signs in with original login and password
+      Then the issued principal token's login is the active alias and its canonical login is the original login
+
+    Scenario: Existing principal token retains login and canonical login after alias changes
       Given Client has a valid principal token issued while a login alias is active
       When System updates or clears that login alias
       Then the existing principal token remains valid until normal expiration
-      And the existing principal token retains the alias snapshot from issue time
+      And the existing principal token retains the login and canonical login captured at issue time
 
   Rule: Password lifecycle
 


### PR DESCRIPTION
```yaml
change_id: 2606151510-token-login-reflects-alias
type: feat
issue_url: https://untill.atlassian.net/browse/AIR-4270
domains: [prod]
scope: [auth]
breaking: true
```
## Why

The frontend shows the login value carried by the principal token, but on alias sign-in that value is the canonical primary login rather than the alias the user just typed, which confuses users mid email-change. Presenting the alias the user signed in with, while keeping the canonical primary login available for backend identity, removes that confusion.

## What

Adjust the authentication token identity contract so a signed-in user is presented with the identifier they recognize:

- After sign-in, the principal token presents the identifier the user signed in by: their active alias when one is set, otherwise their primary login
- The canonical primary login remains available in the token alongside the presented identifier, so backend identity needs are unaffected
- The presented identifier and the canonical login are captured at token issue time and preserved unchanged when the token is refreshed
- Workspace authorization resolves a user's roles using both the presented identifier and the canonical login, so role assignment matches regardless of which identifier a subject was registered under
- When the user has no alias, the token and downstream behavior are unchanged from today

## How

Decisions:

- Rename the `PrincipalPayload.Login` Go field to `PresentedLogin` and keep the wire/JWT claim key as `Login` via a `json:"Login"` struct tag; this preserves the frontend claim contract while turning every existing backend `payload.Login` read into a compile error that must be revisited (the intended guard against reusing the presented value as internal identity)
- Replace the `Alias` field with `CanonicalLogin` in `PrincipalPayload`; its Go field name equals the claim key, so no tag is needed and the JWT claim key changes from `Alias` to `CanonicalLogin`
- In `q.registry.IssuePrincipalToken`, set `PresentedLogin` to the active alias snapshot and fall back to the canonical login when the alias is empty; set `CanonicalLogin` to the resolved canonical primary login, reusing the existing `signInLogin.alias` and `signInLogin.canonicalLogin` values without new resolution logic
- In workspace authorization (`iauthnzimpl`), resolve subject roles against both `PresentedLogin` and `CanonicalLogin` (deduplicated, skipping the `CanonicalLogin` read when it is empty or equal to `PresentedLogin`) instead of `Login` alone
- Keep the user principal's display Name and the n10n subject on the canonical primary login for stable internal identity; the alias-aware value is surfaced only through the token `Login` claim (the `PresentedLogin` field) consumed by the frontend
- Both internal-identity consumers (display Name, n10n subject) fall back to `PresentedLogin` when `CanonicalLogin` is empty; this is a back-compat bridge for tokens issued before the deploy (which carry no `CanonicalLogin` claim and whose `Login`/`PresentedLogin` already holds the canonical login) and for the system principal, and it mirrors the empty-value guard used in role resolution; for newly issued tokens `CanonicalLogin` is always set, so the alias is never used as internal identity
- Leave token refresh and enrich untouched: both round-trip the whole payload (enrich rewrites only `Roles`), so `PresentedLogin` and `CanonicalLogin` are preserved as an issue-time snapshot with no code change

Out of scope:

- Alias lifecycle management (set, update, clear) and the alias index, which are unchanged
- Frontend work to consume the adjusted token field
- API-token identity (`IsAPIToken`), which does not use `Login` for display



---
Content omitted. See change.md for full details.
