### PR TITLE
fix: Safer pull request workflow triggers [AIR-4609]

### DIFF
--- a/.github/workflows/ci-pkg-storage.yml
+++ b/.github/workflows/ci-pkg-storage.yml
@@ -7,12 +7,16 @@ on:
       - 'pkg/vvm/storage/**'
       - 'pkg/vvm/storage/**'
       - 'pkg/elections/**'
-  pull_request_target:
+  pull_request:
     paths:
       - 'pkg/istorage/**'
       - 'pkg/vvm/storage/**'
       - 'pkg/vvm/storage/**'
       - 'pkg/elections/**'
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
 
@@ -31,18 +35,26 @@ jobs:
       elections_changed_push: ${{ steps.push_files.outputs.elections_changed }}
     steps:
 
-      - name: Install GitHub CLI
-        run: sudo apt-get install -y gh
-
       - name: Get changed files in PR
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         id: pr_files
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/files --jq '.[].filename')
+          set -Eeuo pipefail
+
+          CHANGED_FILES_FILE="$(mktemp)"
+          trap 'rm -f "$CHANGED_FILES_FILE"' EXIT
+
+          gh api \
+            --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+            --jq '.[].filename' > "$CHANGED_FILES_FILE"
 
           echo "Changed files:"
-          echo "$CHANGED_FILES"
+          sed 's/^/  /' "$CHANGED_FILES_FILE"
 
           CAS_CHANGED=false
           AMAZON_CHANGED=false
@@ -50,7 +62,7 @@ jobs:
           TTLSTORAGE_CHANGED=false
           ELECTIONS_CHANGED=false
 
-          for FILE in $CHANGED_FILES; do
+          while IFS= read -r FILE || [[ -n "$FILE" ]]; do
             case "$FILE" in
               pkg/istorage/cas/*)
                 CAS_CHANGED=true
@@ -68,16 +80,13 @@ jobs:
                 ELECTIONS_CHANGED=true
                 ;;
             esac
-          done
+          done < "$CHANGED_FILES_FILE"
 
           echo "cas_changed=$CAS_CHANGED" >> "$GITHUB_OUTPUT"
           echo "amazon_changed=$AMAZON_CHANGED" >> "$GITHUB_OUTPUT"
           echo "others_changed=$OTHERS_CHANGED" >> "$GITHUB_OUTPUT"
           echo "ttlstorage_changed=$TTLSTORAGE_CHANGED" >> "$GITHUB_OUTPUT"
           echo "elections_changed=$ELECTIONS_CHANGED" >> "$GITHUB_OUTPUT"
-
-        env:
-          GH_TOKEN: ${{ secrets.REPOREADING_TOKEN }}
 
       - name: Checkout repository
         if: github.event_name == 'push'
@@ -159,7 +168,7 @@ jobs:
       )
     uses: ./.github/workflows/ci_cas.yml
     secrets:
-      personaltoken: ${{ secrets.REPOREADING_TOKEN }}
+      personaltoken: ${{ github.event_name == 'push' && secrets.REPOREADING_TOKEN || github.token }}
 
   trigger_amazon:
     needs: determine_changes
@@ -178,5 +187,4 @@ jobs:
       )
     uses: ./.github/workflows/ci_amazon.yml
     secrets:
-      personaltoken: ${{ secrets.REPOREADING_TOKEN }}
-
+      personaltoken: ${{ github.event_name == 'push' && secrets.REPOREADING_TOKEN || github.token }}

--- a/.github/workflows/ci-pkg-storage.yml
+++ b/.github/workflows/ci-pkg-storage.yml
@@ -168,7 +168,7 @@ jobs:
       )
     uses: ./.github/workflows/ci_cas.yml
     secrets:
-      personaltoken: ${{ github.event_name == 'push' && secrets.REPOREADING_TOKEN || github.token }}
+      personaltoken: ${{ github.event_name == 'push' && secrets.REPOREADING_TOKEN || secrets.GITHUB_TOKEN }}
 
   trigger_amazon:
     needs: determine_changes
@@ -187,4 +187,4 @@ jobs:
       )
     uses: ./.github/workflows/ci_amazon.yml
     secrets:
-      personaltoken: ${{ github.event_name == 'push' && secrets.REPOREADING_TOKEN || github.token }}
+      personaltoken: ${{ github.event_name == 'push' && secrets.REPOREADING_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_amazon.yml
+++ b/.github/workflows/ci_amazon.yml
@@ -61,7 +61,7 @@ jobs:
 
   call-workflow-create-issue:
     needs: build
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'push' }}
     uses: untillpro/ci-action/.github/workflows/create_issue.yml@main
     with:
       repo: "voedger/voedger"

--- a/.github/workflows/ci_cas.yml
+++ b/.github/workflows/ci_cas.yml
@@ -49,7 +49,7 @@ jobs:
 
   call-workflow-create-issue:
     needs: build
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'push' }}
     uses: untillpro/ci-action/.github/workflows/create_issue.yml@main
     with:
       repo: 'voedger/voedger'

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -19,4 +19,4 @@ jobs:
       go_race: "false"
       install_tinygo: "true"
     secrets:
-      reporeading_token: ${{ github.token }}
+      reporeading_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -1,9 +1,13 @@
 name: CI on Pull Request
 
 on:
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - 'pkg/istorage/**'
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   call-workflow-ci:
@@ -15,4 +19,4 @@ jobs:
       go_race: "false"
       install_tinygo: "true"
     secrets:
-      reporeading_token: ${{ secrets.REPOREADING_TOKEN }}
+      reporeading_token: ${{ github.token }}

--- a/uspecs/changes/archive/2607/2607290946-safer-pull-request-trigger/change.md
+++ b/uspecs/changes/archive/2607/2607290946-safer-pull-request-trigger/change.md
@@ -1,0 +1,73 @@
+---
+change_id: 2607290917-safer-pull-request-trigger
+type: fix
+issue_url: https://untill.atlassian.net/browse/AIR-4609
+domains: [devops]
+---
+
+# Change request: Safer pull request workflow triggers
+
+Refs:
+
+- [AIR-4609: voedger: use pull_request triggering event instead of pull_request_target](./issue-4609.md)
+
+## Why
+
+Pull requests from forks currently fail because repository workflows use the trusted `pull_request_target` context while downstream CI checks out pull request code. Auto-merge no longer requires that trigger, so pull request automation should use the safer `pull_request` security boundary and preserve the intended CI and review behavior.
+
+## What
+
+Symptom: A CI run for a pull request from a fork fails when the downstream checkout refuses to load fork code in the trusted `pull_request_target` context.
+
+```text
+contributor opens a pull request from a fork
+      |
+      v
+.github/workflows/ci_pr.yml receives pull_request_target
+      |               <-- fault: starts pull request CI in a trusted base-repository context
+      v
+reusable CI workflow attempts to check out fork pull request code
+      |
+      v
+actions/checkout refuses the unsafe checkout   (symptom)
+```
+
+Corrected behavior: CI workflows that check out and execute pull request code, including code from forks, use `pull_request` triggers and read-only credentials, while separately privileged automation preserves its intended behavior without executing untrusted code.
+
+## How
+
+Decisions:
+
+- Use `pull_request` for CI workflows that check out and execute contributor code, while leaving trusted `push` execution paths unchanged.
+- Run pull request CI without repository secrets by granting only read access and mapping the run-scoped `GITHUB_TOKEN` to reusable workflow inputs that need repository or pull request reads.
+- Keep failure issue creation and other write-capable side effects restricted to trusted push executions; pull request failures are reported only through their workflow check results.
+- Retain `pull_request_target` and `issue_comment` for the separately specified PR review workflow because it requires repository secrets and write permissions and is constrained not to execute pull request scripts.
+- Preserve existing path filters, changed-file classification, and test selection so the trigger migration changes the security context rather than CI coverage.
+
+Assumptions:
+
+- The shared `untillpro/ci-action` pull request workflow accepts the caller's run-scoped `GITHUB_TOKEN` through its existing `reporeading_token` contract, and every dependency needed by fork CI is publicly readable.
+
+References (internal):
+
+- [primary pull request CI boundary](../../../../../.github/workflows/ci_pr.yml)
+- [storage pull request routing and change classification](../../../../../.github/workflows/ci-pkg-storage.yml)
+- [Cassandra failure notification path](../../../../../.github/workflows/ci_cas.yml)
+- [DynamoDB failure notification path](../../../../../.github/workflows/ci_amazon.yml)
+- [privileged review workflow security contract](../../../../specs/devops/dev/arch.md)
+
+References (external):
+
+- [shared pull request CI contract](https://github.com/untillpro/ci-action/blob/main/.github/workflows/ci_pr.yml)
+- [GitHub pull request event and fork restrictions](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request)
+- [GitHub guidance for secure workflow triggers](https://docs.github.com/en/actions/reference/security/secure-use)
+- [GitHub reusable workflow secret passing](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#passing-inputs-and-secrets-to-a-reusable-workflow)
+
+## Provisioning and configuration
+
+GitHub Actions:
+
+- [x] update: [primary pull request CI workflow](../../../../../.github/workflows/ci_pr.yml): replace the `pull_request_target` trigger with `pull_request`, grant only `contents: read` and `pull-requests: read`, and pass the run-scoped `GITHUB_TOKEN` as the reusable workflow's `reporeading_token` (manual edit; no CLI available)
+- [x] update: [storage CI routing workflow](../../../../../.github/workflows/ci-pkg-storage.yml): replace its pull request trigger and event guard with `pull_request`, grant read-only content and pull request access, use `GITHUB_TOKEN` to classify changed files, and pass `REPOREADING_TOKEN` only on trusted push runs while using `GITHUB_TOKEN` on pull request runs (manual edit; no CLI available)
+- [x] update: [Cassandra CI workflow](../../../../../.github/workflows/ci_cas.yml): create failure issues only for trusted push executions so pull request jobs have no write-capable side effects (manual edit; no CLI available)
+- [x] update: [DynamoDB CI workflow](../../../../../.github/workflows/ci_amazon.yml): create failure issues only for trusted push executions so pull request jobs have no write-capable side effects (manual edit; no CLI available)

--- a/uspecs/changes/archive/2607/2607290946-safer-pull-request-trigger/issue-4609.md
+++ b/uspecs/changes/archive/2607/2607290946-safer-pull-request-trigger/issue-4609.md
@@ -1,0 +1,25 @@
+# voedger: use pull_request triggering event instead of pull_request_target
+
+- URL: https://untill.atlassian.net/browse/AIR-4609
+- ID: AIR-4609
+- State: In Progress⚒️
+- Author: Denis Gribanov
+- Labels: none
+- Assignees: Denis Gribanov
+- Parent: AIR-4608
+
+## Why
+
+`pull_request_target` was needed to auto-merge the PR. Now auto-merge is disable to it is better to use more safe `pull_request`
+
+Now we have error on pull request from fork:
+
+```
+Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
+```
+
+## What
+
+* use `pull_request` instead of `pull_request_tagret`
+* investigate what else should be changed after `pull_request` change
+

--- a/uspecs/changes/archive/2607/2607290946-safer-pull-request-trigger/issue-4609.md
+++ b/uspecs/changes/archive/2607/2607290946-safer-pull-request-trigger/issue-4609.md
@@ -20,6 +20,6 @@ Error: Refusing to check out fork pull request code from a 'pull_request_target'
 
 ## What
 
-* use `pull_request` instead of `pull_request_tagret`
+* use `pull_request` instead of `pull_request_target`
 * investigate what else should be changed after `pull_request` change
 

--- a/uspecs/changes/archive/2607/2607290946-safer-pull-request-trigger/issue-4609.md
+++ b/uspecs/changes/archive/2607/2607290946-safer-pull-request-trigger/issue-4609.md
@@ -10,9 +10,9 @@
 
 ## Why
 
-`pull_request_target` was needed to auto-merge the PR. Now auto-merge is disable to it is better to use more safe `pull_request`
+`pull_request_target` was needed for PR auto-merge. Now auto-merge is disabled, so it is safer to use `pull_request`.
 
-Now we have error on pull request from fork:
+Now we get an error on pull requests from forks:
 
 ```
 Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.


### PR DESCRIPTION
```yaml
change_id: 2607290917-safer-pull-request-trigger
type: fix
issue_url: https://untill.atlassian.net/browse/AIR-4609
domains: [devops]
```
## Why

Pull requests from forks currently fail because repository workflows use the trusted `pull_request_target` context while downstream CI checks out pull request code. Auto-merge no longer requires that trigger, so pull request automation should use the safer `pull_request` security boundary and preserve the intended CI and review behavior.

## What

Symptom: A CI run for a pull request from a fork fails when the downstream checkout refuses to load fork code in the trusted `pull_request_target` context.

```text
contributor opens a pull request from a fork
      |
      v
.github/workflows/ci_pr.yml receives pull_request_target
      |               <-- fault: starts pull request CI in a trusted base-repository context
      v
reusable CI workflow attempts to check out fork pull request code
      |
      v
actions/checkout refuses the unsafe checkout   (symptom)
```

Corrected behavior: CI workflows that check out and execute pull request code, including code from forks, use `pull_request` triggers and read-only credentials, while separately privileged automation preserves its intended behavior without executing untrusted code.

## How

Decisions:

- Use `pull_request` for CI workflows that check out and execute contributor code, while leaving trusted `push` execution paths unchanged.
- Run pull request CI without repository secrets by granting only read access and mapping the run-scoped `GITHUB_TOKEN` to reusable workflow inputs that need repository or pull request reads.
- Keep failure issue creation and other write-capable side effects restricted to trusted push executions; pull request failures are reported only through their workflow check results.
- Retain `pull_request_target` and `issue_comment` for the separately specified PR review workflow because it requires repository secrets and write permissions and is constrained not to execute pull request scripts.
- Preserve existing path filters, changed-file classification, and test selection so the trigger migration changes the security context rather than CI coverage.

Assumptions:


---
Content omitted. See change.md for full details.
