### PR TITLE
fix: Reliable command processor basic usage test [AIR-4529]

### DIFF
--- a/pkg/processors/command/impl_test.go
+++ b/pkg/processors/command/impl_test.go
@@ -151,7 +151,7 @@ func TestBasicUsage(t *testing.T) {
 		<-check
 		<-check
 
-		logCap.HasLine("stage=cp.success")
+		logCap.EventuallyHasLine("stage=cp.success")
 	})
 
 	t.Run("500 internal server error command exec error", func(t *testing.T) {

--- a/uspecs/changes/archive/2607/2607161148-fix-command-processor-basic-usage/change.md
+++ b/uspecs/changes/archive/2607/2607161148-fix-command-processor-basic-usage/change.md
@@ -1,0 +1,65 @@
+---
+change_id: 2607161122-fix-command-processor-basic-usage
+type: fix
+issue_url: https://untill.atlassian.net/browse/AIR-4529
+---
+
+# Change request: Reliable command processor basic usage test
+
+Refs:
+
+- [AIR-4529: Fix command processor TestBasicUsage](./issue-AIR-4529.md)
+
+## Why
+
+The command processor basic usage test can fail in CI even when the command completes successfully. The test must tolerate the asynchronous ordering between response delivery and success logging so that it reports actual command processor regressions rather than timing-dependent failures.
+
+## What
+
+Symptom: `TestBasicUsage/basic_usage` intermittently fails because no captured log line contains `stage=cp.success`.
+
+```text
+CI runs command processor TestBasicUsage
+      |
+      v
+the command processor sends the response
+      |
+      v
+the test finishes consuming the response
+      |
+      v
+impl_test.go calls logCap.HasLine immediately   <-- fault: does not wait for the subsequent success log
+      |
+      v
+the command processor emits cp.success after response delivery
+      |
+      v
+the test reports a missing cp.success log line   (symptom)
+```
+
+Corrected behavior: `TestBasicUsage` waits for the asynchronously emitted `cp.success` log entry and succeeds after a valid command execution.
+
+## How
+
+Decisions:
+
+- Replace the immediate success-log assertion in `pkg/processors/command/impl_test.go` with the existing eventually-consistent log assertion
+- Keep the command processor response and success-log ordering unchanged
+- Reuse the logger capture helper's standard timeout and polling behavior without introducing test-specific synchronization
+
+Out of scope:
+
+- Changing command processor runtime behavior or log ordering
+- Changing logger capture timeouts or polling intervals
+
+References:
+
+- [command processor basic usage test](../../../../../pkg/processors/command/impl_test.go)
+- [eventual log assertion helper](../../../../../pkg/goutils/logger/logcapture.go)
+- [command response and success logging flow](../../../../../pkg/processors/command/provide.go)
+
+## Construction
+
+- [x] update: [processors/command/impl_test.go](../../../../../pkg/processors/command/impl_test.go)
+  - replace the immediate `HasLine` check for `stage=cp.success` with `EventuallyHasLine`
+  - preserve the success-log assertion while allowing the command processor's asynchronous post-response logging to complete

--- a/uspecs/changes/archive/2607/2607161148-fix-command-processor-basic-usage/issue-AIR-4529.md
+++ b/uspecs/changes/archive/2607/2607161148-fix-command-processor-basic-usage/issue-AIR-4529.md
@@ -1,0 +1,30 @@
+# Fix command processor TestBasicUsage
+
+- URL: https://untill.atlassian.net/browse/AIR-4529
+- ID: AIR-4529
+- State: In Progress
+- Author: Denis Gribanov
+- Labels: none
+- Assignees: Denis Gribanov
+- Linked issues: AIR-4515 (is duplicated by)
+
+## Description
+
+<custom data-type="smartlink" data-id="id-0">https://github.com/voedger/voedger/actions/runs/29143933977/job/86522107439</custom> 
+
+```
+--- FAIL: TestBasicUsage (0.01s)
+      impl_test.go:154: no log line contains all of the expected substrings
+          log:
+          time=2026-07-11T07:09:49.597Z level=INFO msg="" src=in10nmem.notifier:304 stage=n10n.notifier.start vapp=sys/voedger extension=sys._N10NBroker
+          time=2026-07-11T07:09:49.597Z level=INFO msg="Heartbeat30Duration: 30s" src=in10nmem.(*N10nBroker).heartbeat30:422 stage=n10n.heartbeat.start vapp=sys/voedger extension=sys._N10NBroker
+          time=2026-07-11T07:09:49.601Z level=INFO msg="" src=command.(*cmdProc).recovery:290 stage=cp.partition_recovery.start vapp=sys/voedger extension=sys._Recovery partid=1
+          time=2026-07-11T07:09:49.601Z level=DEBUG msg="args={}" src=command.(*cmdProc).recovery:328 stage=cp.partition_recovery.reapply woffset=1 poffset=2 evqname=sys.CUD vapp=sys/voedger extension=sys._Recovery partid=1
+          time=2026-07-11T07:09:49.601Z level=DEBUG msg="newfields={\"CreatedAtMs\":1783753789600,\"InitCompletedAtMs\":1783753789600,\"Status\":0,\"WSKind\":\"sys.TestWSKind\",\"WSName\":\"stub workspace\",\"sys.ID\":65537,\"sys.IsActive\":true,\"sys.QName\":\"sys.WorkspaceDescriptor\"}" src=command.(*cmdProc).recovery:328 stage=cp.partition_recovery.reapply.log_cud rectype=sys.WorkspaceDescriptor recid=65537 op=create woffset=1 poffset=2 evqname=sys.CUD vapp=sys/voedger extension=sys._Recovery partid=1
+          time=2026-07-11T07:09:49.601Z level=DEBUG msg="" src=command.setUp.setUp.ProvideServiceFactory.func5.func6.2:82 stage=sp.success woffset=1 poffset=2 evqname=sys.CUD partid=1 vapp=sys/voedger extension=sys._Recovery
+          time=2026-07-11T07:09:49.602Z level=INFO msg="completed, nextPLogOffset 3, workspaces {\"1\":{\"NextWLogOffset\":2},\"2\":{\"NextWLogOffset\":2}}" src=command.(*cmdProc).recovery:356 stage=cp.partition_recovery.complete extension=sys._Recovery partid=1 vapp=sys/voedger
+          07/11 07:09:49.602: ---: [oldacl.IsOperationAllowed:30]: old-style OperationKind_Execute sys.Test for [Role sys.AuthenticatedUser,WSID 1;Role sys.System,WSID 1;Host ]:  -> deny
+          time=2026-07-11T07:09:49.602Z level=DEBUG msg="args={\"Text\":\"hello\",\"sys.QName\":\"sys.TestParams\"}" src=command.logEventAndCUDs:384 stage=cp.plog_saved woffset=2 poffset=3 evqname=sys.Test
+          time=2026-07-11T07:09:49.602Z level=DEBUG msg="" src=command.setUp.setUp.ProvideServiceFactory.func5.func6.2:82 stage=sp.success woffset=2 poffset=3 evqname=sys.Test
+      --- FAIL: TestBasicUsage/basic_usage (0.00s)
+```


### PR DESCRIPTION
```yaml
change_id: 2607161122-fix-command-processor-basic-usage
type: fix
issue_url: https://untill.atlassian.net/browse/AIR-4529
```
## Why

The command processor basic usage test can fail in CI even when the command completes successfully. The test must tolerate the asynchronous ordering between response delivery and success logging so that it reports actual command processor regressions rather than timing-dependent failures.

## What

Symptom: `TestBasicUsage/basic_usage` intermittently fails because no captured log line contains `stage=cp.success`.

```text
CI runs command processor TestBasicUsage
      |
      v
the command processor sends the response
      |
      v
the test finishes consuming the response
      |
      v
impl_test.go calls logCap.HasLine immediately   <-- fault: does not wait for the subsequent success log
      |
      v
the command processor emits cp.success after response delivery
      |
      v
the test reports a missing cp.success log line   (symptom)
```

Corrected behavior: `TestBasicUsage` waits for the asynchronously emitted `cp.success` log entry and succeeds after a valid command execution.

## How

Decisions:

- Replace the immediate success-log assertion in `pkg/processors/command/impl_test.go` with the existing eventually-consistent log assertion
- Keep the command processor response and success-log ordering unchanged


---
Content omitted. See change.md for full details.
