### PR TITLE
[AIR-4398] voedger: use Scylla 5.1.13 in tests

### DIFF
--- a/.github/workflows/ci_cas.yml
+++ b/.github/workflows/ci_cas.yml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       scylladb:
-        image: scylladb/scylla
+        image: scylladb/scylla:5.1.13
         ports:
           - 9042:9042
 


### PR DESCRIPTION
## Why

currently the latest version of `scylladb/scylla` image is use in tests. The last version of Scylla introduces tablets replication that does not supports `SimpleStrategy` used in tests

## What

use Scylla 5.1.13 in tests
