### PR TITLE
ci: Wait for Scylla readiness in Cassandra tests [AIR-4407]

### DIFF
--- a/.github/workflows/ci_cas.yml
+++ b/.github/workflows/ci_cas.yml
@@ -24,6 +24,18 @@ jobs:
     - name: Checkout and Setup go
       uses: untillpro/ci-action/checkout-and-setup-go@main
 
+    - name: Wait for Scylla CQL
+      run: |
+        for attempt in {1..60}; do
+          if docker exec "${{ job.services.scylladb.id }}" cqlsh 127.0.0.1 9042 -e "DESCRIBE KEYSPACES"; then
+            exit 0
+          fi
+          echo "Waiting for Scylla CQL readiness, attempt ${attempt}/60..."
+          sleep 2
+        done
+        docker logs "${{ job.services.scylladb.id }}"
+        exit 1
+
     - name: Run Cassandra Implementation Tests
       working-directory: pkg/istorage/cas
       run: go test ./... -v -race

--- a/.github/workflows/ci_cas.yml
+++ b/.github/workflows/ci_cas.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Wait for Scylla CQL
       run: |
         for attempt in {1..60}; do
-          if docker exec "${{ job.services.scylladb.id }}" cqlsh 127.0.0.1 9042 -e "DESCRIBE KEYSPACES"; then
+          if docker exec "${{ job.services.scylladb.id }}" cqlsh 127.0.0.1 9042 -e "DESCRIBE KEYSPACES" 2>/dev/null; then
             exit 0
           fi
           echo "Waiting for Scylla CQL readiness, attempt ${attempt}/60..."

--- a/.github/workflows/ci_cas.yml
+++ b/.github/workflows/ci_cas.yml
@@ -31,7 +31,7 @@ jobs:
             exit 0
           fi
           echo "Waiting for Scylla CQL readiness, attempt ${attempt}/60..."
-          sleep 2
+          sleep 1
         done
         docker logs "${{ job.services.scylladb.id }}"
         exit 1

--- a/uspecs/changes/archive/2607/2607030813-wait-scylla-deploy-before-tests/change.md
+++ b/uspecs/changes/archive/2607/2607030813-wait-scylla-deploy-before-tests/change.md
@@ -1,0 +1,50 @@
+---
+change_id: 2607030808-wait-scylla-deploy-before-tests
+type: ci
+issue_url: https://untill.atlassian.net/browse/AIR-4407
+domains: [devops]
+---
+
+# Change request: Wait for Scylla readiness in Cassandra tests
+
+Refs:
+
+- [AIR-4407: voedger: wait for scylla deploy before tests](./issue-AIR-4407.md)
+
+## Why
+
+The Cassandra test workflow can start Go tests before the Scylla service is ready to accept CQL sessions. This creates misleading TCK failures where storage-not-found expectations are masked by transient gocql protocol-discovery errors.
+
+## What
+
+Improve the CI validation workflow for contributors and reviewers:
+
+- Cassandra implementation tests run only after the Scylla service is ready for CQL traffic.
+- Startup-related Scylla failures are reported as infrastructure readiness problems instead of storage behavior regressions.
+- Pull Request feedback from GitHub Actions becomes more deterministic for Scylla-backed storage checks.
+
+## How
+
+Decisions:
+
+- Add an explicit Scylla CQL readiness wait to the Cassandra GitHub Actions workflow before any Go tests run.
+- Use the existing workflow service container as the readiness target instead of changing Cassandra test code.
+- Keep both Cassandra implementation tests and Cassandra-backed VVM storage tests behind the same readiness gate.
+
+Out of scope:
+
+- Changing Scylla image versions or Cassandra driver behavior.
+- Changing storage TCK expectations or Cassandra storage semantics.
+
+References:
+
+- [Cassandra test workflow](../../../../../.github/workflows/ci_cas.yml)
+- [Cassandra implementation tests](../../../../../pkg/istorage/cas/impl_test.go)
+- [Cassandra-backed VVM storage tests](../../../../../pkg/vvm/storage/impl_elections_test.go)
+
+## Provisioning and configuration
+
+- [x] update: [ci_cas.yml](../../../../../.github/workflows/ci_cas.yml): add a Scylla CQL readiness wait before Cassandra-backed Go tests (manual edit - no CLI available)
+  - use the existing `scylladb` service container as the readiness target
+  - fail with Scylla container logs when readiness is not reached within the configured wait window
+  - run both Cassandra implementation tests and Cassandra-backed VVM storage tests only after readiness succeeds

--- a/uspecs/changes/archive/2607/2607030813-wait-scylla-deploy-before-tests/issue-AIR-4407.md
+++ b/uspecs/changes/archive/2607/2607030813-wait-scylla-deploy-before-tests/issue-AIR-4407.md
@@ -1,0 +1,29 @@
+# voedger: wait for scylla deploy before tests
+
+- URL: https://untill.atlassian.net/browse/AIR-4407
+- ID: AIR-4407
+- State: In Progress
+- Author: Denis Gribanov
+- Labels: none
+- Assignees: Denis Gribanov
+
+## Why
+
+on Scylla tests on `istorage` modification:
+
+https://github.com/voedger/voedger/actions/runs/28647020113/job/84955965697?pr=4588
+
+```text
+=== NAME  TestBasicUsage
+    tck.go:49: 
+        	Error Trace:	/home/runner/work/voedger/voedger/pkg/istorage/tck.go:49
+        	Error:      	Target error should be in err chain:
+        	            	expected: "storage does not exist"
+        	            	in chain: "can't create session: gocql: unable to create session: unable to discover protocol version: read tcp 127.0.0.1:46672->127.0.0.1:9042: read: connection reset by peer"
+        	            		"gocql: unable to create session: unable to discover protocol version: read tcp 127.0.0.1:46672->127.0.0.1:9042: read: connection reset by peer"
+        	Test:       	TestBasicUsage
+```
+
+## What
+
+wait for scylla deploy in github action


### PR DESCRIPTION
```yaml
change_id: 2607030808-wait-scylla-deploy-before-tests
type: ci
issue_url: https://untill.atlassian.net/browse/AIR-4407
domains: [devops]
```
## Why

The Cassandra test workflow can start Go tests before the Scylla service is ready to accept CQL sessions. This creates misleading TCK failures where storage-not-found expectations are masked by transient gocql protocol-discovery errors.

## What

Improve the CI validation workflow for contributors and reviewers:

- Cassandra implementation tests run only after the Scylla service is ready for CQL traffic.
- Startup-related Scylla failures are reported as infrastructure readiness problems instead of storage behavior regressions.
- Pull Request feedback from GitHub Actions becomes more deterministic for Scylla-backed storage checks.

## How

Decisions:

- Add an explicit Scylla CQL readiness wait to the Cassandra GitHub Actions workflow before any Go tests run.
- Use the existing workflow service container as the readiness target instead of changing Cassandra test code.
- Keep both Cassandra implementation tests and Cassandra-backed VVM storage tests behind the same readiness gate.

Out of scope:

- Changing Scylla image versions or Cassandra driver behavior.
- Changing storage TCK expectations or Cassandra storage semantics.

References:

- `[Cassandra test workflow](/.github/workflows/ci_cas.yml)`
- `[Cassandra implementation tests](/pkg/istorage/cas/impl_test.go)`
- `[Cassandra-backed VVM storage tests](/pkg/vvm/storage/impl_elections_test.go)`

## Provisioning and configuration

- [x] update: `[ci_cas.yml](/.github/workflows/ci_cas.yml)`: add a Scylla CQL readiness wait before Cassandra-backed Go tests (manual edit - no CLI available)


---
Content omitted. See change.md for full details.
