### PR TITLE
fix(storage): Fix SIGSEGV during async actualizer CUD logging [AIR-4355]

### DIFF
--- a/pkg/istructsmem/event-types.go
+++ b/pkg/istructsmem/event-types.go
@@ -178,6 +178,22 @@ func (ev *eventType) loadFromBytes(in []byte) (err error) {
 	return nil
 }
 
+// newStoredEvent builds a stored event that owns a private copy of data.
+//
+// The storage read callback provides data valid only during the call (it may
+// reference memory-mapped storage), whereas the returned event keeps zero-copy
+// views into its bytes for its whole lifetime, so the event must own the bytes.
+func newStoredEvent(appCfg *AppConfigType, data []byte) (*eventType, error) {
+	ev := newEvent(appCfg)
+	ev.buffer = bytespool.Get()
+	ev.buffer.B = append(ev.buffer.B[:0], data...)
+	if err := ev.loadFromBytes(ev.buffer.B); err != nil {
+		ev.Free()
+		return nil, err
+	}
+	return ev, nil
+}
+
 // Retrieves ID for event command name
 func (ev *eventType) QNameID() (id istructs.QNameID) {
 	if id, err := ev.appCfg.qNames.ID(ev.QName()); err == nil {

--- a/pkg/istructsmem/event-types_test.go
+++ b/pkg/istructsmem/event-types_test.go
@@ -221,6 +221,8 @@ func testEventBuilderCore(t *testing.T, cachedPLog bool) {
 					func(plogOffset istructs.Offset, ev istructs.IPLogEvent) (err error) {
 						defer ev.Release()
 						cnt++
+						// sequentially-read event must own its bytes so it stays valid after the read callback returns
+						require.NotNil(ev.(*eventType).buffer)
 						switch ev.QName() {
 						case test.saleCmdName:
 							require.Equal(test.plogOfs, plogOffset)

--- a/pkg/istructsmem/impl.go
+++ b/pkg/istructsmem/impl.go
@@ -463,11 +463,11 @@ func (e *appEventsType) ReadPLog(ctx context.Context, partition istructs.Partiti
 			err = e.app.config.storage.Read(ctx, pKey, cFrom, cTo, func(ccols, data []byte) error {
 				count++
 				ofs := glueLogOffset(ofsHi, binary.BigEndian.Uint16(ccols))
-				event := newEvent(e.app.config)
-				if err = event.loadFromBytes(data); err == nil {
-					err = cb(ofs, event)
+				event, err := newStoredEvent(e.app.config, data)
+				if err != nil {
+					return err
 				}
-				return err
+				return cb(ofs, event)
 			})
 			return (err == nil) && (count > 0), err // stop iterate parts if error or no events in last partition
 		})
@@ -504,11 +504,11 @@ func (e *appEventsType) ReadWLog(ctx context.Context, workspace istructs.WSID, o
 			err = e.app.config.storage.Read(ctx, pKey, cFrom, cTo, func(ccols, data []byte) error {
 				count++
 				ofs := glueLogOffset(ofsHi, binary.BigEndian.Uint16(ccols))
-				event := newEvent(e.app.config)
-				if err = event.loadFromBytes(data); err == nil {
-					err = cb(ofs, event)
+				event, err := newStoredEvent(e.app.config, data)
+				if err != nil {
+					return err
 				}
-				return err
+				return cb(ofs, event)
 			})
 			return (err == nil) && (count > 0), err // stop iterate parts if error or no events in last partition
 		})

--- a/pkg/sys/it/bug_test.go
+++ b/pkg/sys/it/bug_test.go
@@ -173,7 +173,7 @@ func TestBug_BatchedLogEventsMustOwnTheirBytes(t *testing.T) {
 	for i := range eventsCnt {
 		name := fmt.Sprintf("buyer-%d", i)
 		expected[name] = true
-		body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"%s","name":"%s"}}]}`, airTablePlan, name)
+		body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":%q,"name":%q}}]}`, airTablePlan, name)
 		vit.PostWS(ws, "c.sys.CUD", body)
 	}
 

--- a/pkg/sys/it/bug_test.go
+++ b/pkg/sys/it/bug_test.go
@@ -5,12 +5,14 @@
 package sys_it
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,9 +20,13 @@ import (
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
+	"github.com/voedger/voedger/pkg/goutils/timeu"
+	"github.com/voedger/voedger/pkg/istorage"
+	"github.com/voedger/voedger/pkg/istorage/bbolt"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/sys"
 	it "github.com/voedger/voedger/pkg/vit"
+	"github.com/voedger/voedger/pkg/vvm"
 )
 
 type rr struct {
@@ -146,4 +152,97 @@ func TestWSNameCausesMaxPseudoWSID(t *testing.T) {
 
 	// need to wait for init anyway, otherwise vit.Time.Add(1 day) on next test -> token expired during the device ws init
 	vit.SignIn(deviceLogin)
+}
+
+// AIR-4355: events read sequentially from the log (ReadToTheEnd) and retained after the read
+// transaction closed must own their bytes. The storage read callback hands the event a zero-copy
+// view that, with a bbolt-backed storage, aliases mmap pages unmapped once the file grows and
+// re-maps - reading a retained event afterwards yields garbage or SIGSEGV.
+func TestBug_BatchedLogEventsMustOwnTheirBytes(t *testing.T) {
+	require := require.New(t)
+
+	cfg := getBboltVITCfg(t)
+	vit := it.NewVIT(t, &cfg)
+	defer vit.TearDown()
+
+	ws := vit.WS(istructs.AppQName_test1_app1, "test_ws")
+	airTablePlan := appdef.NewQName("app1pkg", "air_table_plan")
+
+	const eventsCnt = 16
+	expected := make(map[string]bool, eventsCnt)
+	for i := range eventsCnt {
+		name := fmt.Sprintf("buyer-%d", i)
+		expected[name] = true
+		body := fmt.Sprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"%s","name":"%s"}}]}`, airTablePlan, name)
+		vit.PostWS(ws, "c.sys.CUD", body)
+	}
+
+	// sequentially read the whole WLog and retain the returned events
+	as, err := vit.BuiltIn(istructs.AppQName_test1_app1)
+	require.NoError(err)
+
+	var events []istructs.IWLogEvent
+	require.NoError(as.Events().ReadWLog(context.Background(), ws.WSID, istructs.FirstOffset, istructs.ReadToTheEnd,
+		func(_ istructs.Offset, event istructs.IWLogEvent) error {
+			events = append(events, event)
+			return nil
+		}))
+
+	// churn the very same bbolt storage the events were read from (public storage API only) so the
+	// file grows and re-maps, unmapping the pages the retained events may still point into
+	storage, err := vit.IAppStorageProvider.AppStorage(istructs.AppQName_test1_app1)
+	require.NoError(err)
+
+	small := bytes.Repeat([]byte{0xCD}, 96)
+	smallBatch := make([]istorage.BatchItem, 0, 8192)
+	for i := range 8192 {
+		smallBatch = append(smallBatch, istorage.BatchItem{
+			PKey: []byte("AIR4355-churn-small"), CCols: fmt.Appendf(nil, "%010d", i), Value: small,
+		})
+	}
+	require.NoError(storage.PutBatch(smallBatch))
+
+	large := bytes.Repeat([]byte{0xAB}, int(appdef.MaxFieldLength))
+	for round := range 2 {
+		largeBatch := make([]istorage.BatchItem, 0, 800)
+		for i := range 800 {
+			largeBatch = append(largeBatch, istorage.BatchItem{
+				PKey: fmt.Appendf(nil, "AIR4355-churn-large-%d", round), CCols: fmt.Appendf(nil, "%010d", i), Value: large,
+			})
+		}
+		require.NoError(storage.PutBatch(largeBatch))
+	}
+
+	// the retained events must still expose their original field values; with the bug they read
+	// freed/re-mapped memory here (mismatch or SIGSEGV)
+	found := make(map[string]bool, eventsCnt)
+	for _, event := range events {
+		event.CUDs(func(rec istructs.ICUDRow) bool {
+			if rec.QName() == airTablePlan {
+				found[rec.AsString("name")] = true
+			}
+			return true
+		})
+		event.Release()
+	}
+	for name := range expected {
+		require.True(found[name], name)
+	}
+}
+
+func getBboltVITCfg(t *testing.T) it.VITConfig {
+	dbDir, err := os.MkdirTemp("", "AIR-4355") //nolint:usetesting // bbolt driver does not close the connection so t.TempDir() fails
+	require.NoError(t, err)
+
+	return it.NewOwnVITConfig(
+		it.WithApp(istructs.AppQName_test1_app1, it.ProvideApp1,
+			it.WithUserLogin("login", "pwd"),
+			it.WithChildWorkspace(it.QNameApp1_TestWSKind, "test_ws", "", "", "login", map[string]interface{}{"IntFld": 42}),
+		),
+		it.WithVVMConfig(func(cfg *vvm.VVMConfig) {
+			cfg.StorageFactory = func(time timeu.ITime) (istorage.IAppStorageFactory, error) {
+				return bbolt.Provide(bbolt.ParamsType{DBDir: dbDir}, time), nil
+			}
+		}),
+	)
 }

--- a/uspecs/changes/archive/2606/2606291119-fix-sigsegv-during-tests/change.md
+++ b/uspecs/changes/archive/2606/2606291119-fix-sigsegv-during-tests/change.md
@@ -1,0 +1,77 @@
+---
+change_id: 2606290807-fix-sigsegv-during-tests
+type: fix
+issue_url: https://untill.atlassian.net/browse/AIR-4355
+domains: [prod]
+scope: [storage]
+---
+
+# Change request: Fix SIGSEGV during async actualizer CUD logging
+
+Refs:
+
+- [AIR-4355: voedger: fix SIGSEGV during tests](./issue-AIR-4355.md)
+
+## Why
+
+The airsbp3 test suite aborts intermittently with a fatal SIGSEGV, breaking CI and masking other failures. The crash stems from sequentially read log events referencing transient, memory-mapped storage memory that is invalidated once the read transaction closes, so any deferred access (such as verbose CUD logging in the async actualizer) reads freed memory.
+
+## What
+
+Symptom: The async actualizer's verbose CUD logging faults with a fatal SIGSEGV while reading a record's fields, aborting the test process.
+
+```text
+async actualizer batch-reads PLog (ReadToTheEnd)
+      |
+      v
+ReadPLog/ReadWLog sequential branch (istructsmem/impl.go)   <-- fault: builds event via loadFromBytes over transient storage-callback bytes; event does not own them
+      |
+      v
+storage read transaction closes; bbolt remaps the mmap region
+      |
+      v
+asyncProjector.DoAsync logs CUDs
+  -> FieldsToMap -> rowType.SpecifiedValues -> dynobuffers.IterateFields
+      |
+      v
+flatbuffers reads dangling mmap memory -> SIGSEGV   (symptom)
+```
+
+Corrected behavior: Sequentially read PLog/WLog events own a private, pooled copy of their bytes, so they stay valid after the storage read callback returns and deferred CUD logging no longer faults.
+
+## How
+
+Decisions:
+
+- Fix at the `istructsmem` layer, not per driver: the sequential `ReadPLog`/`ReadWLog` branch builds events via `newStoredEvent`, which copies the storage-callback bytes into a pooled buffer the event owns (`pkg/istructsmem/event-types.go`), so events stay valid after the read transaction closes regardless of any driver's buffer-lifetime contract
+- Only `bbolt` can trigger the defect: its `Read` hands the callback a zero-copy view into the memory-mapped file, valid only inside the read transaction; `mem`, `cas` and `amazondb` copy into Go-managed memory, so they are safe
+- Reproduce with a real-`bbolt` integration test (no driver/engine instrumentation): write events, sequentially read them with `ReadToTheEnd` while retaining the returned events, then drive additional storage writes that free the event pages and make `bbolt` grow and re-map its file; afterwards the retained events read freed/remapped memory on the unfixed code and stay valid on the fixed code
+- Place the reproduction in `sys_it` with an owned VIT config that provides `bbolt` as the storage, so `istructsmem` keeps no dependency on a storage driver; drive writes through the public command pipeline (`c.sys.CUD`) and read via `Events().ReadWLog(...ReadToTheEnd)` so the test exercises the actual fixed code path
+
+Out of scope:
+
+- Hardening `bbolt`'s `TTLGet`, which (unlike every other driver) returns a zero-copy mmap view; no current path retains it, so it is tracked separately
+- Bumping the `voedger` dependency in `airs-bp3` to pick up the fix
+
+References:
+
+- [sequential PLog/WLog read fix](../../../../../pkg/istructsmem/impl.go)
+- [event that owns its bytes](../../../../../pkg/istructsmem/event-types.go)
+- [bbolt read hands back mmap views](../../../../../pkg/istorage/bbolt/impl.go)
+- [transient ReadCallback contract](../../../../../pkg/istorage/interface.go)
+- [sys_it reproduction test](../../../../../pkg/sys/it/bug_test.go)
+
+## Construction
+
+- [x] update: [sys/it/bug_test.go](../../../../../pkg/sys/it/bug_test.go)
+  - add: `TestBug_BatchedLogEventsMustOwnTheirBytes` - a real-`bbolt` VIT integration test that posts `c.sys.CUD` events, sequentially reads the whole WLog (`ReadToTheEnd`) while retaining the returned events, then churns the same storage via the public API so `bbolt` frees pages and grows/re-maps its file, and finally asserts the retained events still expose their original CUD field values
+  - add: `getBboltVITCfg` helper that builds a `NewOwnVITConfig` wiring `bbolt.Provide` over a temp dir as the `StorageFactory`
+
+- [x] update: [istructsmem/event-types_test.go](../../../../../pkg/istructsmem/event-types_test.go)
+  - add: white-box assertion in the sequential-read subtest that the read event owns its `buffer`
+
+- [x] update: [istructsmem/event-types.go](../../../../../pkg/istructsmem/event-types.go)
+  - add: `newStoredEvent` helper that builds an event owning a private, pooled copy of the storage-callback bytes, so the event stays valid after the read transaction closes
+
+- [x] update: [istructsmem/impl.go](../../../../../pkg/istructsmem/impl.go)
+  - update: the sequential (`ReadToTheEnd`) branch of `ReadPLog` and `ReadWLog` to build events via `newStoredEvent` instead of `loadFromBytes` over the transient storage-callback bytes

--- a/uspecs/changes/archive/2606/2606291119-fix-sigsegv-during-tests/issue-AIR-4355.md
+++ b/uspecs/changes/archive/2606/2606291119-fix-sigsegv-during-tests/issue-AIR-4355.md
@@ -1,0 +1,57 @@
+# voedger: fix SIGSEGV during tests
+
+- URL: https://untill.atlassian.net/browse/AIR-4355
+- ID: AIR-4355
+- State: in-progress
+- Author: Denis Gribanov
+- Assignees: Denis Gribanov
+- Labels: none
+
+## Description
+
+https://github.com/untillpro/airs-bp3/issues/2586
+
+```text
+unexpected fault address 0x7f7b39da2dcd
+fatal error: fault
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x7f7b39da2dcd pc=0xcbdcc4]
+
+goroutine 6359 gp=0xc0027ffc20 m=7 mp=0xc003efe008 [running]:
+runtime.throw({0x1ef6ea0?, 0xc0036a7320?})
+	runtime/panic.go:1229 +0x48
+runtime.sigpanic()
+	runtime/signal_unix.go:945 +0x285
+github.com/google/flatbuffers/go.GetInt32(...)
+	flatbuffers@v25.12.19+incompatible/go/encode.go:86
+github.com/google/flatbuffers/go.(*Table).Offset(0xc002d01750, 0x4)
+	flatbuffers@v25.12.19+incompatible/go/table.go:15 +0xc4
+github.com/untillpro/dynobuffers.(*Buffer).getFieldUOffsetTByOrder(0xc002d01730, 0x0)
+	dynobuffers@v0.0.0-20251212090544-93da105bf1da/dynobuffers.go:327 +0x58
+github.com/untillpro/dynobuffers.(*Buffer).IterateFields(0xc002d01730, ...)
+	dynobuffers@v0.0.0-20251212090544-93da105bf1da/dynobuffers.go:2138 +0x117
+github.com/voedger/voedger/pkg/istructsmem.(*rowType).SpecifiedValues(0xc002b7f880, 0xc0036eed20)
+	voedger/pkg/istructsmem/tables-types.go:149 +0x69c
+github.com/voedger/voedger/pkg/coreutils.FieldsToMap(...)
+	voedger/pkg/coreutils/objectreader.go:114 +0x491
+github.com/voedger/voedger/pkg/processors.LogEventAndCUDs-range1(...)
+	voedger/pkg/processors/utils.go:170 +0x350
+github.com/voedger/voedger/pkg/istructsmem.(*cudType).enumRecs(...)
+	voedger/pkg/istructsmem/event-types.go:454
+github.com/voedger/voedger/pkg/istructsmem.(*eventType).CUDs(0xc002d1e288, 0xc00320fb00)
+	voedger/pkg/istructsmem/event-types.go:293 +0xbf
+github.com/voedger/voedger/pkg/processors.LogEventAndCUDs(...)
+	voedger/pkg/processors/utils.go:159 +0xa71
+github.com/voedger/voedger/pkg/processors/actualizers.logEventAndCUDs(...)
+	voedger/pkg/processors/actualizers/async.go:476 +0x306
+github.com/voedger/voedger/pkg/processors/actualizers.(*asyncProjector).DoAsync(...)
+	voedger/pkg/processors/actualizers/async.go:439 +0x8c5
+github.com/voedger/voedger/pkg/pipeline.(*WiredOperator).doAsync(...)
+	voedger/pkg/pipeline/wired-operator.go:90 +0x103
+github.com/voedger/voedger/pkg/pipeline.puller_async(0xc001d32930)
+	voedger/pkg/pipeline/async.go:36 +0x46f
+github.com/voedger/voedger/pkg/pipeline.NewAsyncPipeline.gowrap1()
+	voedger/pkg/pipeline/async-pipeline-impl.go:54 +0x2f
+runtime.goexit({})
+	runtime/asm_amd64.s:1771 +0x1
+created by github.com/voedger/voedger/pkg/pipeline.NewAsyncPipeline in goroutine 5582
+```


### PR DESCRIPTION
```yaml
change_id: 2606290807-fix-sigsegv-during-tests
type: fix
issue_url: https://untill.atlassian.net/browse/AIR-4355
domains: [prod]
scope: [storage]
```
## Why

The airsbp3 test suite aborts intermittently with a fatal SIGSEGV, breaking CI and masking other failures. The crash stems from sequentially read log events referencing transient, memory-mapped storage memory that is invalidated once the read transaction closes, so any deferred access (such as verbose CUD logging in the async actualizer) reads freed memory.

## What

Symptom: The async actualizer's verbose CUD logging faults with a fatal SIGSEGV while reading a record's fields, aborting the test process.

```text
async actualizer batch-reads PLog (ReadToTheEnd)
      |
      v
ReadPLog/ReadWLog sequential branch (istructsmem/impl.go)   <-- fault: builds event via loadFromBytes over transient storage-callback bytes; event does not own them
      |
      v
storage read transaction closes; bbolt remaps the mmap region
      |
      v
asyncProjector.DoAsync logs CUDs
  -> FieldsToMap -> rowType.SpecifiedValues -> dynobuffers.IterateFields
      |
      v
flatbuffers reads dangling mmap memory -> SIGSEGV   (symptom)
```

Corrected behavior: Sequentially read PLog/WLog events own a private, pooled copy of their bytes, so they stay valid after the storage read callback returns and deferred CUD logging no longer faults.

## How

Decisions:

- Fix at the `istructsmem` layer, not per driver: the sequential `ReadPLog`/`ReadWLog` branch builds events via `newStoredEvent`, which copies the storage-callback bytes into a pooled buffer the event owns (`pkg/istructsmem/event-types.go`), so events stay valid after the read transaction closes regardless of any driver's buffer-lifetime contract
- Only `bbolt` can trigger the defect: its `Read` hands the callback a zero-copy view into the memory-mapped file, valid only inside the read transaction; `mem`, `cas` and `amazondb` copy into Go-managed memory, so they are safe


---
Content omitted. See change.md for full details.
