### PR TITLE
feat(auth)!: Token Login claim carries canonical identity, new Alias claim carries the active alias [AIR-4327]

### DIFF
--- a/pkg/iauthnzimpl/impl.go
+++ b/pkg/iauthnzimpl/impl.go
@@ -90,11 +90,11 @@ func (i *implIAuthenticator) Authenticate(requestContext context.Context, as ist
 	}
 
 	// read roles from cdoc.sys.Subjects from the current workspace
-	// resolve against both the presented and canonical logins so role assignment matches
+	// resolve against both the canonical login and the active alias so role assignment matches
 	// regardless of which identifier a subject was registered under
-	subjectLogins := []string{principalPayload.PresentedLogin}
-	if principalPayload.CanonicalLogin != "" && principalPayload.CanonicalLogin != principalPayload.PresentedLogin {
-		subjectLogins = append(subjectLogins, principalPayload.CanonicalLogin)
+	subjectLogins := []string{principalPayload.Login}
+	if principalPayload.Alias != "" && principalPayload.Alias != principalPayload.Login {
+		subjectLogins = append(subjectLogins, principalPayload.Alias)
 	}
 	for _, subjectLogin := range subjectLogins {
 		rolesFromSubjects, err := i.rolesFromSubjects(requestContext, subjectLogin, as, req.RequestWSID)
@@ -114,12 +114,8 @@ func (i *implIAuthenticator) Authenticate(requestContext context.Context, as ist
 	switch principalPayload.SubjectKind {
 	case istructs.SubjectKind_User:
 		pkt = iauthnz.PrincipalKind_User
-		// keep internal identity on the canonical login; fall back to the presented login
-		// for legacy tokens (no CanonicalLogin claim) and the system principal
-		loginName = principalPayload.CanonicalLogin
-		if loginName == "" {
-			loginName = principalPayload.PresentedLogin
-		}
+		// internal identity: canonical Login, with defensive Alias fallback
+		loginName = principalPayload.InternalLogin()
 	case istructs.SubjectKind_Device:
 		pkt = iauthnz.PrincipalKind_Device
 	default:

--- a/pkg/iauthnzimpl/impl.go
+++ b/pkg/iauthnzimpl/impl.go
@@ -114,8 +114,7 @@ func (i *implIAuthenticator) Authenticate(requestContext context.Context, as ist
 	switch principalPayload.SubjectKind {
 	case istructs.SubjectKind_User:
 		pkt = iauthnz.PrincipalKind_User
-		// internal identity: canonical Login, with defensive Alias fallback
-		loginName = principalPayload.InternalLogin()
+		loginName = principalPayload.Login
 	case istructs.SubjectKind_Device:
 		pkt = iauthnz.PrincipalKind_Device
 	default:

--- a/pkg/iauthnzimpl/impl_test.go
+++ b/pkg/iauthnzimpl/impl_test.go
@@ -35,8 +35,8 @@ func TestBasicUsage(t *testing.T) {
 	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, timeu.NewITime())
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(istructs.AppQName_test1_app1)
 	pp := payloads.PrincipalPayload{
-		PresentedLogin: "testlogin",
-		SubjectKind:    istructs.SubjectKind_User,
+		Login:       "testlogin",
+		SubjectKind: istructs.SubjectKind_User,
 		Roles: []payloads.RoleType{
 			{
 				WSID:  42,
@@ -125,8 +125,8 @@ func TestBasicUsage(t *testing.T) {
 
 	t.Run("authenticate in the child workspace", func(t *testing.T) {
 		pp := payloads.PrincipalPayload{
-			PresentedLogin: "testlogin",
-			SubjectKind:    istructs.SubjectKind_User,
+			Login:       "testlogin",
+			SubjectKind: istructs.SubjectKind_User,
 			Roles: []payloads.RoleType{
 				{
 					WSID:  2,
@@ -169,9 +169,9 @@ func TestAuthenticate(t *testing.T) {
 	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(istructs.AppQName_test1_app1)
 	login := "testlogin"
 	pp := payloads.PrincipalPayload{
-		PresentedLogin: login,
-		SubjectKind:    istructs.SubjectKind_User,
-		ProfileWSID:    1,
+		Login:       login,
+		SubjectKind: istructs.SubjectKind_User,
+		ProfileWSID: 1,
 	}
 	userToken, err := appTokens.IssueToken(time.Minute, &pp)
 	require.NoError(err)
@@ -193,10 +193,10 @@ func TestAuthenticate(t *testing.T) {
 
 	notIncludedRole := appdef.NewQName("test", "non-included")
 	pp = payloads.PrincipalPayload{
-		PresentedLogin: login,
-		SubjectKind:    istructs.SubjectKind_User,
-		ProfileWSID:    1,
-		Roles:          []payloads.RoleType{{WSID: 1, QName: testRole}, {WSID: 2, QName: notIncludedRole}},
+		Login:       login,
+		SubjectKind: istructs.SubjectKind_User,
+		ProfileWSID: 1,
+		Roles:       []payloads.RoleType{{WSID: 1, QName: testRole}, {WSID: 2, QName: notIncludedRole}},
 	}
 	enrichedToken, err := appTokens.IssueToken(time.Minute, &pp)
 	require.NoError(err)
@@ -422,9 +422,9 @@ func TestErrors(t *testing.T) {
 	t.Run("unsupported subject kind", func(t *testing.T) {
 
 		pp := payloads.PrincipalPayload{
-			PresentedLogin: "testlogin",
-			SubjectKind:    istructs.SubjectKind_FakeLast,
-			ProfileWSID:    1,
+			Login:       "testlogin",
+			SubjectKind: istructs.SubjectKind_FakeLast,
+			ProfileWSID: 1,
 		}
 		token, err := appTokens.IssueToken(time.Minute, &pp)
 		require.NoError(err)
@@ -448,6 +448,65 @@ func TestErrors(t *testing.T) {
 		token, err := IssueAPIToken(appTokens, time.Hour, []appdef.QName{appdef.NewQName("test", "role")}, istructs.NullWSID, payloads.PrincipalPayload{})
 		require.ErrorIs(err, ErrPersonalAccessTokenOnNullWSID)
 		require.Empty(token)
+	})
+}
+
+func TestSubjectRolesResolveAgainstLoginAndAlias(t *testing.T) {
+	require := require.New(t)
+
+	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, timeu.NewITime())
+	appTokens := payloads.ProvideIAppTokensFactory(tokens).New(istructs.AppQName_test1_app1)
+
+	const canonicalLogin = "jsmith"
+	const aliasLogin = "j.smith"
+	subjectRole := appdef.NewQName("test", "subjectrole")
+
+	// grants subjectRole only to the subject login string it is configured to match
+	rolesGetterFor := func(matchLogin string) SubjectGetterFunc {
+		return func(_ context.Context, login string, _ istructs.IAppStructs, _ istructs.WSID) ([]appdef.QName, error) {
+			if login == matchLogin {
+				return []appdef.QName{subjectRole}, nil
+			}
+			return nil, nil
+		}
+	}
+
+	appStructs := AppStructsWithTestStorage(istructs.AppQName_test1_app1, map[istructs.WSID]map[appdef.QName]map[istructs.RecordID]map[string]interface{}{})
+
+	authenticateWith := func(getterMatch string) []iauthnz.Principal {
+		pp := payloads.PrincipalPayload{
+			Login:       canonicalLogin,
+			Alias:       aliasLogin,
+			SubjectKind: istructs.SubjectKind_User,
+			ProfileWSID: 1,
+		}
+		token, err := appTokens.IssueToken(time.Minute, &pp)
+		require.NoError(err)
+		authn := NewDefaultAuthenticator(rolesGetterFor(getterMatch), TestIsDeviceAllowedFuncs)
+		principals, _, err := authn.Authenticate(context.Background(), appStructs, appTokens, iauthnz.AuthnRequest{
+			Host:        "127.0.0.1",
+			RequestWSID: 1,
+			Token:       token,
+		})
+		require.NoError(err)
+		return principals
+	}
+
+	hasSubjectRole := func(principals []iauthnz.Principal) bool {
+		for _, prn := range principals {
+			if prn.Kind == iauthnz.PrincipalKind_Role && prn.QName == subjectRole {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("subject registered under the canonical login resolves", func(t *testing.T) {
+		require.True(hasSubjectRole(authenticateWith(canonicalLogin)))
+	})
+
+	t.Run("subject registered under the active alias resolves", func(t *testing.T) {
+		require.True(hasSubjectRole(authenticateWith(aliasLogin)))
 	})
 }
 

--- a/pkg/itokens-payloads/consts.go
+++ b/pkg/itokens-payloads/consts.go
@@ -13,9 +13,9 @@ import (
 
 var (
 	systemPrincipalPayload = PrincipalPayload{
-		PresentedLogin: "system",
-		SubjectKind:    istructs.SubjectKind_User,
-		ProfileWSID:    istructs.NullWSID,
+		Login:       "system",
+		SubjectKind: istructs.SubjectKind_User,
+		ProfileWSID: istructs.NullWSID,
 	}
 )
 

--- a/pkg/itokens-payloads/impl_test.go
+++ b/pkg/itokens-payloads/impl_test.go
@@ -31,9 +31,9 @@ func TestBasicUsage_PrincipalPayload(t *testing.T) {
 	signer := itokensjwt.TestTokensJWT()
 
 	srcPayload := PrincipalPayload{
-		PresentedLogin: "login",
-		SubjectKind:    istructs.SubjectKind_User,
-		ProfileWSID:    istructs.WSID(10),
+		Login:       "login",
+		SubjectKind: istructs.SubjectKind_User,
+		ProfileWSID: istructs.WSID(10),
 	}
 
 	var token string
@@ -135,9 +135,9 @@ func TestBasicUsage_IAppTokens(t *testing.T) {
 
 	t.Run("Issue token", func(t *testing.T) {
 		srcPayload := PrincipalPayload{
-			PresentedLogin: "login",
-			SubjectKind:    istructs.SubjectKind_User,
-			ProfileWSID:    istructs.WSID(10),
+			Login:       "login",
+			SubjectKind: istructs.SubjectKind_User,
+			ProfileWSID: istructs.WSID(10),
 		}
 		token, err = at.IssueToken(testDuration, &srcPayload)
 		require.NoError(err)

--- a/pkg/itokens-payloads/types.go
+++ b/pkg/itokens-payloads/types.go
@@ -29,15 +29,6 @@ type PrincipalPayload struct {
 	IsAPIToken  bool
 }
 
-// InternalLogin returns the canonical internal identity: Login, falling back to
-// Alias only when Login is empty (a defensive guard for tokens carrying no Login).
-func (p PrincipalPayload) InternalLogin() string {
-	if p.Login != "" {
-		return p.Login
-	}
-	return p.Alias
-}
-
 type RoleType struct {
 	// for role must be OwnerWSID, not the request WSID
 	WSID istructs.WSID

--- a/pkg/itokens-payloads/types.go
+++ b/pkg/itokens-payloads/types.go
@@ -16,17 +16,26 @@ import (
 // Owner is a record with {WSID, IDOfOwner} key
 // isAPIToken -> principals will be built by Roles only in authenticator
 type PrincipalPayload struct {
-	// PresentedLogin is the frontend-facing presented identity: the active alias snapshot at issue time,
-	// or the canonical login when no alias is set. Not to be used for internal identity, authorization,
-	// quotas, or metrics. Carries a json:"Login" tag so the wire/JWT claim key stays "Login".
-	PresentedLogin string `json:"Login"`
-	// CanonicalLogin is the immutable internal identity: the canonical primary login resolved at issue time.
-	CanonicalLogin string
-	SubjectKind    istructs.SubjectKindType
-	ProfileWSID    istructs.WSID
-	Roles          []RoleType
-	GlobalRoles    []appdef.QName
-	IsAPIToken     bool
+	// Login is the canonical primary login resolved at issue time: the immutable internal identity
+	// used for credentials, routing, authorization, quotas, and metrics. Wire/JWT claim key "Login".
+	Login string
+	// Alias is the active alias snapshot at issue time, empty when no alias is set. Display-only:
+	// not to be used for internal identity, authorization, quotas, or metrics. Wire/JWT claim key "Alias".
+	Alias       string
+	SubjectKind istructs.SubjectKindType
+	ProfileWSID istructs.WSID
+	Roles       []RoleType
+	GlobalRoles []appdef.QName
+	IsAPIToken  bool
+}
+
+// InternalLogin returns the canonical internal identity: Login, falling back to
+// Alias only when Login is empty (a defensive guard for tokens carrying no Login).
+func (p PrincipalPayload) InternalLogin() string {
+	if p.Login != "" {
+		return p.Login
+	}
+	return p.Alias
 }
 
 type RoleType struct {

--- a/pkg/processors/command/impl_test.go
+++ b/pkg/processors/command/impl_test.go
@@ -578,9 +578,9 @@ func TestAuthnz(t *testing.T) {
 	defer tearDown(app)
 
 	pp := payloads.PrincipalPayload{
-		PresentedLogin: "testlogin",
-		SubjectKind:    istructs.SubjectKind_User,
-		ProfileWSID:    1,
+		Login:       "testlogin",
+		SubjectKind: istructs.SubjectKind_User,
+		ProfileWSID: 1,
 	}
 	token, err := app.appTokens.IssueToken(10*time.Second, &pp)
 	require.NoError(err)

--- a/pkg/processors/n10n/impl_subscribeandwatch.go
+++ b/pkg/processors/n10n/impl_subscribeandwatch.go
@@ -53,7 +53,7 @@ func (p *implIN10NProc) validateToken(ctx context.Context, n10nWP *n10nWorkpiece
 }
 
 func (p *implIN10NProc) getSubjectLogin(ctx context.Context, n10nWP *n10nWorkpiece) (err error) {
-	subjectLogin := n10nWP.principalPayload.InternalLogin()
+	subjectLogin := n10nWP.principalPayload.Login
 	n10nWP.subjectLogin = istructs.SubjectLogin(subjectLogin)
 	return nil
 }

--- a/pkg/processors/n10n/impl_subscribeandwatch.go
+++ b/pkg/processors/n10n/impl_subscribeandwatch.go
@@ -53,10 +53,7 @@ func (p *implIN10NProc) validateToken(ctx context.Context, n10nWP *n10nWorkpiece
 }
 
 func (p *implIN10NProc) getSubjectLogin(ctx context.Context, n10nWP *n10nWorkpiece) (err error) {
-	subjectLogin := n10nWP.principalPayload.CanonicalLogin
-	if subjectLogin == "" {
-		subjectLogin = n10nWP.principalPayload.PresentedLogin
-	}
+	subjectLogin := n10nWP.principalPayload.InternalLogin()
 	n10nWP.subjectLogin = istructs.SubjectLogin(subjectLogin)
 	return nil
 }

--- a/pkg/processors/query/impl_test.go
+++ b/pkg/processors/query/impl_test.go
@@ -1338,9 +1338,9 @@ func (m *testMetrics) Increase(string, float64) {}
 
 func getTestToken(appTokens istructs.IAppTokens, wsid istructs.WSID) string {
 	pp := payloads.PrincipalPayload{
-		PresentedLogin: "syslogin",
-		SubjectKind:    istructs.SubjectKind_User,
-		ProfileWSID:    wsid,
+		Login:       "syslogin",
+		SubjectKind: istructs.SubjectKind_User,
+		ProfileWSID: wsid,
 	}
 	token, err := appTokens.IssueToken(time.Minute, &pp)
 	if err != nil {
@@ -1351,9 +1351,9 @@ func getTestToken(appTokens istructs.IAppTokens, wsid istructs.WSID) string {
 
 func getSystemToken(appTokens istructs.IAppTokens) string {
 	pp := payloads.PrincipalPayload{
-		PresentedLogin: "syslogin",
-		SubjectKind:    istructs.SubjectKind_User,
-		ProfileWSID:    istructs.NullWSID,
+		Login:       "syslogin",
+		SubjectKind: istructs.SubjectKind_User,
+		ProfileWSID: istructs.NullWSID,
 	}
 	token, err := appTokens.IssueToken(time.Minute, &pp)
 	if err != nil {

--- a/pkg/registry/appws.vsql
+++ b/pkg/registry/appws.vsql
@@ -186,5 +186,4 @@ ALTER WORKSPACE sys.AppWorkspaceWS (
 	GRANT EXECUTE ON QUERY IssuePrincipalToken TO sys.Anonymous;
 	GRANT EXECUTE ON QUERY InitiateResetPasswordByEmail TO sys.Anonymous;
 	GRANT EXECUTE ON QUERY IssueVerifiedValueTokenForResetPassword TO sys.Anonymous;
-	GRANT SELECT ON TABLE Login TO sys.ProfileOwner;
 );

--- a/pkg/registry/impl_issueprincipaltoken.go
+++ b/pkg/registry/impl_issueprincipaltoken.go
@@ -98,16 +98,12 @@ func provideIssuePrincipalTokenExec(itokens itokens.ITokens, federation federati
 		}
 
 		// issue principal token
-		presentedLogin := loginForSignIn.alias
-		if presentedLogin == "" {
-			presentedLogin = loginForSignIn.canonicalLogin
-		}
 		principalPayload := payloads.PrincipalPayload{
-			PresentedLogin: presentedLogin,
-			CanonicalLogin: loginForSignIn.canonicalLogin,
-			SubjectKind:    istructs.SubjectKindType(loginForSignIn.subjectKind),
-			ProfileWSID:    istructs.WSID(result.profileWSID), //nolint G115 since WSID is created by NewWSID()
-			GlobalRoles:    globalRoles,                       // [~server.authnz.groles/cmp.c.registry.IssuePrincipalToken~impl]
+			Login:       loginForSignIn.canonicalLogin,
+			Alias:       loginForSignIn.alias,
+			SubjectKind: istructs.SubjectKindType(loginForSignIn.subjectKind),
+			ProfileWSID: istructs.WSID(result.profileWSID), //nolint G115 since WSID is created by NewWSID()
+			GlobalRoles: globalRoles,                       // [~server.authnz.groles/cmp.c.registry.IssuePrincipalToken~impl]
 		}
 		ttl := time.Duration(args.ArgumentObject.AsInt32(field_TTLHours)) * time.Hour
 		if ttl == 0 {

--- a/pkg/sys/it/impl_childworkspace_test.go
+++ b/pkg/sys/it/impl_childworkspace_test.go
@@ -151,9 +151,9 @@ func TestForeignAuthorization(t *testing.T) {
 		require.NoError(err)
 		apiToken, err := iauthnzimpl.IssueAPIToken(as.AppTokens(), time.Hour, []appdef.QName{appdef.NewQName("app1pkg", "SpecialAPITokenRole")},
 			childWS.WSID, payloads.PrincipalPayload{
-				PresentedLogin: parentWS.Owner.Name,
-				SubjectKind:    istructs.SubjectKind_User,
-				ProfileWSID:    parentWS.Owner.ProfileWSID,
+				Login:       parentWS.Owner.Name,
+				SubjectKind: istructs.SubjectKind_User,
+				ProfileWSID: parentWS.Owner.ProfileWSID,
 			})
 		require.NoError(err)
 

--- a/pkg/sys/it/impl_qpv2_test.go
+++ b/pkg/sys/it/impl_qpv2_test.go
@@ -214,9 +214,9 @@ func TestQueryProcessor2_Views(t *testing.T) {
 		require.NoError(err)
 		apiToken, err := iauthnzimpl.IssueAPIToken(as.AppTokens(), time.Hour, []appdef.QName{appdef.NewQName("app1pkg", "LimitedAccessRole")},
 			ws.WSID, payloads.PrincipalPayload{
-				PresentedLogin: newLogin.Name,
-				SubjectKind:    istructs.SubjectKind_User,
-				ProfileWSID:    newLoginPrn.ProfileWSID,
+				Login:       newLogin.Name,
+				SubjectKind: istructs.SubjectKind_User,
+				ProfileWSID: newLoginPrn.ProfileWSID,
 			})
 		require.NoError(err)
 
@@ -2241,10 +2241,10 @@ func TestQueryProcessor2_Schemas(t *testing.T) {
 	t.Run("read app schema as a sys.Developer", func(t *testing.T) {
 		// Generate sys.Developer token
 		pp := payloads.PrincipalPayload{
-			PresentedLogin: "Login",
-			SubjectKind:    istructs.SubjectKind_User,
-			ProfileWSID:    1,
-			GlobalRoles:    []appdef.QName{appdef.QNameRoleDeveloper},
+			Login:       "Login",
+			SubjectKind: istructs.SubjectKind_User,
+			ProfileWSID: 1,
+			GlobalRoles: []appdef.QName{appdef.QNameRoleDeveloper},
 		}
 		tokenDeveloper, err := vit.IssueToken(istructs.AppQName_test1_app1, 100*time.Minute, &pp)
 		require.NoError(err)
@@ -2271,10 +2271,10 @@ func TestQueryProcessor2_SchemasRoles(t *testing.T) {
 	t.Run("read app workspace roles as a sys.Developer", func(t *testing.T) {
 		// Generate sys.Developer token
 		pp := payloads.PrincipalPayload{
-			PresentedLogin: "Login",
-			SubjectKind:    istructs.SubjectKind_User,
-			ProfileWSID:    1,
-			GlobalRoles:    []appdef.QName{appdef.QNameRoleDeveloper},
+			Login:       "Login",
+			SubjectKind: istructs.SubjectKind_User,
+			ProfileWSID: 1,
+			GlobalRoles: []appdef.QName{appdef.QNameRoleDeveloper},
 		}
 		tokenDeveloper, err := vit.IssueToken(istructs.AppQName_test1_app1, 100*time.Minute, &pp)
 		require.NoError(err)
@@ -2315,10 +2315,10 @@ func TestQueryProcessor2_SchemasWorkspaceRole(t *testing.T) {
 	t.Run("read app workspace role as sys.Developer", func(t *testing.T) {
 		// Generate sys.Developer token
 		pp := payloads.PrincipalPayload{
-			PresentedLogin: "Login",
-			SubjectKind:    istructs.SubjectKind_User,
-			ProfileWSID:    1,
-			GlobalRoles:    []appdef.QName{appdef.QNameRoleDeveloper},
+			Login:       "Login",
+			SubjectKind: istructs.SubjectKind_User,
+			ProfileWSID: 1,
+			GlobalRoles: []appdef.QName{appdef.QNameRoleDeveloper},
 		}
 		tokenDeveloper, err := vit.IssueToken(istructs.AppQName_test1_app1, 100*time.Minute, &pp)
 		require.NoError(err)

--- a/pkg/sys/it/impl_signupin_test.go
+++ b/pkg/sys/it/impl_signupin_test.go
@@ -244,10 +244,10 @@ func TestLoginAlias(t *testing.T) {
 		waitForLoginAlias(t, vit, login, alias1)
 
 		primaryToken := issuePrincipalToken(t, vit, login.Name, login.Pwd, appQName)
-		assertPrincipalTokenClaims(t, vit, primaryToken, alias1, login.Name)
+		assertPrincipalTokenClaims(t, vit, primaryToken, login.Name, alias1)
 
 		aliasToken := issuePrincipalToken(t, vit, alias1, login.Pwd, appQName)
-		assertPrincipalTokenClaims(t, vit, aliasToken, alias1, login.Name)
+		assertPrincipalTokenClaims(t, vit, aliasToken, login.Name, alias1)
 
 		issuePrincipalToken(t, vit, alias1, "wrong-password", appQName, it.Expect401("login or password is incorrect"))
 	})
@@ -267,18 +267,18 @@ func TestLoginAlias(t *testing.T) {
 
 		issuePrincipalToken(t, vit, alias1, login.Pwd, appQName, it.Expect401("login or password is incorrect"))
 		aliasToken := issuePrincipalToken(t, vit, alias2, login.Pwd, appQName)
-		assertPrincipalTokenClaims(t, vit, aliasToken, alias2, login.Name)
+		assertPrincipalTokenClaims(t, vit, aliasToken, login.Name, alias2)
 	})
 
 	t.Run("existing token keeps alias snapshot and refresh preserves it", func(t *testing.T) {
 		tokenBeforeClear := issuePrincipalToken(t, vit, alias2, login.Pwd, appQName)
-		assertPrincipalTokenClaims(t, vit, tokenBeforeClear, alias2, login.Name)
+		assertPrincipalTokenClaims(t, vit, tokenBeforeClear, login.Name, alias2)
 
 		initiateSetLoginAlias(t, vit, login, "", sysRegistryToken)
 		waitForLoginAlias(t, vit, login, "")
 		issuePrincipalToken(t, vit, alias2, login.Pwd, appQName, it.Expect401("login or password is incorrect"))
 
-		assertPrincipalTokenClaims(t, vit, tokenBeforeClear, alias2, login.Name)
+		assertPrincipalTokenClaims(t, vit, tokenBeforeClear, login.Name, alias2)
 
 		vit.TimeAdd(time.Minute)
 		prnWithAliasSnapshot := &it.Principal{
@@ -290,7 +290,7 @@ func TestLoginAlias(t *testing.T) {
 		resp := vit.PostProfile(prnWithAliasSnapshot, "q.sys.RefreshPrincipalToken", body)
 		refreshedToken := resp.SectionRow()[0].(string)
 		require.NotEqual(tokenBeforeClear, refreshedToken)
-		assertPrincipalTokenClaims(t, vit, refreshedToken, alias2, login.Name)
+		assertPrincipalTokenClaims(t, vit, refreshedToken, login.Name, alias2)
 	})
 
 	t.Run("clearing when no alias is set is idempotent", func(t *testing.T) {
@@ -311,7 +311,7 @@ func TestLoginAlias(t *testing.T) {
 
 		issuePrincipalToken(t, vit, alias2, login.Pwd, appQName, it.Expect401("login or password is incorrect"))
 		aliasToken := issuePrincipalToken(t, vit, alias2, reuseLogin.Pwd, appQName)
-		assertPrincipalTokenClaims(t, vit, aliasToken, alias2, reuseLogin.Name)
+		assertPrincipalTokenClaims(t, vit, aliasToken, reuseLogin.Name, alias2)
 	})
 }
 
@@ -486,18 +486,23 @@ func issuePrincipalToken(t *testing.T, vit *it.VIT, signInIdentifier, pwd string
 	return resp.SectionRow()[0].(string)
 }
 
-func assertPrincipalTokenClaims(t *testing.T, vit *it.VIT, token, expectedPresentedLogin, expectedCanonicalLogin string) {
+func assertPrincipalTokenClaims(t *testing.T, vit *it.VIT, token, expectedLogin, expectedAlias string) {
 	t.Helper()
 	payload := payloads.PrincipalPayload{}
 	_, err := vit.ITokens.ValidateToken(token, &payload)
 	require.NoError(t, err)
-	require.Equal(t, expectedPresentedLogin, payload.PresentedLogin)
+	require.Equal(t, expectedLogin, payload.Login)
+	require.Equal(t, expectedAlias, payload.Alias)
 
 	claims := decodeJWTClaims(t, token)
-	require.Equal(t, expectedPresentedLogin, claims["Login"])
-	require.Equal(t, expectedCanonicalLogin, claims["CanonicalLogin"])
-	_, hasAlias := claims["Alias"]
-	require.False(t, hasAlias)
+	require.Equal(t, expectedLogin, claims["Login"])
+	if expectedAlias == "" {
+		require.Empty(t, claims["Alias"])
+	} else {
+		require.Equal(t, expectedAlias, claims["Alias"])
+	}
+	_, hasCanonical := claims["CanonicalLogin"]
+	require.False(t, hasCanonical)
 }
 
 func decodeJWTClaims(t *testing.T, token string) map[string]any {
@@ -546,6 +551,28 @@ func getLoginCDoc(t *testing.T, vit *it.VIT, login it.Login) map[string]any {
 	cdocLogin := map[string]any{}
 	require.NoError(t, json.Unmarshal([]byte(resp.SectionRow()[0].(string)), &cdocLogin))
 	return cdocLogin
+}
+
+func TestLoginAliasStateVisibility(t *testing.T) {
+	vit := it.NewVIT(t, &it.SharedConfig_App1)
+	defer vit.TearDown()
+
+	appQName := istructs.AppQName_test1_app1
+	login := vit.SignUp(vit.NextName(), "pwd1", appQName)
+	vit.SignIn(login)
+
+	alias := vit.NextName()
+	sysRegistryToken := vit.GetSystemPrincipal(istructs.AppQName_sys_registry).Token
+	initiateSetLoginAlias(t, vit, login, alias, sysRegistryToken)
+	waitForLoginAlias(t, vit, login, alias)
+
+	// System can read the login's alias lifecycle state (Alias / AliasInProc / AliasError).
+	// The complementary half — a non-System caller cannot read the registry Login record —
+	// is covered by TestAuthnz/"foreign app" (regular user, cross-app read of registry.Login -> 403).
+	cdocLogin := getLoginCDoc(t, vit, login)
+	require.Equal(t, alias, cdocLogin["Alias"])
+	require.Equal(t, float64(0), cdocLogin["AliasInProc"])
+	require.Empty(t, cdocLogin["AliasError"])
 }
 
 func TestWorkInForeignProfileWithEnrichedToken(t *testing.T) {

--- a/pkg/sys/it/impl_sqlquery_test.go
+++ b/pkg/sys/it/impl_sqlquery_test.go
@@ -586,9 +586,9 @@ func TestAuthnz(t *testing.T) {
 	require.NoError(t, err)
 	apiToken, err := iauthnzimpl.IssueAPIToken(as.AppTokens(), time.Hour, []appdef.QName{apiRole},
 		ws.WSID, payloads.PrincipalPayload{
-			PresentedLogin: ws.Owner.Name,
-			SubjectKind:    istructs.SubjectKind_User,
-			ProfileWSID:    ws.Owner.ProfileWSID,
+			Login:       ws.Owner.Name,
+			SubjectKind: istructs.SubjectKind_User,
+			ProfileWSID: ws.Owner.ProfileWSID,
 		})
 	require.NoError(t, err)
 

--- a/pkg/sys/it/impl_workspace_test.go
+++ b/pkg/sys/it/impl_workspace_test.go
@@ -340,10 +340,10 @@ func TestCreateChildOfChildWorkspace(t *testing.T) {
 	// owner of ws is not owner of child of ws so let's generate a token with a WorkspaceOwner role
 	// note: WSID the role belongs to must be ws, not newWS because iauthnz implementation compares wsid to ownerWSID
 	pp := payloads.PrincipalPayload{
-		PresentedLogin: ws.Owner.Name,
-		SubjectKind:    istructs.SubjectKind_User,
-		ProfileWSID:    ws.Owner.ProfileWSID,
-		Roles:          []payloads.RoleType{{WSID: ws.WSID, QName: iauthnz.QNameRoleWorkspaceOwner}},
+		Login:       ws.Owner.Name,
+		SubjectKind: istructs.SubjectKind_User,
+		ProfileWSID: ws.Owner.ProfileWSID,
+		Roles:       []payloads.RoleType{{WSID: ws.WSID, QName: iauthnz.QNameRoleWorkspaceOwner}},
 	}
 	tokenForChildOfChild, err := vit.IssueToken(istructs.AppQName_test1_app1, time.Minute, &pp)
 	require.NoError(t, err)

--- a/pkg/vit/impl.go
+++ b/pkg/vit/impl.go
@@ -594,10 +594,9 @@ func (vit *VIT) RefreshTokens() {
 		for _, prn := range appPrns {
 			// issue principal token
 			principalPayload := payloads.PrincipalPayload{
-				PresentedLogin: prn.Name,
-				CanonicalLogin: prn.Name,
-				SubjectKind:    istructs.SubjectKind_User,
-				ProfileWSID:    prn.ProfileWSID,
+				Login:       prn.Name,
+				SubjectKind: istructs.SubjectKind_User,
+				ProfileWSID: prn.ProfileWSID,
 			}
 			as, err := vit.BuiltIn(prn.AppQName)
 			require.NoError(vit.T, err) // notest

--- a/uspecs/changes/archive/2606/2606201047-token-claim-login-canonical/change.md
+++ b/uspecs/changes/archive/2606/2606201047-token-claim-login-canonical/change.md
@@ -1,0 +1,136 @@
+---
+change_id: 2606191522-token-claim-login-canonical
+type: feat
+issue_url: https://untill.atlassian.net/browse/AIR-4327
+domains: [prod]
+scope: [auth]
+breaking: true
+---
+
+# Change request: Token Login claim carries canonical identity, new Alias claim carries the active alias
+
+Refs:
+
+- [AIR-4327: voedger: flip token claim contract to Login (canonical) + PresentedLogin (alias)](./issue-AIR-4327.md)
+
+## Why
+
+The previous change made the `Login` token claim carry the alias snapshot, silently switching every existing reader from the canonical identity to the alias and breaking the frontend change-password flow. Restoring `Login` to the canonical identity is safe-by-default: identity used for credentials, routing, authorization, quotas, and metrics stays correct with no migration, while showing the alias becomes an explicit opt-in.
+
+## What
+
+In the prod auth domain, principal-token claims are restructured so the canonical identity is the default:
+
+- The `Login` claim again carries the canonical primary login (its historical meaning), so all identity consumers read the canonical login without changes.
+- A new `Alias` claim carries the active alias snapshot at issue time, and is empty when no alias is set.
+- Authorization resolves subject roles against both the canonical login and the active alias, so role assignments keyed on either remain effective.
+- This supersedes the earlier alias-in-Login contract; tokens minted under the old contract self-heal within token TTL on re-sign-in or refresh.
+
+## How
+
+Decisions:
+
+- In `pkg/itokens-payloads/types.go`, rename the `CanonicalLogin` field to `Login` with no json tag so the wire claim `Login` again carries the canonical identity; rename the `PresentedLogin` field to `Alias` and drop its `json:"Login"` tag so it serializes under a new `Alias` claim, left empty when no alias is set.
+- In `pkg/itokens-payloads/consts.go`, set the system principal's canonical `Login` to `"system"` and leave `Alias` empty.
+- In `pkg/registry/impl_issueprincipaltoken.go`, set `Login` directly from `loginForSignIn.canonicalLogin` and `Alias` from `loginForSignIn.alias` (no fallback to canonical), so `Alias` is empty when no alias exists.
+- In `pkg/iauthnzimpl/impl.go`, key the internal identity (`loginName`) on `Login` with a fallback to `Alias` for legacy/system tokens, and keep resolving subject roles against both `Login` and `Alias` with the existing dedup.
+- In `pkg/processors/n10n/impl_subscribeandwatch.go` and the `pkg/vit` test helper, read/set the internal identity from `Login` (fallback `Alias`).
+- Remove the dormant `GRANT SELECT ON TABLE Login TO sys.ProfileOwner` in `pkg/registry/appws.vsql`: `ProfileOwner` is only ever emitted in a subject's own profile workspace, never in the registry app workspace where the `Login` table lives, so the grant confers no client read access today. Removing it makes the schema match the System-only read contract specified by the `Login alias state visibility` feature rule. Non-breaking: no client ever had effective read access through it.
+- Token transition relies on token TTL plus self-healing on re-sign-in/refresh; no data migration and no explicit deployment cutover orchestration.
+- Update the affected `*_test.go` payload constructions and the auth specs/diagrams to reflect `Login` = canonical and `Alias` = active alias.
+
+Out of scope:
+
+- Frontend `Alias` display reader for change-password (optional AIR-4292 follow-up).
+- Any other authentication or authorization behavior beyond the claim contract.
+
+References:
+
+- [principal token payload type](../../../../../pkg/itokens-payloads/types.go)
+- [system principal payload defaults](../../../../../pkg/itokens-payloads/consts.go)
+- [principal token issue](../../../../../pkg/registry/impl_issueprincipaltoken.go)
+- [registry app-workspace schema and ACL grants](../../../../../pkg/registry/appws.vsql)
+- [authorization subject/role resolution](../../../../../pkg/iauthnzimpl/impl.go)
+- [n10n subject login resolution](../../../../../pkg/processors/n10n/impl_subscribeandwatch.go)
+- [principal token claim assertions](../../../../../pkg/sys/it/impl_signupin_test.go)
+- [token architecture spec](../../../../../uspecs/specs/prod/auth/arch-tokens.md)
+- [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+
+## Functional design
+
+- [x] update: [auth/authn.feature](../../../../specs/prod/auth/authn.feature)
+  - update: "Principal token carries authn identity fields" scenario -> the issued principal token identifies its login (canonical), subject kind, and profileWSID (core always-present fields; alias semantics covered by the dedicated scenario below)
+  - update: "Client refreshes a principal token" scenario -> the new token preserves login (canonical), alias, subject kind, and profileWSID from the input token
+  - replace: merge the two scenarios "Principal token uses the active alias as login after alias sign-in" and "Principal token uses the active alias as login when signing in with the original login" into one scenario outline owning alias semantics -> the token's login is always the canonical login; its alias is the active alias when an alias is active (regardless of which identifier was used to sign in) and empty when no alias is set
+  - update: "Existing principal token retains login and canonical login after alias changes" scenario -> the existing token retains the login (canonical) and alias captured at issue time
+  - add: "Login alias state visibility" rule -> System can read a login's alias state (active alias, in-progress flag, error); a non-System caller's read is rejected (documents the pre-existing System-only read access of the registry Login record; not introduced by the token-claim change)
+
+## Technical design
+
+- [x] update: [auth/arch-tokens.md](../../../../specs/prod/auth/arch-tokens.md)
+  - update: `[PrincipalPayload]` contract -> `Login` = canonical login (immutable internal identity); rename the `CanonicalLogin` field to `Alias` = active alias snapshot at issue time, empty when no alias; both captured at issue time and never re-read on refresh
+  - update: the Issue and Refresh scenario prose and pseudocode to build and preserve `Login` (canonical) + `Alias`, replacing `Login` (alias snapshot) + `CanonicalLogin`
+
+- [x] update: [auth/arch-authn.md](../../../../specs/prod/auth/arch-authn.md)
+  - update: the `[q.registry.IssuePrincipalToken]` description and the sign-in pseudocode -> set `Login` = canonical login and `Alias` = active-alias snapshot (empty when no alias), dropping the alias-as-`Login` / `CanonicalLogin` wording
+
+- [x] update: [auth/arch-authz.md](../../../../specs/prod/auth/arch-authz.md)
+  - update: the `[Subjects reader]` composition -> match `[(cdoc.sys.Subject)]` rows against `PrincipalPayload.Login` and `PrincipalPayload.Alias` (renamed from `CanonicalLogin`), keeping the same dedup
+
+- [x] update: [auth/arch.md](../../../../specs/prod/auth/arch.md)
+  - update: the `PrincipalPayload(...)` field list and the refresh note -> replace `CanonicalLogin` with `Alias`; `Login` now denotes the canonical login
+
+- [x] update: [auth/authn--td.md](../../../../specs/prod/auth/authn--td.md)
+  - update: the token issue/refresh flows and worked examples -> `Login` carries the canonical login and `Alias` carries the active alias, replacing `Login` (active alias) + `CanonicalLogin`
+
+## Construction
+
+### Tests
+
+- [x] update: [sys/it/impl_signupin_test.go](../../../../../pkg/sys/it/impl_signupin_test.go)
+  - update: `assertPrincipalTokenClaims` -> rename params to `(expectedLogin, expectedAlias)`; assert `payload.Login` and the `Login` claim equal the canonical login, `payload.Alias` and the `Alias` claim equal the active alias (empty when none), and that no `CanonicalLogin` claim is present
+  - update: the alias sign-in assertions so the token's `Login` is the canonical login and `Alias` is the active alias, for both alias and original-login sign-in
+  - add: test for the `Login alias state visibility` rule -> System reads a login's alias state (asserts `Alias`/`AliasInProc`/`AliasError`). The non-System-rejected half is already covered by `TestAuthnz/"foreign app"` (regular user cross-app read of `registry.Login` -> 403, independent of the dormant grant), so no duplicate was added
+
+- [x] update: [iauthnzimpl/impl_test.go](../../../../../pkg/iauthnzimpl/impl_test.go)
+  - update: `PrincipalPayload` fixtures `PresentedLogin:` -> `Login:`
+  - add/update: a case asserting subject roles resolve against both `Login` and `Alias`
+
+- [x] update: rename `PresentedLogin:` -> `Login:` (canonical) and drop `CanonicalLogin:` in the remaining payload fixtures
+  - [itokens-payloads/impl_test.go](../../../../../pkg/itokens-payloads/impl_test.go)
+  - [processors/command/impl_test.go](../../../../../pkg/processors/command/impl_test.go)
+  - [processors/query/impl_test.go](../../../../../pkg/processors/query/impl_test.go)
+  - [sys/it/impl_childworkspace_test.go](../../../../../pkg/sys/it/impl_childworkspace_test.go)
+  - [sys/it/impl_qpv2_test.go](../../../../../pkg/sys/it/impl_qpv2_test.go)
+  - [sys/it/impl_sqlquery_test.go](../../../../../pkg/sys/it/impl_sqlquery_test.go)
+  - [sys/it/impl_workspace_test.go](../../../../../pkg/sys/it/impl_workspace_test.go)
+
+### Payload contract
+
+- [x] update: [itokens-payloads/types.go](../../../../../pkg/itokens-payloads/types.go)
+  - rename the `CanonicalLogin` field -> `Login` (no json tag; canonical wire claim)
+  - rename the `PresentedLogin` field -> `Alias`, dropping the `json:"Login"` tag so it serializes as the `Alias` claim, empty when no alias
+  - rewrite the doc comments: `Login` = canonical immutable internal identity; `Alias` = active alias snapshot, display-only
+
+- [x] update: [itokens-payloads/consts.go](../../../../../pkg/itokens-payloads/consts.go)
+  - `systemPrincipalPayload`: set `Login: "system"`, leave `Alias` empty
+
+### Token issue and consumers
+
+- [x] update: [registry/impl_issueprincipaltoken.go](../../../../../pkg/registry/impl_issueprincipaltoken.go)
+  - set `Login = loginForSignIn.canonicalLogin` and `Alias = loginForSignIn.alias`; remove the `presentedLogin` fallback that copied the canonical login into the alias field
+
+- [x] update: [iauthnzimpl/impl.go](../../../../../pkg/iauthnzimpl/impl.go)
+  - resolve subject roles against `Login` (primary) and `Alias` (when non-empty and `!= Login`), keeping the existing dedup
+  - key `loginName` on `Login`, falling back to `Alias` for legacy/system tokens
+
+- [x] update: [n10n/impl_subscribeandwatch.go](../../../../../pkg/processors/n10n/impl_subscribeandwatch.go)
+  - read the subject login from `Login`, falling back to `Alias`
+
+- [x] update: [vit/impl.go](../../../../../pkg/vit/impl.go)
+  - set `Login: prn.Name` in the VIT-issued `PrincipalPayload`; leave `Alias` empty
+
+### Schema
+
+- [x] update: [registry/appws.vsql](../../../../../pkg/registry/appws.vsql)
+  - remove the dormant `GRANT SELECT ON TABLE Login TO sys.ProfileOwner`: no client holds `ProfileOwner` in the registry app workspace where `Login` lives, so it grants no access; removal aligns the schema with the System-only read contract

--- a/uspecs/changes/archive/2606/2606201047-token-claim-login-canonical/issue-AIR-4327.md
+++ b/uspecs/changes/archive/2606/2606201047-token-claim-login-canonical/issue-AIR-4327.md
@@ -1,0 +1,41 @@
+# voedger: flip token claim contract to Login (canonical) + Alias (active alias)
+
+- URL: https://untill.atlassian.net/browse/AIR-4327
+- ID: AIR-4327
+- State: To Do
+- Author: Maksim Geraskin
+- Assignees: Maksim Geraskin
+- Labels: none
+
+> **Local copy note:** This change-folder copy uses the `Alias` claim name agreed during spec authoring; the new claim was originally proposed in the ticket as `PresentedLogin`. Rationale is recorded as a comment on AIR-4327, and the live ticket text may still read `PresentedLogin`. References to the *existing* `PresentedLogin` field under "Current contract" are intentionally left unchanged, since that is its name in the currently deployed code.
+
+## Description
+
+Revisit the principal-token claim contract so the Login claim carries the canonical (immutable internal) identity and a new Alias claim carries the active alias snapshot at issue time. This inverts the contract shipped in change 2606151848-token-login-reflects-alias and supersedes that decision.
+
+### Current contract
+
+In pkg/itokens-payloads/types.go, PrincipalPayload.PresentedLogin carries a json:"Login" tag (wire claim Login = alias snapshot, or canonical when no alias), and CanonicalLogin is a separate claim. Net: every existing reader of the Login claim silently switched from canonical to alias.
+
+### Proposed contract
+
+* `Login` (wire claim) = canonical primary login (its historical meaning).
+* `Alias` (new wire claim) = active alias snapshot at issue time; empty when no alias is set.
+
+### Rationale
+
+Safe-by-default: the dangerous default (Login = identity used for credentials, routing, authorization, quotas, metrics) stays correct with no migration, and "show the alias" becomes an explicit opt-in via Alias. The current contract inverts this and forces every identity consumer to migrate off Login (this is what broke the frontend change-password flow, since the registry GetCDocLogin cannot resolve an alias).
+
+### Scope
+
+* `pkg/itokens-payloads/types.go`: rename CanonicalLogin -> Login (no tag) and the PresentedLogin field -> Alias (drop the json:"Login" tag, serializing as the new Alias claim); update doc comments and consts.go initializer.
+* `pkg/registry/impl_issueprincipaltoken.go`: set Login = loginForSignIn.canonicalLogin and Alias = alias snapshot (empty when no alias).
+* `pkg/iauthnzimpl`: resolve subject roles against both Login and Alias (same dedup as today, renamed fields).
+* `uspecs/specs/prod/auth/arch-tokens.md` and related specs/tests: update claim descriptions.
+* Token transition window: tokens minted under the current contract carry Login = alias; after the switch they would be misread as canonical. Define the cutover (bounded by token TTL and self-healing on re-sign-in / refresh) and whether the current contract is already deployed.
+
+Supersedes change 2606151848-token-login-reflects-alias. Frontend impact (AIR-4292): change-password then needs no frontend change; the only optional follow-up is an Alias reader for display.
+
+---
+
+Co-authored by [Augment Code](https://www.augmentcode.com/?utm_source=atlassian&utm_medium=jira_issue&utm_campaign=jira)

--- a/uspecs/specs/prod/auth/arch-authn.md
+++ b/uspecs/specs/prod/auth/arch-authn.md
@@ -70,7 +70,7 @@ Registry records and indexes
 ### Sign-in and lifecycle queries/commands
 
 - `[q.registry.IssuePrincipalToken]`
-  - Resolves the sign-in identifier against `[(registry.Login)]` directly, then against `[(registry.LoginAlias)]` if the direct lookup misses; verifies the password hash, enforces the `Profile workspace readiness gate`, builds `PrincipalPayload` (setting `Login` to the active-alias snapshot with canonical fallback and `CanonicalLogin` to the canonical login, both captured at issue time) and delegates token issuance to [Token management](./arch-tokens.md). Returns the same `errLoginOrPasswordIsIncorrect` for missing login, deactivated login, missing alias, and wrong password to prevent enumeration.
+  - Resolves the sign-in identifier against `[(registry.Login)]` directly, then against `[(registry.LoginAlias)]` if the direct lookup misses; verifies the password hash, enforces the `Profile workspace readiness gate`, builds `PrincipalPayload` (setting `Login` to the canonical login and `Alias` to the active-alias snapshot, empty when no alias, both captured at issue time) and delegates token issuance to [Token management](./arch-tokens.md). Returns the same `errLoginOrPasswordIsIncorrect` for missing login, deactivated login, missing alias, and wrong password to prevent enumeration.
   - impl: [pkg/registry/impl_issueprincipaltoken.go#provideIssuePrincipalTokenExec](../../../../pkg/registry/impl_issueprincipaltoken.go)
 
 - `[c.registry.CreateLogin]`, `[c.registry.CreateEmailLogin]`
@@ -124,7 +124,7 @@ Registry records and indexes
        -> on miss: [(registry.LoginAlias)] -> [(registry.Login)]
        -> checkPasswordHash
        -> Profile workspace readiness gate: if ProfileWSID == 0 or WSError != "" return error result
-       -> build PrincipalPayload(Login=alias snapshot or canonical login, CanonicalLogin, SubjectKind, ProfileWSID, GlobalRoles)
+       -> build PrincipalPayload(Login=canonical login, Alias=active alias snapshot, SubjectKind, ProfileWSID, GlobalRoles)
        -> [Token management].IssueToken (see arch-tokens.md)
   -> @Client: principalToken, profileWSID
 ```

--- a/uspecs/specs/prod/auth/arch-authz.md
+++ b/uspecs/specs/prod/auth/arch-authz.md
@@ -72,7 +72,7 @@ Role sources
   - impl: [pkg/iauthnzimpl/impl.go#Authenticate](../../../../pkg/iauthnzimpl/impl.go)
 
 - `[Subjects reader]`
-  - Reads `[(cdoc.sys.Subject)]` from `RequestWSID` for the resolved subject (or `sys.Guest` when anonymous) through the injected `subjectRolesGetter`, matching rows against both `PrincipalPayload.Login` and `PrincipalPayload.CanonicalLogin` so an invite under either identifier resolves, and emits one `Principal{Kind: Role, WSID: RequestWSID, QName: role}` per matched role.
+  - Reads `[(cdoc.sys.Subject)]` from `RequestWSID` for the resolved subject (or `sys.Guest` when anonymous) through the injected `subjectRolesGetter`, matching rows against both `PrincipalPayload.Login` and `PrincipalPayload.Alias` so an invite under either identifier resolves, and emits one `Principal{Kind: Role, WSID: RequestWSID, QName: role}` per matched role.
   - impl: [pkg/iauthnzimpl/impl.go#rolesFromSubjects](../../../../pkg/iauthnzimpl/impl.go)
 
 - `[Workspace role deriver]`
@@ -89,7 +89,7 @@ Four sources by origin contribute to a request's principal set; each is enumerat
 
 - `[Invite-granted]`
   - Origin: `[[Workspace membership]]` writes `[(cdoc.sys.Subject)]` rows in the inviting workspace as part of the join flow; see [arch-membership.md](./arch-membership.md).
-  - Composition: `[Subjects reader]` reads `[(cdoc.sys.Subject)]` rows in `RequestWSID` matching either `PrincipalPayload.Login` or `PrincipalPayload.CanonicalLogin` and emits one `Principal{Kind: Role, WSID: RequestWSID, QName: role}` per matched role.
+  - Composition: `[Subjects reader]` reads `[(cdoc.sys.Subject)]` rows in `RequestWSID` matching either `PrincipalPayload.Login` or `PrincipalPayload.Alias` and emits one `Principal{Kind: Role, WSID: RequestWSID, QName: role}` per matched role.
 
 - `[Token-carried]`
   - Origin: `[[Authentication]]` snapshots roles into `PrincipalPayload` at sign-in (per-app `Roles` from the registry login record) and `[c.registry.UpdateGlobalRoles]` updates the `GlobalRoles` field consumed at the next sign-in; see [arch-authn.md](./arch-authn.md). A second runtime write path is `[q.sys.EnrichPrincipalToken]`, which folds the request's composed `Principal{Kind: Role}` set into `PrincipalPayload.Roles` and re-issues the token so those roles travel into workspaces where they would not otherwise be composed; the token-lifecycle detail lives in [arch-tokens.md](./arch-tokens.md).
@@ -123,7 +123,7 @@ VSQL role inheritance (e.g., `ProfileOwner -> WorkspaceOwner`) is expanded later
             emit [Token-carried] PrincipalPayload.Roles filtered to RequestWSID
             return (principals, NullWSID)
        -> emit [Token-carried] PrincipalPayload.GlobalRoles in RequestWSID
-       -> emit [Invite-granted] via [Subjects reader] for PrincipalPayload.Login and PrincipalPayload.CanonicalLogin in RequestWSID
+       -> emit [Invite-granted] via [Subjects reader] for PrincipalPayload.Login and PrincipalPayload.Alias in RequestWSID
        -> profileWSID = PrincipalPayload.ProfileWSID
        -> if Role(System) already in principals: return
        -> if profileWSID == NullWSID: emit Role(System), return

--- a/uspecs/specs/prod/auth/arch-tokens.md
+++ b/uspecs/specs/prod/auth/arch-tokens.md
@@ -15,10 +15,10 @@ Roles:
 ## Scenarios overview
 
 - **`Issue principal token`**
-  - At the end of sign-in (see [arch-authn.md](./arch-authn.md#sign-in-by-login-or-by-active-alias)) the authentication subsystem builds `PrincipalPayload` and calls `[ITokens].IssueToken(appQName, ttl, &payload)` to mint a `[Principal Token]`. The `Login` field carries the active alias snapshot at issue time, or the canonical login when no alias is set; the `CanonicalLogin` field always carries the canonical login. Both are captured at issue time and are immune to any subsequent change to `[(registry.Login)]` or `[(registry.LoginAlias)]`.
+  - At the end of sign-in (see [arch-authn.md](./arch-authn.md#sign-in-by-login-or-by-active-alias)) the authentication subsystem builds `PrincipalPayload` and calls `[ITokens].IssueToken(appQName, ttl, &payload)` to mint a `[Principal Token]`. The `Login` field carries the canonical primary login (the immutable internal identity); the new `Alias` field carries the active alias snapshot at issue time, or is empty when no alias is set. Both are captured at issue time and are immune to any subsequent change to `[(registry.Login)]` or `[(registry.LoginAlias)]`.
 
 - **`Refresh principal token`**
-  - `@Client` calls `[q.sys.RefreshPrincipalToken]` with the current `[Principal Token]`; the payload is decoded, the same identity (including the captured `Login` and `CanonicalLogin`) is re-encoded with the same TTL/AppQName by `[ITokens].IssueToken`, and the new token is returned. Refresh never re-resolves the login or alias and never updates the captured values.
+  - `@Client` calls `[q.sys.RefreshPrincipalToken]` with the current `[Principal Token]`; the payload is decoded, the same identity (including the captured `Login` and `Alias`) is re-encoded with the same TTL/AppQName by `[ITokens].IssueToken`, and the new token is returned. Refresh never re-resolves the login or alias and never updates the captured values.
 
 - **`Enrich principal token`**
   - `@Client` (basic auth, `WorkspaceOwner`) calls `[q.sys.EnrichPrincipalToken]` with the current `[Principal Token]`; the payload is decoded, every runtime-composed `Principal{Kind: Role}` for the request is folded into `PrincipalPayload.Roles` (deduplicated by `RoleType{WSID, QName}`), and a fresh `[Principal Token]` is minted by `[IAppTokens].IssueToken` with `DefaultPrincipalTokenExpiration`. Unlike refresh, enrich rewrites the `Roles` set; the other identity fields are preserved.
@@ -58,7 +58,7 @@ Payload contract
 ### Token endpoints
 
 - `[q.sys.RefreshPrincipalToken]`
-  - Reads the bearer token from request state via `storages.GetPrincipalTokenFromState`, decodes `PrincipalPayload` through `payloads.GetPayloadRegistry`, and re-issues a token for the same AppQName, duration, and payload. The decoded `Login` and `CanonicalLogin` are preserved verbatim, so the snapshot taken at the original issue time survives the refresh; alias changes performed in the registry between issue and refresh have no effect on the refreshed token.
+  - Reads the bearer token from request state via `storages.GetPrincipalTokenFromState`, decodes `PrincipalPayload` through `payloads.GetPayloadRegistry`, and re-issues a token for the same AppQName, duration, and payload. The decoded `Login` and `Alias` are preserved verbatim, so the snapshot taken at the original issue time survives the refresh; alias changes performed in the registry between issue and refresh have no effect on the refreshed token.
   - impl: [pkg/sys/authnz/impl_refreshprincipaltoken.go#provideRefreshPrincipalTokenExec](../../../../pkg/sys/authnz/impl_refreshprincipaltoken.go)
 
 - `[q.sys.EnrichPrincipalToken]`
@@ -80,8 +80,8 @@ Payload contract
 
 - `[PrincipalPayload]`
   - Identity payload carried by `[Principal Token]`:
-    - `Login` - identifier the subject is known by: the active alias snapshot at issue time, or the canonical login when no alias is set; never re-read on refresh
-    - `CanonicalLogin` - canonical login resolved at issue time; never re-read on refresh
+    - `Login` - canonical primary login resolved at issue time: the immutable internal identity used for credentials, routing, authorization, quotas, and metrics; never re-read on refresh
+    - `Alias` - active alias snapshot at issue time, empty when no alias is set; never re-read on refresh
     - `SubjectKind` - `User` or `Device`
     - `ProfileWSID` - profile workspace of the subject (`NullWSID` for system-only tokens)
     - `Roles []{WSID, QName}` - workspace-scoped roles emitted on every request; for `IsAPIToken=true` these are the only persisted-role source (alongside the implicit `AuthenticatedUser`)
@@ -98,7 +98,7 @@ Payload contract
 
 ```text
 [q.registry.IssuePrincipalToken] (see arch-authn.md)
-  -> build PrincipalPayload{Login=alias snapshot or canonical login, CanonicalLogin, SubjectKind, ProfileWSID, GlobalRoles}
+  -> build PrincipalPayload{Login=canonical login, Alias=active alias snapshot, SubjectKind, ProfileWSID, GlobalRoles}
   -> [ITokens].IssueToken(appQName, ttl, &payload)
   -> @Client: principalToken, profileWSID
 ```
@@ -111,10 +111,10 @@ Payload contract
        -> storages.GetPrincipalTokenFromState(state) -> current token
        -> payloads.GetPayloadRegistry([ITokens], token, &payload) -> decode + appQName + ttl
        -> [ITokens].IssueToken(appQName, ttl, &payload)
-  -> @Client: principalToken (new), Login and CanonicalLogin unchanged from original issue
+  -> @Client: principalToken (new), Login and Alias unchanged from original issue
 ```
 
-The `Login` and `CanonicalLogin` fields are taken verbatim from the decoded payload and are not re-resolved against `[(registry.Login)]` or `[(registry.LoginAlias)]`. A login whose alias was set, replaced, or cleared after the original issue continues to refresh with the snapshotted `Login` until the next sign-in. To pick up a new alias the caller must sign in again rather than refresh.
+The `Login` and `Alias` fields are taken verbatim from the decoded payload and are not re-resolved against `[(registry.Login)]` or `[(registry.LoginAlias)]`. A login whose alias was set, replaced, or cleared after the original issue continues to refresh with the snapshotted `Alias` until the next sign-in. To pick up a new alias the caller must sign in again rather than refresh.
 
 ### Enrich principal token
 

--- a/uspecs/specs/prod/auth/arch.md
+++ b/uspecs/specs/prod/auth/arch.md
@@ -21,7 +21,7 @@ Roles:
   - Request processing composes a principal set from four origin-perspective sources — invite-granted roles (`[(cdoc.sys.Subject)]` rows written by `[[Workspace membership]]`), token-carried roles (`PrincipalPayload.Roles` and `GlobalRoles` snapshotted by `[[Authentication]]`), request-context roles (derived at composition time from request state), and anonymous-grants (when no token is presented) — and evaluates ACL rules against it.
 
 - **`Manage tokens`**
-  - Principal tokens are issued, refreshed, and validated; refresh preserves the identity payload including the `Login` and `CanonicalLogin` captured at issue time.
+  - Principal tokens are issued, refreshed, and validated; refresh preserves the identity payload including the `Login` and `Alias` captured at issue time.
 
 - **`Manage membership`**
   - Invite lifecycle creates subjects doc and joined-workspace records, updates roles, and removes members.
@@ -84,7 +84,7 @@ Shared concepts
   - impl: [pkg/sys/invite/impl_applyinviteevents.go](../../../../pkg/sys/invite/impl_applyinviteevents.go)
 
 - `[Principal Token]`
-  - Bearer token carrying `PrincipalPayload(Login, CanonicalLogin, SubjectKind, ProfileWSID, Roles, GlobalRoles, IsAPIToken)`. Produced by `[[Authentication]]` and `[[Token management]]`, consumed by `[[Authorization]]` on every request.
+  - Bearer token carrying `PrincipalPayload(Login, Alias, SubjectKind, ProfileWSID, Roles, GlobalRoles, IsAPIToken)`. Produced by `[[Authentication]]` and `[[Token management]]`, consumed by `[[Authorization]]` on every request.
   - decl: [pkg/itokens-payloads/types.go#PrincipalPayload](../../../../pkg/itokens-payloads/types.go)
 
 - `[Auth boundary]`

--- a/uspecs/specs/prod/auth/authn--td.md
+++ b/uspecs/specs/prod/auth/authn--td.md
@@ -170,7 +170,7 @@ State and workspace lifecycle
   - impl: [pkg/registry/impl_setloginalias.go#applySetLoginAlias](../../../../pkg/registry/impl_setloginalias.go)
 
 - `[/q.registry.IssuePrincipalToken/]`
-  - Resolves sign-in by primary login or active alias, validates password and profile readiness, applies TTL policy, and issues principal tokens. On the alias path, it reads `[(registry.LoginAlias)]`, fetches the source `[(registry.Login)]` with `q.sys.GetCDoc`, validates `Login.Alias` against the submitted identifier, and snapshots the presented identifier into `Login` (the active alias, or the canonical login when none is set) and the canonical login into `CanonicalLogin`; payload-field semantics are owned by [arch-tokens.md](./arch-tokens.md).
+  - Resolves sign-in by primary login or active alias, validates password and profile readiness, applies TTL policy, and issues principal tokens. On the alias path, it reads `[(registry.LoginAlias)]`, fetches the source `[(registry.Login)]` with `q.sys.GetCDoc`, validates `Login.Alias` against the submitted identifier, and snapshots the canonical login into `Login` and the active alias (empty when none is set) into `Alias`; payload-field semantics are owned by [arch-tokens.md](./arch-tokens.md).
   - decl: [pkg/registry/appws.vsql#IssuePrincipalToken](../../../../pkg/registry/appws.vsql)
   - impl: [pkg/registry/impl_issueprincipaltoken.go#provideIssuePrincipalTokenExec](../../../../pkg/registry/impl_issueprincipaltoken.go)
 
@@ -200,7 +200,7 @@ State and workspace lifecycle
   - Token primitives and `PrincipalPayload` are owned by [arch-tokens.md](./arch-tokens.md#token-primitives); referenced here as the layer that issues and validates the tokens carried by the authn HTTP flows.
 
 - `[/q.sys.RefreshPrincipalToken/]`
-  - Issues a replacement principal token from the existing principal token payload and duration, preserving identity fields including `Login` and `CanonicalLogin`.
+  - Issues a replacement principal token from the existing principal token payload and duration, preserving identity fields including `Login` and `Alias`.
   - decl: [pkg/sys/sys.vsql#RefreshPrincipalToken](../../../../pkg/sys/sys.vsql)
   - impl: [pkg/sys/authnz/impl_refreshprincipaltoken.go#provideRefreshPrincipalTokenExec](../../../../pkg/sys/authnz/impl_refreshprincipaltoken.go)
 
@@ -414,7 +414,7 @@ State and workspace lifecycle
   -> [(registry.LoginAlias)]: active alias hit
   -> [/q.sys.GetCDoc/]: read source [(registry.Login)] in SourceAppWSID
   -> [(registry.Login)]: Alias equals submitted alias; password hash matches and profileWSID is non-zero
-  -> [Token service]: issue principal token with Login (active alias) and CanonicalLogin (canonical login)
+  -> [Token service]: issue principal token with Login (canonical login) and Alias (active alias)
   -> @Client: principalToken, expiresInSeconds, profileWSID
 ```
 
@@ -469,7 +469,7 @@ State and workspace lifecycle
   -> [Auth login handler]
   -> [/q.registry.IssuePrincipalToken/]
   -> [(registry.Login)]: login, alias, subject kind, profileWSID
-  -> [Token service]: PrincipalPayload(Login, CanonicalLogin, SubjectKind, ProfileWSID)
+  -> [Token service]: PrincipalPayload(Login, Alias, SubjectKind, ProfileWSID)
   -> @Client: principalToken
 ```
 
@@ -500,7 +500,7 @@ State and workspace lifecycle
   -> [API v2 auth routes]
   -> [Auth refresh handler]
   -> [/q.sys.RefreshPrincipalToken/]
-  -> [Token service]: validate existing token and issue replacement preserving Login, CanonicalLogin, SubjectKind, ProfileWSID from the input token
+  -> [Token service]: validate existing token and issue replacement preserving Login, Alias, SubjectKind, ProfileWSID from the input token
   -> [Auth refresh handler]
   -> @Client: new principalToken, expiresInSeconds, profileWSID
 ```
@@ -509,10 +509,10 @@ State and workspace lifecycle
 
 ```text
 @Client
-  -> [Token service]: principal token already issued with Login = j.smith, CanonicalLogin = jsmith
+  -> [Token service]: principal token already issued with Login = jsmith, Alias = j.smith
   -> @System: update or clear login alias
   -> [Token service]: existing token remains valid until normal expiration
-  -> @Client: existing token payload still carries Login = j.smith, CanonicalLogin = jsmith
+  -> @Client: existing token payload still carries Login = jsmith, Alias = j.smith
 ```
 
 ### Password lifecycle

--- a/uspecs/specs/prod/auth/authn.feature
+++ b/uspecs/specs/prod/auth/authn.feature
@@ -93,6 +93,25 @@ Feature: Authentication
       Then the alias change is rejected
       And the response indicates incorrect login format
 
+  Rule: Login alias state visibility
+
+    Scenario Outline: Reading a login's alias state requires a System Principal Token
+      Given a user login exists with an active login alias
+      When <caller> reads the login's alias state
+      Then the read <result>
+
+      Examples:
+        | caller                                    | result      |
+        | System                                    | succeeds    |
+        | a caller without a System Principal Token | is rejected |
+
+    Scenario: A System read returns the login's alias lifecycle fields
+      Given a user login "jsmith" with active alias "j.smith", no alias change in progress, and no alias error
+      When System reads the login's alias state
+      Then Alias is "j.smith"
+      And AliasInProc is 0
+      And AliasError is empty
+
   Rule: Sign-in and profile readiness
 
     Scenario Outline: Subject signs in after profile workspace is ready
@@ -151,7 +170,7 @@ Feature: Authentication
       Given "<subject>" login exists
       And the profile workspace for "<subject>" is ready
       When Client signs in with login and password
-      Then the issued principal token identifies login, canonical login, subject kind, and profileWSID
+      Then the issued principal token identifies its login (the canonical login), subject kind, and profileWSID
 
       Examples:
         | subject |
@@ -173,25 +192,26 @@ Feature: Authentication
       Given Client has a valid principal token
       When Client refreshes the principal token
       Then the response contains a new principalToken
-      And the new principalToken preserves login, canonical login, subject kind, and profileWSID from the input token
+      And the new principalToken preserves the login (canonical), alias, subject kind, and profileWSID from the input token
 
-    Scenario: Principal token uses the active alias as login after alias sign-in
-      Given a user login exists with an active login alias
+    Scenario Outline: Principal token carries the canonical login and the active alias
+      Given a user login that <alias state>
       And the profile workspace for the user is ready
-      When Client signs in with alias and password
-      Then the issued principal token's login is the active alias and its canonical login is the original login
+      When Client signs in with <identifier> and password
+      Then the issued principal token's login is the canonical login
+      And its alias is <alias value>
 
-    Scenario: Principal token uses the active alias as login when signing in with the original login
-      Given a user login exists with an active login alias
-      And the profile workspace for the user is ready
-      When Client signs in with original login and password
-      Then the issued principal token's login is the active alias and its canonical login is the original login
+      Examples:
+        | alias state         | identifier     | alias value      |
+        | has an active alias | alias          | the active alias |
+        | has an active alias | original login | the active alias |
+        | has no active alias | original login | empty            |
 
-    Scenario: Existing principal token retains login and canonical login after alias changes
+    Scenario: Existing principal token retains login and alias after alias changes
       Given Client has a valid principal token issued while a login alias is active
       When System updates or clears that login alias
       Then the existing principal token remains valid until normal expiration
-      And the existing principal token retains the login and canonical login captured at issue time
+      And the existing principal token retains the login (canonical) and alias captured at issue time
 
   Rule: Password lifecycle
 


### PR DESCRIPTION
```yaml
change_id: 2606191522-token-claim-login-canonical
type: feat
issue_url: https://untill.atlassian.net/browse/AIR-4327
domains: [prod]
scope: [auth]
breaking: true
```
## Why

The previous change made the `Login` token claim carry the alias snapshot, silently switching every existing reader from the canonical identity to the alias and breaking the frontend change-password flow. Restoring `Login` to the canonical identity is safe-by-default: identity used for credentials, routing, authorization, quotas, and metrics stays correct with no migration, while showing the alias becomes an explicit opt-in.

## What

In the prod auth domain, principal-token claims are restructured so the canonical identity is the default:

- The `Login` claim again carries the canonical primary login (its historical meaning), so all identity consumers read the canonical login without changes.
- A new `Alias` claim carries the active alias snapshot at issue time, and is empty when no alias is set.
- Authorization resolves subject roles against both the canonical login and the active alias, so role assignments keyed on either remain effective.
- This supersedes the earlier alias-in-Login contract; tokens minted under the old contract self-heal within token TTL on re-sign-in or refresh.

## How

Decisions:

- In `pkg/itokens-payloads/types.go`, rename the `CanonicalLogin` field to `Login` with no json tag so the wire claim `Login` again carries the canonical identity; rename the `PresentedLogin` field to `Alias` and drop its `json:"Login"` tag so it serializes under a new `Alias` claim, left empty when no alias is set.
- In `pkg/itokens-payloads/consts.go`, set the system principal's canonical `Login` to `"system"` and leave `Alias` empty.
- In `pkg/registry/impl_issueprincipaltoken.go`, set `Login` directly from `loginForSignIn.canonicalLogin` and `Alias` from `loginForSignIn.alias` (no fallback to canonical), so `Alias` is empty when no alias exists.
- In `pkg/iauthnzimpl/impl.go`, key the internal identity (`loginName`) on `Login` with a fallback to `Alias` for legacy/system tokens, and keep resolving subject roles against both `Login` and `Alias` with the existing dedup.
- In `pkg/processors/n10n/impl_subscribeandwatch.go` and the `pkg/vit` test helper, read/set the internal identity from `Login` (fallback `Alias`).
- Remove the dormant `GRANT SELECT ON TABLE Login TO sys.ProfileOwner` in `pkg/registry/appws.vsql`: `ProfileOwner` is only ever emitted in a subject's own profile workspace, never in the registry app workspace where the `Login` table lives, so the grant confers no client read access today. Removing it makes the schema match the System-only read contract specified by the `Login alias state visibility` feature rule. Non-breaking: no client ever had effective read access through it.
- Token transition relies on token TTL plus self-healing on re-sign-in/refresh; no data migration and no explicit deployment cutover orchestration.
- Update the affected `*_test.go` payload constructions and the auth specs/diagrams to reflect `Login` = canonical and `Alias` = active alias.

Out of scope:

- Frontend `Alias` display reader for change-password (optional AIR-4292 follow-up).
- Any other authentication or authorization behavior beyond the claim contract.

References:


---
Content omitted. See change.md for full details.
