### PR TITLE
refactor(auth): Remove unused RecordID return from getActiveLoginAlias [AIR-4260]

### DIFF
--- a/pkg/registry/impl_setloginalias.go
+++ b/pkg/registry/impl_setloginalias.go
@@ -154,7 +154,7 @@ func execCmdPutLoginAliasIndex(args istructs.ExecCommandArgs) error {
 		return err
 	}
 
-	existingAlias, _, err := getLoginAlias(args.State, args.WSID, appName, alias)
+	existingAlias, err := getLoginAlias(args.State, args.WSID, appName, alias)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func execCmdDeactivateLoginAliasIndex(args istructs.ExecCommandArgs) error {
 		return err
 	}
 
-	loginAlias, _, err := getActiveLoginAlias(args.State, args.WSID, appName, alias)
+	loginAlias, err := getActiveLoginAlias(args.State, args.WSID, appName, alias)
 	if err != nil || loginAlias == nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func assertIdentifierAvailable(st istructs.IState, appName, identifier string, t
 		return coreutils.NewHTTPErrorf(http.StatusConflict, "sign-in identifier already exists")
 	}
 
-	loginAlias, _, err := getActiveLoginAlias(st, targetAppWSID, appName, identifier)
+	loginAlias, err := getActiveLoginAlias(st, targetAppWSID, appName, identifier)
 	if err != nil || loginAlias == nil {
 		return err
 	}
@@ -264,36 +264,36 @@ func assertIdentifierAvailable(st istructs.IState, appName, identifier string, t
 	return coreutils.NewHTTPErrorf(http.StatusConflict, "sign-in identifier already exists")
 }
 
-func getActiveLoginAlias(st istructs.IState, wsid istructs.WSID, appName, alias string) (istructs.IStateValue, istructs.RecordID, error) {
-	loginAlias, recordID, err := getLoginAlias(st, wsid, appName, alias)
+func getActiveLoginAlias(st istructs.IState, wsid istructs.WSID, appName, alias string) (istructs.IStateValue, error) {
+	loginAlias, err := getLoginAlias(st, wsid, appName, alias)
 	if err != nil || loginAlias == nil {
-		return nil, recordID, err
+		return nil, err
 	}
 	if !loginAlias.AsBool(appdef.SystemField_IsActive) {
-		return nil, istructs.NullRecordID, nil
+		return nil, nil
 	}
-	return loginAlias, recordID, nil
+	return loginAlias, nil
 }
 
-func getLoginAlias(st istructs.IState, wsid istructs.WSID, appName, alias string) (istructs.IStateValue, istructs.RecordID, error) {
+func getLoginAlias(st istructs.IState, wsid istructs.WSID, appName, alias string) (istructs.IStateValue, error) {
 	recordID, err := uniques.GetRecordIDByUniqueCombination(wsid, QNameCDocLoginAlias, st.AppStructs(), map[string]interface{}{
 		field_AppName: appName,
 		field_Alias:   alias,
 	})
 	if err != nil || recordID == istructs.NullRecordID {
-		return nil, recordID, err
+		return nil, err
 	}
 
 	kb, err := st.KeyBuilder(sys.Storage_Record, QNameCDocLoginAlias)
 	if err != nil {
-		return nil, istructs.NullRecordID, err
+		return nil, err
 	}
 	kb.PutRecordID(sys.Storage_Record_Field_ID, recordID)
 	loginAlias, err := st.MustExist(kb)
 	if err != nil {
-		return nil, istructs.NullRecordID, err
+		return nil, err
 	}
-	return loginAlias, recordID, nil
+	return loginAlias, nil
 }
 
 func callRegistryFunc(fed federationCaller, tokens itokens.ITokens, appQName appdef.AppQName, wsid istructs.WSID, resource string, body string, optFuncs ...httpu.ReqOptFunc) (*federation.FuncResponse, error) {
@@ -341,7 +341,7 @@ func loginFromPrimaryCDoc(login string, cdocLogin istructs.IStateValue) signInLo
 }
 
 func resolveAliasSignInLogin(submittedLogin, appName string, st istructs.IState, wsid istructs.WSID, tokens itokens.ITokens, fed federationCaller) (signInLogin, bool, error) {
-	loginAlias, _, err := getActiveLoginAlias(st, wsid, appName, submittedLogin)
+	loginAlias, err := getActiveLoginAlias(st, wsid, appName, submittedLogin)
 	if err != nil || loginAlias == nil {
 		return signInLogin{}, false, err
 	}

--- a/uspecs/changes/archive/2606/2606181505-remove-unused-alias-recordid/change.md
+++ b/uspecs/changes/archive/2606/2606181505-remove-unused-alias-recordid/change.md
@@ -1,0 +1,35 @@
+---
+change_id: 2606181452-remove-unused-alias-recordid
+type: refactor
+issue_url: https://untill.atlassian.net/browse/AIR-4260
+domains: [prod]
+scope: [auth]
+---
+
+# Change request: Remove unused RecordID return from getActiveLoginAlias
+
+Refs:
+
+- [AIR-4260: RecordID result of getActiveLoginAlias is never used](./issue-AIR-4260.md)
+
+## Why
+
+The `getActiveLoginAlias` helper in the registry login-alias code returns a `RecordID` that every caller discards. The dead return value adds noise to the signature and invites confusion about whether the id is meant to be consumed.
+
+## What
+
+Simplify the registry login-alias lookup helper without changing any externally observable behavior:
+
+- Drop the unused `RecordID` from the return signatures of the internal `getActiveLoginAlias` and `getLoginAlias` helpers, leaving the `IStateValue` and `error` they actually provide
+- Adjust the call sites in `pkg/registry` so they no longer discard a `RecordID` placeholder
+- Preserve all current sign-in, alias deactivation, and identifier-availability behavior: alias resolution, ownership checks, and record updates continue to operate through the returned `IStateValue` exactly as before
+
+## Construction
+
+- [x] update: [registry/impl_setloginalias.go](../../../../../pkg/registry/impl_setloginalias.go)
+  - remove: `RecordID` from the return signature of `getActiveLoginAlias`, leaving `(istructs.IStateValue, error)`; drop the now-redundant `NullRecordID` bookkeeping in the inactive-alias branch
+  - remove: `RecordID` from the return signature of `getLoginAlias`, leaving `(istructs.IStateValue, error)`; keep `recordID` as a local since it is still needed to build the record key
+  - update: call site in `execCmdPutLoginAliasIndex` to drop the discarded `RecordID` placeholder
+  - update: call site in `execCmdDeactivateLoginAliasIndex` to drop the discarded `RecordID` placeholder
+  - update: call site in `assertIdentifierAvailable` to drop the discarded `RecordID` placeholder
+  - update: call site in `resolveAliasSignInLogin` to drop the discarded `RecordID` placeholder

--- a/uspecs/changes/archive/2606/2606181505-remove-unused-alias-recordid/issue-AIR-4260.md
+++ b/uspecs/changes/archive/2606/2606181505-remove-unused-alias-recordid/issue-AIR-4260.md
@@ -1,0 +1,11 @@
+# RecordID result of getActiveLoginAlias is never used
+
+- URL: https://untill.atlassian.net/browse/AIR-4260
+- ID: AIR-4260
+- State: in-progress
+
+## Description
+
+## Why
+
+RecordID result of  getActiveLoginAlias  is never used What investigate whether it must be used or removed


### PR DESCRIPTION
```yaml
change_id: 2606181452-remove-unused-alias-recordid
type: refactor
issue_url: https://untill.atlassian.net/browse/AIR-4260
domains: [prod]
scope: [auth]
```
## Why

The `getActiveLoginAlias` helper in the registry login-alias code returns a `RecordID` that every caller discards. The dead return value adds noise to the signature and invites confusion about whether the id is meant to be consumed.

## What

Simplify the registry login-alias lookup helper without changing any externally observable behavior:

- Drop the unused `RecordID` from the return signatures of the internal `getActiveLoginAlias` and `getLoginAlias` helpers, leaving the `IStateValue` and `error` they actually provide
- Adjust the call sites in `pkg/registry` so they no longer discard a `RecordID` placeholder
- Preserve all current sign-in, alias deactivation, and identifier-availability behavior: alias resolution, ownership checks, and record updates continue to operate through the returned `IStateValue` exactly as before

## Construction

- [x] update: `[registry/impl_setloginalias.go](/pkg/registry/impl_setloginalias.go)`
  - remove: `RecordID` from the return signature of `getActiveLoginAlias`, leaving `(istructs.IStateValue, error)`; drop the now-redundant `NullRecordID` bookkeeping in the inactive-alias branch
  - remove: `RecordID` from the return signature of `getLoginAlias`, leaving `(istructs.IStateValue, error)`; keep `recordID` as a local since it is still needed to build the record key
  - update: call site in `execCmdPutLoginAliasIndex` to drop the discarded `RecordID` placeholder
  - update: call site in `execCmdDeactivateLoginAliasIndex` to drop the discarded `RecordID` placeholder
  - update: call site in `assertIdentifierAvailable` to drop the discarded `RecordID` placeholder
  - update: call site in `resolveAliasSignInLogin` to drop the discarded `RecordID` placeholder
