### PR TITLE
fix(routing): Correct Retry-After header emission on router error responses [AIR-4175]

### DIFF
--- a/pkg/router/impl_blob.go
+++ b/pkg/router/impl_blob.go
@@ -8,7 +8,6 @@ package router
 import (
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/gorilla/mux"
 	"github.com/voedger/voedger/pkg/appdef"
@@ -26,8 +25,7 @@ func (s *routerService) blobHTTPRequestHandler_Write(numsAppsWorkspaces map[appd
 			newBLOBOKResponseIniter(rw, http.StatusOK), req.Body, func(sysErr coreutils.SysError) {
 				writeCommonError_V1(rw, sysErr, sysErr.HTTPStatus)
 			}, s.requestSender) {
-			rw.WriteHeader(http.StatusServiceUnavailable)
-			rw.Header().Add("Retry-After", strconv.Itoa(DefaultRetryAfterSecondsOn503))
+			replyServiceUnavailable(rw)
 		}
 	})
 }
@@ -42,8 +40,7 @@ func (s *routerService) blobHTTPRequestHandler_Read(numsAppsWorkspaces map[appde
 			newBLOBOKResponseIniter(rw, http.StatusOK), func(sysErr coreutils.SysError) {
 				writeCommonError_V1(rw, sysErr, sysErr.HTTPStatus)
 			}, existingBLOBIDOrSUID, s.requestSender, iblobstoragestg.RLimiter_Null) {
-			rw.WriteHeader(http.StatusServiceUnavailable)
-			rw.Header().Add("Retry-After", strconv.Itoa(DefaultRetryAfterSecondsOn503))
+			replyServiceUnavailable(rw)
 		}
 	})
 }

--- a/pkg/router/impl_test.go
+++ b/pkg/router/impl_test.go
@@ -172,7 +172,7 @@ type testObject struct {
 func TestSysErrorHeaders(t *testing.T) {
 	require := require.New(t)
 	sysErr := coreutils.SysError{HTTPStatus: http.StatusTooManyRequests, Message: "rate limit exceeded"}.
-		AddHeader("Retry-After", "10")
+		AddHeader(httpu.RetryAfter, "10")
 	router := setUp(t, func(requestCtx context.Context, request bus.Request, responder bus.IResponder) {
 		go func() {
 			err := responder.Respond(bus.ResponseMeta{ContentType: httpu.ContentType_ApplicationJSON, StatusCode: sysErr.HTTPStatus}, sysErr)
@@ -232,6 +232,23 @@ func TestRetryAfter_writeCommonError_V1(t *testing.T) {
 
 	require.Equal(http.StatusTooManyRequests, resp.StatusCode)
 	require.Equal("7", resp.Header.Get(httpu.RetryAfter))
+}
+
+func TestRetryAfter_replyErr(t *testing.T) {
+	require := require.New(t)
+	sysErr := coreutils.SysError{HTTPStatus: http.StatusTooManyRequests, Message: "rate limit exceeded"}.
+		AddHeader(httpu.RetryAfter, "8")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		replyErr(w, sysErr)
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusTooManyRequests, resp.StatusCode)
+	require.Equal("8", resp.Header.Get(httpu.RetryAfter))
 }
 
 type busyBlobRequestHandler struct{}

--- a/pkg/router/impl_test.go
+++ b/pkg/router/impl_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -29,10 +30,12 @@ import (
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/goutils/testingu"
+	"github.com/voedger/voedger/pkg/iblobstorage"
 	"github.com/voedger/voedger/pkg/in10n"
 	"github.com/voedger/voedger/pkg/in10nmem"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/pipeline"
+	blobprocessor "github.com/voedger/voedger/pkg/processors/blobber"
 )
 
 const (
@@ -183,7 +186,85 @@ func TestSysErrorHeaders(t *testing.T) {
 	defer resp.Body.Close()
 
 	require.Equal(http.StatusTooManyRequests, resp.StatusCode)
-	require.Equal("10", resp.Header.Get("Retry-After"))
+	require.Equal("10", resp.Header.Get(httpu.RetryAfter))
+}
+
+func TestRetryAfter_BLOBServiceUnavailable(t *testing.T) {
+	require := require.New(t)
+	for _, c := range []struct {
+		name string
+		url  func(port int) string
+	}{
+		{"write", func(port int) string {
+			return fmt.Sprintf("http://127.0.0.1:%d/blob/test1/app1/%d", port, testWSID)
+		}},
+		{"read", func(port int) string {
+			return fmt.Sprintf("http://127.0.0.1:%d/blob/test1/app1/%d/1", port, testWSID)
+		}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			router := setUpWithBlobHandler(t, func(requestCtx context.Context, request bus.Request, responder bus.IResponder) {
+			}, busyBlobRequestHandler{})
+			defer tearDown(router)
+
+			resp, err := http.Post(c.url(router.port()), httpu.ContentType_ApplicationJSON, http.NoBody)
+			require.NoError(err)
+			defer resp.Body.Close()
+
+			require.Equal(http.StatusServiceUnavailable, resp.StatusCode)
+			require.Equal(strconv.Itoa(DefaultRetryAfterSecondsOn503), resp.Header.Get(httpu.RetryAfter))
+		})
+	}
+}
+
+func TestRetryAfter_writeCommonError_V1(t *testing.T) {
+	require := require.New(t)
+	sysErr := coreutils.SysError{HTTPStatus: http.StatusTooManyRequests, Message: "rate limit exceeded"}.
+		AddHeader(httpu.RetryAfter, "7")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeCommonError_V1(w, sysErr, sysErr.HTTPStatus)
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusTooManyRequests, resp.StatusCode)
+	require.Equal("7", resp.Header.Get(httpu.RetryAfter))
+}
+
+type busyBlobRequestHandler struct{}
+
+func (busyBlobRequestHandler) HandleRead(appdef.AppQName, istructs.WSID, map[string]string, context.Context,
+	func(headersKeyValue ...string) io.Writer, blobprocessor.ErrorResponder, string, bus.IRequestSender, iblobstorage.RLimiterType) bool {
+	return false
+}
+
+func (busyBlobRequestHandler) HandleWrite(appdef.AppQName, istructs.WSID, map[string]string, context.Context,
+	url.Values, func(headersKeyValue ...string) io.Writer, io.ReadCloser, blobprocessor.ErrorResponder, bus.IRequestSender) bool {
+	return false
+}
+
+func (busyBlobRequestHandler) HandleWrite_V2(appdef.AppQName, istructs.WSID, map[string]string, context.Context,
+	func(headersKeyValue ...string) io.Writer, io.ReadCloser, blobprocessor.ErrorResponder, bus.IRequestSender, appdef.QName, string) bool {
+	return false
+}
+
+func (busyBlobRequestHandler) HandleRead_V2(appdef.AppQName, istructs.WSID, map[string]string, context.Context,
+	func(headersKeyValue ...string) io.Writer, blobprocessor.ErrorResponder, appdef.QName, string, istructs.RecordID,
+	bus.IRequestSender, iblobstorage.RLimiterType) bool {
+	return false
+}
+
+func (busyBlobRequestHandler) HandleReadTemp_V2(appdef.AppQName, istructs.WSID, map[string]string, context.Context,
+	func(headersKeyValue ...string) io.Writer, blobprocessor.ErrorResponder, bus.IRequestSender, iblobstorage.SUUID, iblobstorage.RLimiterType) bool {
+	return false
+}
+
+func (busyBlobRequestHandler) HandleWriteTemp_V2(appdef.AppQName, istructs.WSID, map[string]string, context.Context,
+	func(headersKeyValue ...string) io.Writer, io.ReadCloser, blobprocessor.ErrorResponder, bus.IRequestSender) bool {
+	return false
 }
 
 func TestHandlerPanic(t *testing.T) {
@@ -413,10 +494,10 @@ type testRouter struct {
 	clientDisconnections chan struct{}
 }
 
-func startRouter(t *testing.T, router *testRouter, rp RouterParams, requestHandler bus.RequestHandler) {
+func startRouter(t *testing.T, router *testRouter, rp RouterParams, requestHandler bus.RequestHandler, blobRequestHandler blobprocessor.IRequestHandler) {
 	ctx, cancel := context.WithCancel(context.Background())
 	requestSender := bus.NewIRequestSender(testingu.MockTime, requestHandler)
-	httpSrv, acmeSrv, adminService := Provide(rp, nil, nil, nil, requestSender,
+	httpSrv, acmeSrv, adminService := Provide(rp, nil, blobRequestHandler, nil, requestSender,
 		map[appdef.AppQName]istructs.NumAppWorkspaces{istructs.AppQName_test1_app1: 10}, nil, nil, nil)
 	require.Nil(t, acmeSrv)
 	require.NoError(t, httpSrv.Prepare(nil))
@@ -441,6 +522,10 @@ func startRouter(t *testing.T, router *testRouter, rp RouterParams, requestHandl
 }
 
 func setUp(t *testing.T, requestHandler bus.RequestHandler) *testRouter {
+	return setUpWithBlobHandler(t, requestHandler, nil)
+}
+
+func setUpWithBlobHandler(t *testing.T, requestHandler bus.RequestHandler, blobRequestHandler blobprocessor.IRequestHandler) *testRouter {
 	rp := RouterParams{
 		HTTPServerParams: HTTPServerParams{
 			Port:             0,
@@ -454,7 +539,7 @@ func setUp(t *testing.T, requestHandler bus.RequestHandler) *testRouter {
 		clientDisconnections: make(chan struct{}, 1),
 	}
 
-	startRouter(t, router, rp, requestHandler)
+	startRouter(t, router, rp, requestHandler, blobRequestHandler)
 	return router
 }
 

--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -81,6 +81,7 @@ func replyServiceUnavailable(rw http.ResponseWriter) {
 func replyErr(rw http.ResponseWriter, err error) {
 	var sysError coreutils.SysError
 	if errors.As(err, &sysError) {
+		applySysErrorHeaders(rw, sysError)
 		ReplyJSON(rw, sysError.ToJSON_APIV2(), sysError.HTTPStatus)
 	} else {
 		ReplyCommonError(rw, err.Error(), http.StatusInternalServerError)

--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -53,9 +53,10 @@ func writeCommonError_V2(w http.ResponseWriter, err error, code int) bool {
 }
 
 func writeCommonError_V1(w http.ResponseWriter, err error, code int) bool {
-	w.Header().Set(httpu.ContentType, httpu.ContentType_ApplicationJSON)
-	w.WriteHeader(code)
 	sysErr := coreutils.WrapSysErrorToExact(err, code)
+	w.Header().Set(httpu.ContentType, httpu.ContentType_ApplicationJSON)
+	applySysErrorHeaders(w, sysErr)
+	w.WriteHeader(code)
 	return writeResponse(w, sysErr.ToJSON_APIV1())
 }
 
@@ -73,7 +74,7 @@ func writeResponse(w http.ResponseWriter, data string) bool {
 }
 
 func replyServiceUnavailable(rw http.ResponseWriter) {
-	rw.Header().Set("Retry-After", strconv.Itoa(DefaultRetryAfterSecondsOn503))
+	rw.Header().Set(httpu.RetryAfter, strconv.Itoa(DefaultRetryAfterSecondsOn503))
 	rw.WriteHeader(http.StatusServiceUnavailable)
 }
 

--- a/pkg/sys/it/impl_rates_test.go
+++ b/pkg/sys/it/impl_rates_test.go
@@ -136,7 +136,7 @@ func TestQueryLimiter_BasicUsage(t *testing.T) {
 			resp := vit.GET(fmt.Sprintf(`api/v2/apps/test1/app1/workspaces/%d/queries/sys.Echo?args=%s`, ws.WSID, url.QueryEscape(`{"Text":"Hello"}`)),
 				httpu.WithAuthorizeBy(sys.Token), httpu.Expect503(), httpu.WithNoRetryPolicy())
 			require.Equal(t, http.StatusServiceUnavailable, resp.HTTPResp.StatusCode)
-			require.Equal(t, fmt.Sprintf("%d", router.DefaultRetryAfterSecondsOn503), resp.HTTPResp.Header.Get("Retry-After"))
+			require.Equal(t, fmt.Sprintf("%d", router.DefaultRetryAfterSecondsOn503), resp.HTTPResp.Header.Get(httpu.RetryAfter))
 
 			vit.TimeAdd(10 * time.Second)
 			releaseQuerySlots(wg, okToFinish, limit)

--- a/uspecs/changes/archive/2606/2606291347-correct-retry-after-header-order/change.md
+++ b/uspecs/changes/archive/2606/2606291347-correct-retry-after-header-order/change.md
@@ -39,7 +39,7 @@ client sends request to the router
 client receives the error without Retry-After   (symptom)
 ```
 
-Corrected behavior: Every router path that emits a back-off-eligible error sets `Retry-After` (and any other headers) before writing the status code, referencing the `httpu.RetryAfter` constant instead of a raw string. The `writeCommonError_V1` writer applies the `SysError` headers before `WriteHeader`, so a processor-provided `Retry-After` reaches the client on BLOB and HTTP error responses as well.
+Corrected behavior: Every router path that emits a back-off-eligible error sets `Retry-After` (and any other headers) before writing the status code, referencing the `httpu.RetryAfter` constant instead of a raw string. The `writeCommonError_V1` writer (V1 BLOB / HTTP error path) and the `replyErr` writer (V2 BLOB error path) apply the `SysError` headers before `WriteHeader`, so a processor-provided `Retry-After` reaches the client on BLOB and HTTP error responses as well.
 
 ## How
 
@@ -47,7 +47,7 @@ Decisions:
 
 - Fix the ordering at the emission site in the BLOB handlers by reusing the already-correct `replyServiceUnavailable` helper instead of duplicating the header-then-status sequence inline
 - Reference the `httpu.RetryAfter` constant everywhere a `Retry-After` header name is written, replacing the raw `"Retry-After"` literal (the `replyServiceUnavailable` helper)
-- Reuse the existing `applySysErrorHeaders` helper to propagate `SysError` headers before the status line in `writeCommonError_V1` (used by the BLOB and HTTP error responders)
+- Reuse the existing `applySysErrorHeaders` helper to propagate `SysError` headers before the status line in `writeCommonError_V1` (V1 BLOB and HTTP error responders) and in `replyErr` (V2 BLOB error responder)
 - Leave the processors unchanged — they already attach `Retry-After` to the `SysError` via `httpu.RetryAfter`
 
 Out of scope:
@@ -70,7 +70,8 @@ References:
 
 - [x] update: [router/impl_test.go](../../../../../pkg/router/impl_test.go)
   - add: regression asserting BLOB write and read `503` responses carry the `Retry-After` header (fault A)
-  - add: case asserting a `SysError` carrying `Retry-After` rendered through `writeCommonError_V1` (BLOB / HTTP error path) propagates the header
+  - add: case asserting a `SysError` carrying `Retry-After` rendered through `writeCommonError_V1` (V1 BLOB / HTTP error path) propagates the header
+  - add: case asserting a `SysError` carrying `Retry-After` rendered through `replyErr` (V2 BLOB error path) propagates the header
 
 - [x] update: [sys/it/impl_rates_test.go](../../../../../pkg/sys/it/impl_rates_test.go)
   - switch the existing query `503` `Retry-After` assertion from the raw `"Retry-After"` literal to the `httpu.RetryAfter` constant, keeping the rest of the file consistent
@@ -81,3 +82,4 @@ References:
 - [x] update: [router/utils.go](../../../../../pkg/router/utils.go)
   - `replyServiceUnavailable`: use the `httpu.RetryAfter` constant instead of the `"Retry-After"` literal
   - `writeCommonError_V1`: apply `applySysErrorHeaders` for the unwrapped `SysError` before `WriteHeader`
+  - `replyErr`: apply `applySysErrorHeaders` before delegating to `ReplyJSON`, so the V2 BLOB error path propagates `SysError` headers

--- a/uspecs/changes/archive/2606/2606291347-correct-retry-after-header-order/change.md
+++ b/uspecs/changes/archive/2606/2606291347-correct-retry-after-header-order/change.md
@@ -1,0 +1,83 @@
+---
+change_id: 2606291233-correct-retry-after-header-order
+type: fix
+issue_url: https://untill.atlassian.net/browse/AIR-4175
+domains: [prod]
+scope: [routing]
+---
+
+# Change request: Correct Retry-After header emission on router error responses
+
+Refs:
+
+- [AIR-4175: correct order for Retry-After header](./issue-AIR-4175.md)
+
+## Why
+
+The BLOB handler emits the `Retry-After` header after writing the status code, so the header is silently dropped and clients retrying a busy BLOB endpoint never learn how long to wait. The same root concern shows up in other router error paths: a raw `"Retry-After"` string literal instead of the `httpu.RetryAfter` constant, and error writers that render a `SysError` without applying its headers — so a processor-provided `Retry-After` (on a 429 rate-limit error) is also dropped. All of these should be made consistent so every back-off-eligible response carries `Retry-After`.
+
+## What
+
+Symptom: A client that receives a back-off-eligible error from the router — `503 Service Unavailable` from a busy BLOB endpoint, or a `429 Too Many Requests` rate-limit error — gets no `Retry-After` header, so it cannot back off for the intended interval.
+
+```text
+client sends request to the router
+      |
+      +--> BLOB read/write endpoint reports service unavailable
+      |          |
+      |          v
+      |    blob handler: rw.WriteHeader(503) then rw.Header().Add("Retry-After", ...)
+      |          <-- fault A: header is added after the status line is written, so net/http discards it
+      |
+      +--> a processor returns a 429 SysError carrying Retry-After (httpu.RetryAfter)
+                 |
+                 v
+           error rendered via writeCommonError_V1 (BLOB and HTTP paths)
+                 <-- fault B: SysError headers are never applied before WriteHeader, so Retry-After is dropped
+                 |
+                 v
+client receives the error without Retry-After   (symptom)
+```
+
+Corrected behavior: Every router path that emits a back-off-eligible error sets `Retry-After` (and any other headers) before writing the status code, referencing the `httpu.RetryAfter` constant instead of a raw string. The `writeCommonError_V1` writer applies the `SysError` headers before `WriteHeader`, so a processor-provided `Retry-After` reaches the client on BLOB and HTTP error responses as well.
+
+## How
+
+Decisions:
+
+- Fix the ordering at the emission site in the BLOB handlers by reusing the already-correct `replyServiceUnavailable` helper instead of duplicating the header-then-status sequence inline
+- Reference the `httpu.RetryAfter` constant everywhere a `Retry-After` header name is written, replacing the raw `"Retry-After"` literal (the `replyServiceUnavailable` helper)
+- Reuse the existing `applySysErrorHeaders` helper to propagate `SysError` headers before the status line in `writeCommonError_V1` (used by the BLOB and HTTP error responders)
+- Leave the processors unchanged — they already attach `Retry-After` to the `SysError` via `httpu.RetryAfter`
+
+Out of scope:
+
+- Changing the computed `Retry-After` durations or `DefaultRetryAfterSecondsOn503`
+- Switching the header value between delta-seconds and HTTP-date form
+- Any non-`Retry-After` header handling
+
+References:
+
+- [BLOB request handlers with the ordering fault](../../../../../pkg/router/impl_blob.go)
+- [common error writers and replyServiceUnavailable](../../../../../pkg/router/utils.go)
+- [applySysErrorHeaders helper](../../../../../pkg/router/impl_http.go)
+- [httpu.RetryAfter constant](../../../../../pkg/goutils/httpu/consts.go)
+- [router Retry-After response test](../../../../../pkg/router/impl_test.go)
+- [integration test for rate-limit Retry-After](../../../../../pkg/sys/it/impl_rates_test.go)
+- [RFC 9110 §10.2.3 Retry-After](https://datatracker.ietf.org/doc/html/rfc9110#section-10.2.3)
+
+## Construction
+
+- [x] update: [router/impl_test.go](../../../../../pkg/router/impl_test.go)
+  - add: regression asserting BLOB write and read `503` responses carry the `Retry-After` header (fault A)
+  - add: case asserting a `SysError` carrying `Retry-After` rendered through `writeCommonError_V1` (BLOB / HTTP error path) propagates the header
+
+- [x] update: [sys/it/impl_rates_test.go](../../../../../pkg/sys/it/impl_rates_test.go)
+  - switch the existing query `503` `Retry-After` assertion from the raw `"Retry-After"` literal to the `httpu.RetryAfter` constant, keeping the rest of the file consistent
+
+- [x] update: [router/impl_blob.go](../../../../../pkg/router/impl_blob.go)
+  - replace the inline `Retry-After`-then-`503` sequence in both handlers with a call to the `replyServiceUnavailable` helper, fixing the ordering and removing the duplication
+
+- [x] update: [router/utils.go](../../../../../pkg/router/utils.go)
+  - `replyServiceUnavailable`: use the `httpu.RetryAfter` constant instead of the `"Retry-After"` literal
+  - `writeCommonError_V1`: apply `applySysErrorHeaders` for the unwrapped `SysError` before `WriteHeader`

--- a/uspecs/changes/archive/2606/2606291347-correct-retry-after-header-order/issue-AIR-4175.md
+++ b/uspecs/changes/archive/2606/2606291347-correct-retry-after-header-order/issue-AIR-4175.md
@@ -1,0 +1,17 @@
+# correct order for Retry-After header
+
+- URL: https://untill.atlassian.net/browse/AIR-4175
+- ID: AIR-4175
+- State: in-progress
+- Author: Denis Gribanov
+- Assignees: Denis Gribanov
+- Labels: none
+
+## Why
+
+In BLOB handler (and probably in other places) `Retry-After` header is sent after status code. So it is dropped by the client.
+
+## What
+
+- use `httpu.RetryAfter` const instead of `"Retry-After"` string
+- first send `Retry-After` and any others, status code the last

--- a/uspecs/changes/archive/2606/2606291347-correct-retry-after-header-order/issue-AIR-4175.md
+++ b/uspecs/changes/archive/2606/2606291347-correct-retry-after-header-order/issue-AIR-4175.md
@@ -9,7 +9,7 @@
 
 ## Why
 
-In BLOB handler (and probably in other places) `Retry-After` header is sent after status code. So it is dropped by the client.
+In BLOB handler (and probably in other places) `Retry-After` header is sent after status code. So it is dropped by net/http and never reaches the client.
 
 ## What
 


### PR DESCRIPTION
```yaml
change_id: 2606291233-correct-retry-after-header-order
type: fix
issue_url: https://untill.atlassian.net/browse/AIR-4175
domains: [prod]
scope: [routing]
```
## Why

The BLOB handler emits the `Retry-After` header after writing the status code, so the header is silently dropped and clients retrying a busy BLOB endpoint never learn how long to wait. The same root concern shows up in other router error paths: a raw `"Retry-After"` string literal instead of the `httpu.RetryAfter` constant, and error writers that render a `SysError` without applying its headers — so a processor-provided `Retry-After` (on a 429 rate-limit error) is also dropped. All of these should be made consistent so every back-off-eligible response carries `Retry-After`.

## What

Symptom: A client that receives a back-off-eligible error from the router — `503 Service Unavailable` from a busy BLOB endpoint, or a `429 Too Many Requests` rate-limit error — gets no `Retry-After` header, so it cannot back off for the intended interval.

```text
client sends request to the router
      |
      +--> BLOB read/write endpoint reports service unavailable
      |          |
      |          v
      |    blob handler: rw.WriteHeader(503) then rw.Header().Add("Retry-After", ...)
      |          <-- fault A: header is added after the status line is written, so net/http discards it
      |
      +--> a processor returns a 429 SysError carrying Retry-After (httpu.RetryAfter)
                 |
                 v
           error rendered via writeCommonError_V1 (BLOB and HTTP paths)
                 <-- fault B: SysError headers are never applied before WriteHeader, so Retry-After is dropped
                 |
                 v
client receives the error without Retry-After   (symptom)
```

Corrected behavior: Every router path that emits a back-off-eligible error sets `Retry-After` (and any other headers) before writing the status code, referencing the `httpu.RetryAfter` constant instead of a raw string. The `writeCommonError_V1` writer applies the `SysError` headers before `WriteHeader`, so a processor-provided `Retry-After` reaches the client on BLOB and HTTP error responses as well.

## How

Decisions:



---
Content omitted. See change.md for full details.
