### PR TITLE
fix(auth): Replace accepted invitations without revoking membership [AIR-4631]

### DIFF
--- a/pkg/sys/invite/consts.go
+++ b/pkg/sys/invite/consts.go
@@ -59,6 +59,7 @@ const (
 	Field_SubjectKind           = "SubjectKind"
 	Field_ProfileWSID           = "ProfileWSID"
 	Field_SubjectID             = "SubjectID"
+	Field_InviteEmail           = "InviteEmail"
 	Field_LoginHash             = "LoginHash"
 	field_ActualLogin           = "ActualLogin"
 	Field_Version               = "Version"

--- a/pkg/sys/invite/errors.go
+++ b/pkg/sys/invite/errors.go
@@ -8,12 +8,15 @@ import (
 	"errors"
 )
 
+const errControllingInviteNotIdentifiedMessageFormat = "A workspace membership is already active for canonical login %q. The existing accepted invitation must be cancelled manually before another invitation can be accepted."
+
 var (
-	ErrInviteNotExists               = errors.New("invite not exists")
-	errInviteExpired                 = errors.New("invite expired")
-	errInviteTemplateInvalid         = errors.New("invite template invalid, it must be prefixed with 'text:' or 'resource:'")
-	errInviteVerificationCodeInvalid = errors.New("invite verification code invalid")
-	ErrInviteStateInvalid            = errors.New("invite state invalid")
+	ErrInviteNotExists                = errors.New("invite not exists")
+	ErrControllingInviteNotIdentified = errors.New("controlling invitation not identified")
+	errInviteExpired                  = errors.New("invite expired")
+	errInviteTemplateInvalid          = errors.New("invite template invalid, it must be prefixed with 'text:' or 'resource:'")
+	errInviteVerificationCodeInvalid  = errors.New("invite verification code invalid")
+	ErrInviteStateInvalid             = errors.New("invite state invalid")
 
 	// [~server.invites.invite/err.State~impl]
 	ErrReInviteNotAllowedForState = errors.New("re-invite not allowed for state")

--- a/pkg/sys/invite/impl_applyinviteevents.go
+++ b/pkg/sys/invite/impl_applyinviteevents.go
@@ -6,6 +6,7 @@
 package invite
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/voedger/voedger/pkg/coreutils/federation"
 	"github.com/voedger/voedger/pkg/goutils/httpu"
 	"github.com/voedger/voedger/pkg/goutils/jsonu"
+	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/goutils/strconvu"
 	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istructs"
@@ -144,6 +146,30 @@ func updateInviteViaCUD(fed federation.IFederation, appQName appdef.AppQName, ws
 	return err
 }
 
+func joinedInviteCUD(inviteID, subjectID istructs.RecordID, updated int64) string {
+	return jsonu.Jprintf(`{"sys.ID":%d,"fields":{"State":%d,"SubjectID":%d,"Updated":%d}}`,
+		inviteID, State_Joined, subjectID, updated)
+}
+
+func applyJoinedInviteViaCUD(fed federation.IFederation, appQName appdef.AppQName, wsid istructs.WSID, token string, previousInviteID, currentInviteID, subjectID istructs.RecordID, roles, inviteEmail string, updated int64) error {
+	cuds := make([]string, 0, 3)
+	if previousInviteID != istructs.NullRecordID {
+		cuds = append(cuds, jsonu.Jprintf(`{"sys.ID":%d,"fields":{"State":%d,"Updated":%d}}`,
+			previousInviteID, State_Cancelled, updated))
+	}
+	cuds = append(cuds,
+		joinedInviteCUD(currentInviteID, subjectID, updated),
+		jsonu.Jprintf(`{"sys.ID":%d,"fields":{"Roles":%q,%q:%q}}`,
+			subjectID, roles, Field_InviteEmail, inviteEmail),
+	)
+	_, err := fed.Func(
+		cudURL(appQName, wsid),
+		`{"cuds":[`+strings.Join(cuds, ",")+`]}`,
+		httpu.WithAuthorizeBy(token),
+		httpu.WithDiscardResponse())
+	return err
+}
+
 func deactivateSubjectAndJoinedWorkspace(fed federation.IFederation, appQName appdef.AppQName, wsid istructs.WSID, token string, svCDocInvite istructs.IStateValue) error {
 	subjectID := svCDocInvite.AsRecordID(field_SubjectID)
 	_, err := fed.Func(
@@ -225,15 +251,38 @@ func sendEmail(s istructs.IState, intents istructs.IIntents, smtpCfg smtp.Cfg, s
 // handleApplyJoinWorkspace finalizes c.sys.InitiateJoinWorkspace:
 //   - creates sys.JoinedWorkspace in the invitee's profile workspace (so the user can list workspaces they joined);
 //   - creates or re-activates sys.Subject in the inviting workspace (so the user can authorize there);
-//   - moves the invite to State_Joined.
+//   - moves the current invite to State_Joined and records it as the Subject's controlling invitation;
+//   - when the Subject is already active, retires its previous controlling invitation.
 //
 // The Subject lookup has three cases: missing (first join), inactive (was Cancelled/Left previously - re-join),
-// active (idempotent retry). All paths must be safe to re-run because the projector is asynchronous.
+// and active (replacement). A replay whose current invitation is already Joined is filtered by applyInviteEvents.
 func handleApplyJoinWorkspace(event istructs.IPLogEvent, s istructs.IState, svCDocInvite istructs.IStateValue, inviteID istructs.RecordID, time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens) error {
 	login := svCDocInvite.AsString(field_ActualLogin)
-	existingSubjectID, isActive, err := SubjectExistsByLogin(login, s)
+	existingSubjectID, subject, subjectExists, err := subjectByLogin(login, s)
 	if err != nil {
 		return err
+	}
+	isActive := subjectExists && subject.AsBool(appdef.SystemField_IsActive)
+
+	// The command pre-validates replacement, but the asynchronous projector repeats the
+	// authoritative check against its own PLog-order state before producing side effects.
+	previousInviteID := istructs.NullRecordID
+	if isActive {
+		previousInviteID, _, err = resolveControllingInvite(
+			existingSubjectID,
+			subject,
+			login,
+			svCDocInvite.AsString(Field_Email),
+			inviteID,
+			s,
+		)
+		if err != nil {
+			if errors.Is(err, ErrControllingInviteNotIdentified) {
+				logger.Error(fmt.Sprintf("ap.sys.ApplyInviteEvents: skipping join event because the controlling invitation was not resolved: workspace=%d invite=%d canonicalLogin=%q", event.Workspace(), inviteID, login))
+				return nil
+			}
+			return err
+		}
 	}
 
 	// WSName is needed for the JoinedWorkspace record below.
@@ -265,57 +314,54 @@ func handleApplyJoinWorkspace(event istructs.IPLogEvent, s istructs.IState, svCD
 		return err
 	}
 
-	// Step 2: ensure sys.Subject exists in the inviting workspace and carries the invited Roles.
-	// `body` is the CUD that finalizes the Subject; in the inactive case we additionally pre-run an activation CUD
-	// because the platform forbids combining sys.IsActive with other fields in a single CUD (HTTP 403).
-	var body string
-	switch {
-	case existingSubjectID == istructs.NullRecordID:
-		// First join: insert a new Subject with all fields.
-		body = jsonu.Jprintf(`{"cuds":[{"fields":{"sys.ID":1,"sys.QName":"sys.Subject","Login":%q,"Roles":%q,"SubjectKind":%d,"ProfileWSID":%d}}]}`,
-			svCDocInvite.AsString(field_ActualLogin), svCDocInvite.AsString(Field_Roles), svCDocInvite.AsInt32(authnz.Field_SubjectKind),
-			svCDocInvite.AsInt64(Field_InviteeProfileWSID))
-	case !isActive:
-		// Re-join after Cancel/Leave: re-activate first, then update Roles in the second CUD below.
-		// Two separate CUDs are required: sys.IsActive cannot be updated together with other fields.
-		body = fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"sys.IsActive":true}}]}`, existingSubjectID)
-		_, err = fed.Func(
+	// Step 2: ensure sys.Subject exists and is active. sys.IsActive cannot be combined
+	// with other fields in one CUD, so re-join activates the Subject first.
+	if !subjectExists {
+		const rawSubjectID = istructs.RecordID(1)
+		updated := time.Now().UnixMilli()
+		subjectCUD := jsonu.Jprintf(`{"fields":{"sys.ID":%d,"sys.QName":"sys.Subject","Login":%q,"Roles":%q,"SubjectKind":%d,"ProfileWSID":%d,%q:%q}}`,
+			rawSubjectID,
+			login,
+			svCDocInvite.AsString(Field_Roles),
+			svCDocInvite.AsInt32(authnz.Field_SubjectKind),
+			svCDocInvite.AsInt64(Field_InviteeProfileWSID),
+			Field_InviteEmail,
+			svCDocInvite.AsString(Field_Email))
+		_, err := fed.Func(
 			cudURL(appQName, event.Workspace()),
-			body,
+			`{"cuds":[`+subjectCUD+`,`+joinedInviteCUD(inviteID, rawSubjectID, updated)+`]}`,
 			httpu.WithAuthorizeBy(token),
 			httpu.WithDiscardResponse())
 		if err != nil {
 			return err
 		}
-		fallthrough
-	default:
-		// Active Subject (idempotent retry) or fallthrough from !isActive: refresh Roles.
-		body = jsonu.Jprintf(`{"cuds":[{"sys.ID":%d,"fields":{"Roles":%q}}]}`, existingSubjectID, svCDocInvite.AsString(Field_Roles))
+		return nil
 	}
-	// Insert path needs the new ID for the invite's SubjectID; update path can discard the response.
-	subjectID := existingSubjectID
-	if existingSubjectID == istructs.NullRecordID {
-		resp, err := fed.Func(
-			cudURL(appQName, event.Workspace()),
-			body,
-			httpu.WithAuthorizeBy(token))
-		if err != nil {
-			return err
-		}
-		subjectID = resp.NewID()
-	} else {
+	if !isActive {
 		_, err = fed.Func(
 			cudURL(appQName, event.Workspace()),
-			body,
+			fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"sys.IsActive":true}}]}`, existingSubjectID),
 			httpu.WithAuthorizeBy(token),
 			httpu.WithDiscardResponse())
 		if err != nil {
 			return err
 		}
 	}
-	// Step 3: mark the invite as Joined and remember the SubjectID for later Cancel/Leave/UpdateRoles handlers.
-	return updateInviteViaCUD(fed, appQName, event.Workspace(), token, inviteID,
-		jsonu.Jprintf(`"State":%d,"SubjectID":%d,"Updated":%d`, State_Joined, subjectID, time.Now().UnixMilli()))
+
+	// Step 3: finalize all workspace-local replacement/re-join state together. Omitting
+	// SubjectID from the previous invitation preserves its historical membership linkage.
+	return applyJoinedInviteViaCUD(
+		fed,
+		appQName,
+		event.Workspace(),
+		token,
+		previousInviteID,
+		inviteID,
+		existingSubjectID,
+		svCDocInvite.AsString(Field_Roles),
+		svCDocInvite.AsString(Field_Email),
+		time.Now().UnixMilli(),
+	)
 }
 
 func handleApplyUpdateInviteRoles(event istructs.IPLogEvent, s istructs.IState, intents istructs.IIntents, svCDocInvite istructs.IStateValue, inviteID istructs.RecordID, time timeu.ITime, fed federation.IFederation, tokens itokens.ITokens, smtpCfg smtp.Cfg) error {

--- a/pkg/sys/invite/impl_applyinviteevents_test.go
+++ b/pkg/sys/invite/impl_applyinviteevents_test.go
@@ -6,7 +6,15 @@
 package invite
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -14,9 +22,19 @@ import (
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/coreutils"
+	"github.com/voedger/voedger/pkg/coreutils/federation"
+	"github.com/voedger/voedger/pkg/goutils/logger"
+	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/itokensjwt"
 	"github.com/voedger/voedger/pkg/sys"
+	"github.com/voedger/voedger/pkg/sys/authnz"
 	"github.com/voedger/voedger/pkg/sys/smtp"
+)
+
+const (
+	applyInviteEventsTestInviteEmail      = "InviteEmail"
+	applyInviteEventsTestReplacementRoles = "app1pkg.SpecialAPITokenRole"
 )
 
 func newMockEventWithCUDs(t *testing.T, cmdQName appdef.QName, cuds []istructs.ICUDRow) *coreutils.MockPLogEvent {
@@ -110,4 +128,291 @@ func TestApplyInviteEvents_Version1ReachesDispatch(t *testing.T) {
 	err := projectorFn(event, st, nil)
 	require.ErrorIs(err, expectedErr)
 	st.AssertCalled(t, "KeyBuilder", sys.Storage_Record, QNameCDocInvite)
+}
+
+func TestApplyInviteEvents_SequentialJoinEventsReplaceControllerInPLogOrder(t *testing.T) {
+	const (
+		subjectID       = istructs.RecordID(101)
+		firstInviteID   = istructs.RecordID(201)
+		secondInviteID  = istructs.RecordID(202)
+		thirdInviteID   = istructs.RecordID(203)
+		canonicalEmail  = "jsmith@example.com"
+		aliasEmail      = "j.smith@example.com"
+		replacementMail = "john.smith@example.com"
+	)
+
+	firstRequests := projectInviteReplacement(t, joinReplacementInput{
+		previousInviteID:    firstInviteID,
+		previousInviteEmail: canonicalEmail,
+		currentInviteID:     secondInviteID,
+		currentInviteEmail:  aliasEmail,
+		subjectID:           subjectID,
+	})
+	requireAtomicInviteReplacement(t, firstRequests, firstInviteID, secondInviteID, subjectID, aliasEmail)
+
+	secondRequests := projectInviteReplacement(t, joinReplacementInput{
+		previousInviteID:    secondInviteID,
+		previousInviteEmail: aliasEmail,
+		currentInviteID:     thirdInviteID,
+		currentInviteEmail:  replacementMail,
+		subjectID:           subjectID,
+	})
+	requireAtomicInviteReplacement(t, secondRequests, secondInviteID, thirdInviteID, subjectID, replacementMail)
+}
+
+func TestApplyInviteEvents_ReplayedJoinedInviteIsNoOp(t *testing.T) {
+	const inviteID = istructs.RecordID(42)
+
+	inviteKey := newApplyInviteEventsKeyBuilder()
+	invite := &coreutils.MockStateValue{}
+	invite.On("AsInt32", Field_State).Return(int32(State_Joined))
+
+	st := &coreutils.MockState{}
+	st.On("KeyBuilder", sys.Storage_Record, QNameCDocInvite).Return(inviteKey, nil).Once()
+	st.On("MustExist", inviteKey).Return(invite, nil).Once()
+
+	event := newMockEventWithCUDs(t, qNameCmdInitiateJoinWorkspace, []istructs.ICUDRow{
+		newInviteCUD(1, inviteID),
+	})
+	event.On("ArgumentObject").Return(&coreutils.TestObject{
+		Data: map[string]any{field_InviteID: inviteID},
+	})
+
+	require.NoError(t, applyInviteEvents(nil, nil, nil, smtp.Cfg{})(event, st, nil))
+	st.AssertNumberOfCalls(t, "KeyBuilder", 1)
+	st.AssertNumberOfCalls(t, "MustExist", 1)
+}
+
+func TestApplyInviteEvents_UnresolvedControllingInviteIsLoggedAndSkipped(t *testing.T) {
+	const (
+		workspaceID    = istructs.WSID(500)
+		subjectID      = istructs.RecordID(101)
+		inviteID       = istructs.RecordID(202)
+		canonicalLogin = "jsmith@example.com"
+		aliasEmail     = "j.smith@example.com"
+	)
+
+	currentInviteKey := newApplyInviteEventsKeyBuilder()
+	subjectIndexKey := newApplyInviteEventsKeyBuilder()
+	subjectKey := newApplyInviteEventsKeyBuilder()
+	inviteIndexKey := newApplyInviteEventsKeyBuilder()
+
+	currentInvite := &coreutils.MockStateValue{}
+	currentInvite.On("AsInt32", Field_State).Return(int32(State_Invited)).Maybe()
+	currentInvite.On("AsString", field_ActualLogin).Return(canonicalLogin).Maybe()
+	currentInvite.On("AsString", Field_Email).Return(aliasEmail).Maybe()
+
+	subjectIndex := &coreutils.MockStateValue{}
+	subjectIndex.On("AsRecordID", Field_SubjectID).Return(subjectID).Maybe()
+
+	subject := &coreutils.MockStateValue{}
+	subject.On("AsBool", appdef.SystemField_IsActive).Return(true).Maybe()
+	subject.On("AsString", Field_InviteEmail).Return("").Maybe()
+
+	st := &coreutils.MockState{}
+	st.On("KeyBuilder", sys.Storage_Record, QNameCDocInvite).Return(currentInviteKey, nil).Once()
+	st.On("MustExist", currentInviteKey).Return(currentInvite, nil).Once()
+	st.On("KeyBuilder", sys.Storage_View, QNameViewSubjectsIdx).Return(subjectIndexKey, nil).Once()
+	st.On("CanExist", subjectIndexKey).Return(subjectIndex, true, nil).Once()
+	st.On("KeyBuilder", sys.Storage_Record, QNameCDocSubject).Return(subjectKey, nil).Once()
+	st.On("CanExist", subjectKey).Return(subject, true, nil).Once()
+	st.On("KeyBuilder", sys.Storage_View, qNameViewInviteIndex).Return(inviteIndexKey, nil).Twice()
+	st.On("CanExist", inviteIndexKey).Return(nil, false, nil).Twice()
+
+	event := newMockEventWithCUDs(t, qNameCmdInitiateJoinWorkspace, []istructs.ICUDRow{
+		newInviteCUD(1, inviteID),
+	})
+	event.On("ArgumentObject").Return(&coreutils.TestObject{
+		Data: map[string]any{field_InviteID: inviteID},
+	})
+	event.On("Workspace").Return(workspaceID)
+
+	logCapture := logger.StartCapture(t, logger.LogLevelError)
+	require.NoError(t, applyInviteEvents(nil, nil, nil, smtp.Cfg{})(event, st, &coreutils.MockIntents{}))
+	logCapture.HasLine(
+		"skipping join event because the controlling invitation was not resolved",
+		"workspace=500",
+		"invite=202",
+		`canonicalLogin="jsmith@example.com"`,
+	)
+	st.AssertExpectations(t)
+	st.AssertNotCalled(t, "KeyBuilder", sys.Storage_Record, appdef.QNameCDocWorkspaceDescriptor)
+}
+
+type joinReplacementInput struct {
+	previousInviteID    istructs.RecordID
+	previousInviteEmail string
+	currentInviteID     istructs.RecordID
+	currentInviteEmail  string
+	subjectID           istructs.RecordID
+}
+
+type capturedFederationRequest struct {
+	path string
+	body string
+}
+
+type capturedFederationRequests struct {
+	sync.Mutex
+	items []capturedFederationRequest
+}
+
+func (c *capturedFederationRequests) append(request capturedFederationRequest) {
+	c.Lock()
+	defer c.Unlock()
+	c.items = append(c.items, request)
+}
+
+func (c *capturedFederationRequests) snapshot() []capturedFederationRequest {
+	c.Lock()
+	defer c.Unlock()
+	return append([]capturedFederationRequest(nil), c.items...)
+}
+
+func projectInviteReplacement(t *testing.T, input joinReplacementInput) []capturedFederationRequest {
+	t.Helper()
+	const (
+		workspaceID      = istructs.WSID(500)
+		inviteeProfileID = istructs.WSID(600)
+		workspaceName    = "Acme"
+	)
+
+	requests := &capturedFederationRequests{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		requests.append(capturedFederationRequest{path: r.URL.Path, body: string(body)})
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	fed, cleanup := federation.New(context.Background(), func() *url.URL {
+		return serverURL
+	}, func() int {
+		return 0
+	}, nil)
+	t.Cleanup(cleanup)
+
+	currentInviteKey := newApplyInviteEventsKeyBuilder()
+	previousInviteKey := newApplyInviteEventsKeyBuilder()
+	subjectIndexKey := newApplyInviteEventsKeyBuilder()
+	subjectKey := newApplyInviteEventsKeyBuilder()
+	inviteIndexKey := newApplyInviteEventsKeyBuilder()
+	workspaceKey := newApplyInviteEventsKeyBuilder()
+
+	currentInvite := &coreutils.MockStateValue{}
+	currentInvite.On("AsInt32", Field_State).Return(int32(State_Invited)).Maybe()
+	currentInvite.On("AsString", field_ActualLogin).Return("jsmith@example.com").Maybe()
+	currentInvite.On("AsString", Field_Email).Return(input.currentInviteEmail).Maybe()
+	currentInvite.On("AsString", Field_Roles).Return(applyInviteEventsTestReplacementRoles).Maybe()
+	currentInvite.On("AsInt32", authnz.Field_SubjectKind).Return(int32(istructs.SubjectKind_User)).Maybe()
+	currentInvite.On("AsInt64", Field_InviteeProfileWSID).Return(int64(inviteeProfileID)).Maybe()
+
+	previousInvite := &coreutils.MockStateValue{}
+	previousInvite.On("AsInt32", Field_State).Return(int32(State_Joined)).Maybe()
+	previousInvite.On("AsString", Field_Email).Return(input.previousInviteEmail).Maybe()
+	previousInvite.On("AsRecordID", field_SubjectID).Return(input.subjectID).Maybe()
+
+	subjectIndex := &coreutils.MockStateValue{}
+	subjectIndex.On("AsRecordID", Field_SubjectID).Return(input.subjectID).Maybe()
+
+	subject := &coreutils.MockStateValue{}
+	subject.On("AsBool", appdef.SystemField_IsActive).Return(true).Maybe()
+	subject.On("AsString", applyInviteEventsTestInviteEmail).Return(input.previousInviteEmail).Maybe()
+
+	inviteIndex := &coreutils.MockStateValue{}
+	inviteIndex.On("AsRecordID", field_InviteID).Return(input.previousInviteID).Maybe()
+
+	workspace := &coreutils.MockStateValue{}
+	workspace.On("AsString", authnz.Field_WSName).Return(workspaceName).Maybe()
+
+	st := &coreutils.MockState{}
+	st.On("App").Return(istructs.AppQName_test1_app1).Maybe()
+	st.On("KeyBuilder", sys.Storage_Record, QNameCDocInvite).Return(currentInviteKey, nil).Once()
+	st.On("MustExist", currentInviteKey).Return(currentInvite, nil).Maybe()
+	st.On("CanExist", currentInviteKey).Return(currentInvite, true, nil).Maybe()
+	st.On("KeyBuilder", sys.Storage_View, QNameViewSubjectsIdx).Return(subjectIndexKey, nil).Maybe()
+	st.On("CanExist", subjectIndexKey).Return(subjectIndex, true, nil).Maybe()
+	st.On("MustExist", subjectIndexKey).Return(subjectIndex, nil).Maybe()
+	st.On("KeyBuilder", sys.Storage_Record, QNameCDocSubject).Return(subjectKey, nil).Maybe()
+	st.On("CanExist", subjectKey).Return(subject, true, nil).Maybe()
+	st.On("MustExist", subjectKey).Return(subject, nil).Maybe()
+	st.On("KeyBuilder", sys.Storage_View, qNameViewInviteIndex).Return(inviteIndexKey, nil).Maybe()
+	st.On("CanExist", inviteIndexKey).Return(inviteIndex, true, nil).Maybe()
+	st.On("MustExist", inviteIndexKey).Return(inviteIndex, nil).Maybe()
+	st.On("KeyBuilder", sys.Storage_Record, QNameCDocInvite).Return(previousInviteKey, nil).Maybe()
+	st.On("MustExist", previousInviteKey).Return(previousInvite, nil).Maybe()
+	st.On("CanExist", previousInviteKey).Return(previousInvite, true, nil).Maybe()
+	st.On("KeyBuilder", sys.Storage_Record, appdef.QNameCDocWorkspaceDescriptor).Return(workspaceKey, nil).Maybe()
+	st.On("MustExist", workspaceKey).Return(workspace, nil).Maybe()
+
+	event := newMockEventWithCUDs(t, qNameCmdInitiateJoinWorkspace, []istructs.ICUDRow{
+		newInviteCUD(1, input.currentInviteID),
+	})
+	event.On("ArgumentObject").Return(&coreutils.TestObject{
+		Data: map[string]any{field_InviteID: input.currentInviteID},
+	})
+	event.On("Workspace").Return(workspaceID)
+
+	tm := timeu.NewITime()
+	tokens := itokensjwt.ProvideITokens(itokensjwt.SecretKeyExample, tm)
+	require.NoError(t, applyInviteEvents(tm, fed, tokens, smtp.Cfg{})(event, st, nil))
+	return requests.snapshot()
+}
+
+func newApplyInviteEventsKeyBuilder() *coreutils.MockStateKeyBuilder {
+	key := &coreutils.MockStateKeyBuilder{}
+	key.On("PutInt32", mock.Anything, mock.Anything).Return().Maybe()
+	key.On("PutInt64", mock.Anything, mock.Anything).Return().Maybe()
+	key.On("PutString", mock.Anything, mock.Anything).Return().Maybe()
+	key.On("PutQName", mock.Anything, mock.Anything).Return().Maybe()
+	key.On("PutRecordID", mock.Anything, mock.Anything).Return().Maybe()
+	return key
+}
+
+func requireAtomicInviteReplacement(t *testing.T, requests []capturedFederationRequest, previousInviteID, currentInviteID, subjectID istructs.RecordID, currentInviteEmail string) {
+	t.Helper()
+
+	workspaceCUDRequests := make([]capturedFederationRequest, 0, 1)
+	for _, request := range requests {
+		require.NotContains(t, request.path, "DeactivateJoinedWorkspace")
+		if strings.HasSuffix(request.path, "/c.sys.CUD") {
+			workspaceCUDRequests = append(workspaceCUDRequests, request)
+		}
+	}
+	require.Len(t, workspaceCUDRequests, 1, "replacement must use one workspace-local CUD")
+
+	var body struct {
+		CUDs []struct {
+			ID     istructs.RecordID `json:"sys.ID"`
+			Fields map[string]any    `json:"fields"`
+		} `json:"cuds"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(workspaceCUDRequests[0].body), &body))
+	require.Len(t, body.CUDs, 3)
+
+	cudsByID := make(map[istructs.RecordID]map[string]any, len(body.CUDs))
+	for _, cud := range body.CUDs {
+		cudsByID[cud.ID] = cud.Fields
+		require.NotContains(t, cud.Fields, appdef.SystemField_IsActive)
+	}
+
+	previousFields := cudsByID[previousInviteID]
+	require.Equal(t, float64(State_Cancelled), previousFields[Field_State])
+	if writtenSubjectID, ok := previousFields[field_SubjectID]; ok {
+		require.Equal(t, float64(subjectID), writtenSubjectID, "retired invitation must preserve its historical SubjectID")
+	}
+
+	currentFields := cudsByID[currentInviteID]
+	require.Equal(t, float64(State_Joined), currentFields[Field_State])
+	require.Equal(t, float64(subjectID), currentFields[field_SubjectID])
+
+	subjectFields := cudsByID[subjectID]
+	require.Equal(t, applyInviteEventsTestReplacementRoles, subjectFields[Field_Roles])
+	require.Equal(t, currentInviteEmail, subjectFields[applyInviteEventsTestInviteEmail])
 }

--- a/pkg/sys/invite/impl_initiatejoinworkspace.go
+++ b/pkg/sys/invite/impl_initiatejoinworkspace.go
@@ -5,6 +5,7 @@
 package invite
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -29,11 +30,12 @@ func provideCmdInitiateJoinWorkspace(sr istructsmem.IStatelessResources, time ti
 // [~server.invites/Join.InitiateJoinWorkspace~impl]
 func execCmdInitiateJoinWorkspace(tm timeu.ITime, tokens itokens.ITokens) func(args istructs.ExecCommandArgs) (err error) {
 	return func(args istructs.ExecCommandArgs) (err error) {
+		inviteID := args.ArgumentObject.AsRecordID(field_InviteID)
 		skbCDocInvite, err := args.State.KeyBuilder(sys.Storage_Record, QNameCDocInvite)
 		if err != nil {
 			return
 		}
-		skbCDocInvite.PutRecordID(sys.Storage_Record_Field_ID, args.ArgumentObject.AsRecordID(field_InviteID))
+		skbCDocInvite.PutRecordID(sys.Storage_Record_Field_ID, inviteID)
 		svCDocInvite, ok, err := args.State.CanExist(skbCDocInvite)
 		if err != nil {
 			return
@@ -72,6 +74,17 @@ func execCmdInitiateJoinWorkspace(tm timeu.ITime, tokens itokens.ITokens) func(a
 			return coreutils.NewHTTPErrorf(http.StatusBadRequest, fmt.Sprintf("invitation was sent to %s but current login is %s", emailWeSentTo, loginFromToken))
 		}
 
+		subjectID, subject, subjectExists, err := subjectByLogin(loginFromToken, args.State)
+		if err != nil {
+			return err
+		}
+		if subjectExists && subject.AsBool(appdef.SystemField_IsActive) {
+			_, _, err = resolveControllingInvite(subjectID, subject, loginFromToken, principalPayload.Alias, inviteID, args.State)
+			if err = controllingInviteResolutionError(err, loginFromToken); err != nil {
+				return err
+			}
+		}
+
 		svbCDocInvite, err := args.Intents.UpdateValue(skbCDocInvite, svCDocInvite)
 		if err != nil {
 			return
@@ -84,4 +97,11 @@ func execCmdInitiateJoinWorkspace(tm timeu.ITime, tokens itokens.ITokens) func(a
 
 		return
 	}
+}
+
+func controllingInviteResolutionError(err error, canonicalLogin string) error {
+	if errors.Is(err, ErrControllingInviteNotIdentified) {
+		return coreutils.NewHTTPErrorf(http.StatusConflict, fmt.Sprintf(errControllingInviteNotIdentifiedMessageFormat, canonicalLogin))
+	}
+	return err
 }

--- a/pkg/sys/invite/impl_initiateleaveworkspace.go
+++ b/pkg/sys/invite/impl_initiateleaveworkspace.go
@@ -12,6 +12,7 @@ import (
 	"github.com/voedger/voedger/pkg/goutils/timeu"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/istructsmem"
+	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
 	"github.com/voedger/voedger/pkg/sys"
 )
 
@@ -33,26 +34,29 @@ func execCmdInitiateLeaveWorkspace(_ timeu.ITime) func(args istructs.ExecCommand
 			return
 		}
 
-		skbViewInviteIndex, err := args.State.KeyBuilder(sys.Storage_View, qNameViewInviteIndex)
+		canonicalLogin := svPrincipal.AsString(sys.Storage_RequestSubject_Field_Name)
+		subjectID, subject, subjectExists, err := subjectByLogin(canonicalLogin, args.State)
 		if err != nil {
-			return
+			return err
 		}
-		skbViewInviteIndex.PutInt32(field_Dummy, value_Dummy_One)
-		skbViewInviteIndex.PutString(Field_Login, svPrincipal.AsString(sys.Storage_RequestSubject_Field_Name))
-		svViewInviteIndex, err := args.State.MustExist(skbViewInviteIndex)
+		if !subjectExists || !subject.AsBool(appdef.SystemField_IsActive) {
+			return coreutils.NewHTTPError(http.StatusBadRequest, ErrInviteStateInvalid)
+		}
+
+		principalPayload, err := payloads.GetPrincipalPayload(args.State.AppStructs().AppTokens(), svPrincipal.AsString(sys.Storage_RequestSubject_Field_Token))
 		if err != nil {
-			return
+			return err
+		}
+		inviteID, svCDocInvite, err := resolveControllingInvite(subjectID, subject, canonicalLogin, principalPayload.Alias, istructs.NullRecordID, args.State)
+		if err = controllingInviteResolutionError(err, canonicalLogin); err != nil {
+			return err
 		}
 
 		skbCDocInvite, err := args.State.KeyBuilder(sys.Storage_Record, QNameCDocInvite)
 		if err != nil {
 			return err
 		}
-		skbCDocInvite.PutRecordID(sys.Storage_Record_Field_ID, svViewInviteIndex.AsRecordID(field_InviteID))
-		svCDocInvite, err := args.State.MustExist(skbCDocInvite)
-		if err != nil {
-			return err
-		}
+		skbCDocInvite.PutRecordID(sys.Storage_Record_Field_ID, inviteID)
 
 		if !isValidInviteState(svCDocInvite.AsInt32(Field_State), qNameCmdInitiateLeaveWorkspace) {
 			return coreutils.NewHTTPError(http.StatusBadRequest, ErrInviteStateInvalid)

--- a/pkg/sys/invite/utils.go
+++ b/pkg/sys/invite/utils.go
@@ -131,29 +131,132 @@ func LoginFromToken(st istructs.IState) (loginFromToken string, err error) {
 	return svPrincipal.AsString(sys.Storage_RequestSubject_Field_Name), nil
 }
 
-// SubjectExistsByLogin returns SubjectID and isActive status for a Subject with the given login.
-// Returns (0, false, nil) if no Subject exists for this login.
-func SubjectExistsByLogin(login string, state istructs.IState) (subjectID istructs.RecordID, isActive bool, err error) {
+// subjectByLogin returns the Subject ID and record for a canonical login.
+func subjectByLogin(login string, state istructs.IState) (subjectID istructs.RecordID, subject istructs.IStateValue, ok bool, err error) {
 	skbViewSubjectsIdx, err := GetSubjectIdxViewKeyBuilder(login, state)
 	if err != nil {
 		// notest
-		return 0, false, err
+		return 0, nil, false, err
 	}
 	val, ok, err := state.CanExist(skbViewSubjectsIdx)
 	if err != nil || !ok {
-		return 0, false, err
+		return 0, nil, false, err
 	}
 	subjectID = val.AsRecordID(Field_SubjectID)
 
 	skbSubject, err := state.KeyBuilder(sys.Storage_Record, QNameCDocSubject)
 	if err != nil {
 		// notest
-		return 0, false, err
+		return 0, nil, false, err
 	}
 	skbSubject.PutRecordID(sys.Storage_Record_Field_ID, subjectID)
-	svSubject, ok, err := state.CanExist(skbSubject)
+	subject, ok, err = state.CanExist(skbSubject)
+	if err != nil || !ok {
+		return 0, nil, false, err
+	}
+	return subjectID, subject, true, nil
+}
+
+// SubjectExistsByLogin returns SubjectID and isActive status for a Subject with the given login.
+// Returns (0, false, nil) if no Subject exists for this login.
+func SubjectExistsByLogin(login string, state istructs.IState) (subjectID istructs.RecordID, isActive bool, err error) {
+	subjectID, subject, ok, err := subjectByLogin(login, state)
 	if err != nil || !ok {
 		return 0, false, err
 	}
-	return subjectID, svSubject.AsBool(appdef.SystemField_IsActive), nil
+	return subjectID, subject.AsBool(appdef.SystemField_IsActive), nil
+}
+
+// findInviteByEmail resolves an exact invitation email through InviteIndexView.
+func findInviteByEmail(email string, state istructs.IState) (inviteID istructs.RecordID, invite istructs.IStateValue, ok bool, err error) {
+	if email == "" {
+		return 0, nil, false, nil
+	}
+
+	skbViewInviteIndex, err := state.KeyBuilder(sys.Storage_View, qNameViewInviteIndex)
+	if err != nil {
+		// notest
+		return 0, nil, false, err
+	}
+	skbViewInviteIndex.PutInt32(field_Dummy, value_Dummy_One)
+	skbViewInviteIndex.PutString(Field_Login, email)
+	svViewInviteIndex, ok, err := state.CanExist(skbViewInviteIndex)
+	if err != nil || !ok {
+		return 0, nil, false, err
+	}
+
+	inviteID = svViewInviteIndex.AsRecordID(field_InviteID)
+	if inviteID == istructs.NullRecordID {
+		return 0, nil, false, nil
+	}
+
+	skbInvite, err := state.KeyBuilder(sys.Storage_Record, QNameCDocInvite)
+	if err != nil {
+		// notest
+		return 0, nil, false, err
+	}
+	skbInvite.PutRecordID(sys.Storage_Record_Field_ID, inviteID)
+	invite, ok, err = state.CanExist(skbInvite)
+	if err != nil || !ok {
+		return 0, nil, false, err
+	}
+	return inviteID, invite, true, nil
+}
+
+// resolveControllingInvite returns the sole Joined invitation controlling subject.
+// Subject.InviteEmail is authoritative when it resolves to a valid controller; otherwise
+// canonical login and active alias provide the legacy fallback candidates.
+func resolveControllingInvite(subjectID istructs.RecordID, subject istructs.IStateValue, canonicalLogin, activeAlias string, excludedInviteID istructs.RecordID, state istructs.IState) (inviteID istructs.RecordID, invite istructs.IStateValue, err error) {
+	type inviteLookupResult struct {
+		id     istructs.RecordID
+		invite istructs.IStateValue
+		ok     bool
+		err    error
+	}
+
+	lookupCache := map[string]inviteLookupResult{}
+	lookup := func(email string) inviteLookupResult {
+		if result, found := lookupCache[email]; found {
+			return result
+		}
+		id, value, ok, err := findInviteByEmail(email, state)
+		result := inviteLookupResult{id: id, invite: value, ok: ok, err: err}
+		lookupCache[email] = result
+		return result
+	}
+
+	isValidController := func(result inviteLookupResult) bool {
+		return result.ok &&
+			result.id != excludedInviteID &&
+			State(result.invite.AsInt32(Field_State)) == State_Joined &&
+			result.invite.AsRecordID(field_SubjectID) == subjectID
+	}
+
+	if result := lookup(subject.AsString(Field_InviteEmail)); result.err != nil {
+		return 0, nil, result.err
+	} else if isValidController(result) {
+		return result.id, result.invite, nil
+	}
+
+	candidates := map[istructs.RecordID]istructs.IStateValue{}
+	for _, email := range []string{canonicalLogin, activeAlias} {
+		if email == "" {
+			continue
+		}
+		result := lookup(email)
+		if result.err != nil {
+			return 0, nil, result.err
+		}
+		if isValidController(result) {
+			candidates[result.id] = result.invite
+		}
+	}
+
+	if len(candidates) != 1 {
+		return 0, nil, ErrControllingInviteNotIdentified
+	}
+	for id, value := range candidates {
+		return id, value, nil
+	}
+	return 0, nil, ErrControllingInviteNotIdentified
 }

--- a/pkg/sys/invite/utils_test.go
+++ b/pkg/sys/invite/utils_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/appdef/builder"
 	"github.com/voedger/voedger/pkg/coreutils"
+	"github.com/voedger/voedger/pkg/istructs"
+	"github.com/voedger/voedger/pkg/sys"
 )
 
 var (
@@ -150,4 +152,74 @@ func TestValidateInviteRoles(t *testing.T) {
 			requireRolesError(t, validateInviteRoles("test.Reader,test.Reader", ws), ErrRoleDuplicate)
 		})
 	})
+}
+
+func TestResolveControllingInviteRejectsMultipleFallbackCandidates(t *testing.T) {
+	const (
+		subjectID      = istructs.RecordID(101)
+		canonicalID    = istructs.RecordID(201)
+		aliasID        = istructs.RecordID(202)
+		excludedID     = istructs.RecordID(203)
+		canonicalLogin = "jsmith@example.com"
+		activeAlias    = "j.smith@example.com"
+	)
+
+	newIndexKey := func(email string) *coreutils.MockStateKeyBuilder {
+		key := &coreutils.MockStateKeyBuilder{}
+		key.On("PutInt32", field_Dummy, value_Dummy_One).Return().Once()
+		key.On("PutString", Field_Login, email).Return().Once()
+		return key
+	}
+	newInviteKey := func(id istructs.RecordID) *coreutils.MockStateKeyBuilder {
+		key := &coreutils.MockStateKeyBuilder{}
+		key.On("PutRecordID", sys.Storage_Record_Field_ID, id).Return().Once()
+		return key
+	}
+	newJoinedInvite := func() *coreutils.MockStateValue {
+		invite := &coreutils.MockStateValue{}
+		invite.On("AsInt32", Field_State).Return(int32(State_Joined)).Once()
+		invite.On("AsRecordID", field_SubjectID).Return(subjectID).Once()
+		return invite
+	}
+
+	canonicalIndexKey := newIndexKey(canonicalLogin)
+	aliasIndexKey := newIndexKey(activeAlias)
+	canonicalInviteKey := newInviteKey(canonicalID)
+	aliasInviteKey := newInviteKey(aliasID)
+
+	canonicalIndex := &coreutils.MockStateValue{}
+	canonicalIndex.On("AsRecordID", field_InviteID).Return(canonicalID).Once()
+	aliasIndex := &coreutils.MockStateValue{}
+	aliasIndex.On("AsRecordID", field_InviteID).Return(aliasID).Once()
+	canonicalInvite := newJoinedInvite()
+	aliasInvite := newJoinedInvite()
+
+	subject := &coreutils.MockStateValue{}
+	subject.On("AsString", Field_InviteEmail).Return("").Once()
+
+	st := &coreutils.MockState{}
+	st.On("KeyBuilder", sys.Storage_View, qNameViewInviteIndex).Return(canonicalIndexKey, nil).Once()
+	st.On("CanExist", canonicalIndexKey).Return(canonicalIndex, true, nil).Once()
+	st.On("KeyBuilder", sys.Storage_Record, QNameCDocInvite).Return(canonicalInviteKey, nil).Once()
+	st.On("CanExist", canonicalInviteKey).Return(canonicalInvite, true, nil).Once()
+	st.On("KeyBuilder", sys.Storage_View, qNameViewInviteIndex).Return(aliasIndexKey, nil).Once()
+	st.On("CanExist", aliasIndexKey).Return(aliasIndex, true, nil).Once()
+	st.On("KeyBuilder", sys.Storage_Record, QNameCDocInvite).Return(aliasInviteKey, nil).Once()
+	st.On("CanExist", aliasInviteKey).Return(aliasInvite, true, nil).Once()
+
+	inviteID, invite, err := resolveControllingInvite(subjectID, subject, canonicalLogin, activeAlias, excludedID, st)
+	require.ErrorIs(t, err, ErrControllingInviteNotIdentified)
+	require.Equal(t, istructs.NullRecordID, inviteID)
+	require.Nil(t, invite)
+
+	st.AssertExpectations(t)
+	canonicalIndexKey.AssertExpectations(t)
+	aliasIndexKey.AssertExpectations(t)
+	canonicalInviteKey.AssertExpectations(t)
+	aliasInviteKey.AssertExpectations(t)
+	canonicalIndex.AssertExpectations(t)
+	aliasIndex.AssertExpectations(t)
+	canonicalInvite.AssertExpectations(t)
+	aliasInvite.AssertExpectations(t)
+	subject.AssertExpectations(t)
 }

--- a/pkg/sys/it/impl_invites_feature_test.go
+++ b/pkg/sys/it/impl_invites_feature_test.go
@@ -38,10 +38,11 @@ type invitesFeatureInvite struct {
 }
 
 type invitesFeatureSubject struct {
-	id       istructs.RecordID
-	login    string
-	roles    string
-	isActive bool
+	id          istructs.RecordID
+	login       string
+	roles       string
+	inviteEmail string
+	isActive    bool
 }
 
 // [~server.invites.invite/it~impl]
@@ -179,6 +180,7 @@ func TestInvites(t *testing.T) {
 		// Then User Login "jsmith@example.com" becomes a member of Workspace "Acme"
 		subject := requireInvitesFeatureMembership(t, f, f.email, true)
 		require.Equal(t, initialRoles, subject.roles)
+		require.Equal(t, f.email, subject.inviteEmail)
 
 		// And the membership identifies canonical User Login "jsmith@example.com"
 		require.Equal(t, f.email, subject.login)
@@ -210,6 +212,7 @@ func TestInvites(t *testing.T) {
 		// Then User Login "jsmith@example.com" becomes a member of Workspace "Acme"
 		subject := requireInvitesFeatureMembership(t, f, f.email, true)
 		require.Equal(t, initialRoles, subject.roles)
+		require.Equal(t, alias, subject.inviteEmail)
 
 		// And the membership identifies canonical User Login "jsmith@example.com"
 		require.Equal(t, f.email, subject.login)
@@ -287,28 +290,288 @@ func TestInvites(t *testing.T) {
 		require.Empty(t, getInvitesFeatureSubjects(t, f, f.email))
 	})
 
-	t.Run("invites: scn: Alias-addressed invitation reuses an existing canonical membership", func(t *testing.T) {
-		f := newInvitesFeatureFixture(t, "alias_reuse")
+	t.Run("invites: scn: Existing member replaces the controlling invitation through another authenticated identifier: canonical to alias", func(t *testing.T) {
+		// | previous recipient  | new recipient       |
+		// | jsmith@example.com  | j.smith@example.com |
+		f := newInvitesFeatureFixture(t, "replace_canonical_alias")
 
 		// Given User Login "jsmith@example.com" has active Login Alias "j.smith@example.com"
 		principal, alias := setInvitesFeatureAlias(t, f)
 
-		// And User Login "jsmith@example.com" is already a member of Workspace "Acme"
-		canonicalInviteID, _, canonicalCode := sendInvitesFeatureInvitation(t, f, f.email, initialRoles, f.vit.Now().Add(time.Hour).UnixMilli())
-		acceptInvitesFeatureInvitation(t, f, canonicalInviteID, principal, canonicalCode)
+		// And User Login "jsmith@example.com" joined Workspace "Acme" through an invitation for "<previous recipient>" with Role "app1pkg.LimitedAccessRole"
+		// previous recipient = jsmith@example.com
+		// And Workspace "Acme" has an invitation for "<new recipient>" with Role "app1pkg.SpecialAPITokenRole"
+		// new recipient = j.smith@example.com
+		previousInviteID, newInviteID, newCode := prepareInvitesFeatureReplacement(t, f, principal, f.email, alias)
 
-		// And Workspace "Acme" has an invitation for "j.smith@example.com"
-		aliasInviteID, _, aliasCode := sendInvitesFeatureInvitation(t, f, alias, newRoles, f.vit.Now().Add(time.Hour).UnixMilli())
+		// When User Login "jsmith@example.com" submits the new invitation verification code
+		acceptInvitesFeatureInvitation(t, f, newInviteID, principal, newCode)
 
-		// When User Login "jsmith@example.com" submits the invitation verification code
-		acceptInvitesFeatureInvitation(t, f, aliasInviteID, principal, aliasCode)
+		// Then User Login "jsmith@example.com" remains an active member of Workspace "Acme"
+		subject := requireInvitesFeatureMembership(t, f, f.email, true)
 
-		// Then Workspace "Acme" has exactly one membership for User Login "jsmith@example.com"
-		subjects := getInvitesFeatureSubjects(t, f, f.email)
-		require.Len(t, subjects, 1)
-		require.True(t, subjects[0].isActive)
-		require.Equal(t, newRoles, subjects[0].roles)
-		require.Equal(t, f.email, getInvitesFeatureInvitation(t, f, aliasInviteID).actualLogin)
+		// And Workspace "Acme" has exactly one membership for User Login "jsmith@example.com"
+		require.Len(t, getInvitesFeatureSubjects(t, f, f.email), 1)
+
+		// And the invitation for "<previous recipient>" is cancelled
+		// previous recipient = jsmith@example.com
+		previousInvite := getInvitesFeatureInvitation(t, f, previousInviteID)
+		require.Equal(t, invite.State_Cancelled, previousInvite.state)
+		require.Equal(t, subject.id, previousInvite.subjectID)
+
+		// And Workspace "Acme" has exactly one joined invitation for the membership, addressed to "<new recipient>"
+		// new recipient = j.smith@example.com
+		newInvite := getInvitesFeatureInvitation(t, f, newInviteID)
+		require.Equal(t, invite.State_Joined, newInvite.state)
+		require.Equal(t, subject.id, newInvite.subjectID)
+		require.Equal(t, alias, newInvite.email)
+		require.Equal(t, alias, subject.inviteEmail)
+
+		// And User Login "jsmith@example.com" has Role "app1pkg.SpecialAPITokenRole" in Workspace "Acme"
+		require.Equal(t, newRoles, subject.roles)
+		joinedWorkspace := FindCDocJoinedWorkspaceByInvitingWorkspaceWSIDAndLogin(f.vit, f.ws.WSID, principal)
+		require.True(t, joinedWorkspace.isActive)
+		require.Equal(t, newRoles, joinedWorkspace.roles)
+	})
+
+	t.Run("invites: scn: Existing member replaces the controlling invitation through another authenticated identifier: alias to canonical", func(t *testing.T) {
+		// | previous recipient  | new recipient       |
+		// | j.smith@example.com | jsmith@example.com  |
+		f := newInvitesFeatureFixture(t, "replace_alias_canonical")
+
+		// Given User Login "jsmith@example.com" has active Login Alias "j.smith@example.com"
+		principal, alias := setInvitesFeatureAlias(t, f)
+
+		// And User Login "jsmith@example.com" joined Workspace "Acme" through an invitation for "<previous recipient>" with Role "app1pkg.LimitedAccessRole"
+		// previous recipient = j.smith@example.com
+		// And Workspace "Acme" has an invitation for "<new recipient>" with Role "app1pkg.SpecialAPITokenRole"
+		// new recipient = jsmith@example.com
+		previousInviteID, newInviteID, newCode := prepareInvitesFeatureReplacement(t, f, principal, alias, f.email)
+
+		// When User Login "jsmith@example.com" submits the new invitation verification code
+		acceptInvitesFeatureInvitation(t, f, newInviteID, principal, newCode)
+
+		// Then User Login "jsmith@example.com" remains an active member of Workspace "Acme"
+		subject := requireInvitesFeatureMembership(t, f, f.email, true)
+
+		// And Workspace "Acme" has exactly one membership for User Login "jsmith@example.com"
+		require.Len(t, getInvitesFeatureSubjects(t, f, f.email), 1)
+
+		// And the invitation for "<previous recipient>" is cancelled
+		// previous recipient = j.smith@example.com
+		previousInvite := getInvitesFeatureInvitation(t, f, previousInviteID)
+		require.Equal(t, invite.State_Cancelled, previousInvite.state)
+		require.Equal(t, subject.id, previousInvite.subjectID)
+
+		// And Workspace "Acme" has exactly one joined invitation for the membership, addressed to "<new recipient>"
+		// new recipient = jsmith@example.com
+		newInvite := getInvitesFeatureInvitation(t, f, newInviteID)
+		require.Equal(t, invite.State_Joined, newInvite.state)
+		require.Equal(t, subject.id, newInvite.subjectID)
+		require.Equal(t, f.email, newInvite.email)
+		require.Equal(t, f.email, subject.inviteEmail)
+
+		// And User Login "jsmith@example.com" has Role "app1pkg.SpecialAPITokenRole" in Workspace "Acme"
+		require.Equal(t, newRoles, subject.roles)
+		joinedWorkspace := FindCDocJoinedWorkspaceByInvitingWorkspaceWSIDAndLogin(f.vit, f.ws.WSID, principal)
+		require.True(t, joinedWorkspace.isActive)
+		require.Equal(t, newRoles, joinedWorkspace.roles)
+	})
+
+	t.Run("invites: scn: Workspace owner cannot manage a retired invitation: cancel", func(t *testing.T) {
+		// | operation                                                                            |
+		// | cancels the retired invitation                                                       |
+		f := newInvitesFeatureFixture(t, "reject_retired_cancel")
+		principal, alias := setInvitesFeatureAlias(t, f)
+
+		// Given User Login "jsmith@example.com" is an active member of Workspace "Acme" through a joined invitation for "j.smith@example.com" with Role "app1pkg.SpecialAPITokenRole"
+		// And the previous invitation for "jsmith@example.com" was retired after replacement
+		retiredInviteID, currentInviteID, currentCode := prepareInvitesFeatureReplacement(t, f, principal, f.email, alias)
+		acceptInvitesFeatureInvitation(t, f, currentInviteID, principal, currentCode)
+
+		// When Workspace Owner <operation>
+		// operation = cancels the retired invitation
+		f.vit.PostWS(f.ws, "c.sys.InitiateCancelAcceptedInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, retiredInviteID), httpu.Expect400())
+
+		// Then the response status is "400 Bad Request"
+		// And User Login "jsmith@example.com" remains an active member of Workspace "Acme"
+		subject := requireInvitesFeatureMembership(t, f, f.email, true)
+
+		// And User Login "jsmith@example.com" has Role "app1pkg.SpecialAPITokenRole" in Workspace "Acme"
+		require.Equal(t, newRoles, subject.roles)
+
+		// And the invitation for "j.smith@example.com" remains joined
+		require.Equal(t, invite.State_Joined, getInvitesFeatureInvitation(t, f, currentInviteID).state)
+		require.Equal(t, invite.State_Cancelled, getInvitesFeatureInvitation(t, f, retiredInviteID).state)
+		require.True(t, FindCDocJoinedWorkspaceByInvitingWorkspaceWSIDAndLogin(f.vit, f.ws.WSID, principal).isActive)
+	})
+
+	t.Run("invites: scn: Workspace owner cannot manage a retired invitation: update roles", func(t *testing.T) {
+		// | operation                                                                            |
+		// | updates the retired invitation to Role "app1pkg.LimitedAccessRole"                   |
+		f := newInvitesFeatureFixture(t, "reject_retired_update")
+		principal, alias := setInvitesFeatureAlias(t, f)
+
+		// Given User Login "jsmith@example.com" is an active member of Workspace "Acme" through a joined invitation for "j.smith@example.com" with Role "app1pkg.SpecialAPITokenRole"
+		// And the previous invitation for "jsmith@example.com" was retired after replacement
+		retiredInviteID, currentInviteID, currentCode := prepareInvitesFeatureReplacement(t, f, principal, f.email, alias)
+		acceptInvitesFeatureInvitation(t, f, currentInviteID, principal, currentCode)
+
+		// When Workspace Owner <operation>
+		// operation = updates the retired invitation to Role "app1pkg.LimitedAccessRole"
+		body := fmt.Sprintf(`{"args":{"InviteID":%d,"Roles":"%s","EmailTemplate":"%s","EmailSubject":"%s"}}`,
+			retiredInviteID, initialRoles, "text:"+invite.EmailTemplatePlaceholder_Roles, "roles updated")
+		f.vit.PostWS(f.ws, "c.sys.InitiateUpdateInviteRoles", body, httpu.Expect400())
+
+		// Then the response status is "400 Bad Request"
+		// And User Login "jsmith@example.com" remains an active member of Workspace "Acme"
+		subject := requireInvitesFeatureMembership(t, f, f.email, true)
+
+		// And User Login "jsmith@example.com" has Role "app1pkg.SpecialAPITokenRole" in Workspace "Acme"
+		require.Equal(t, newRoles, subject.roles)
+
+		// And the invitation for "j.smith@example.com" remains joined
+		require.Equal(t, invite.State_Joined, getInvitesFeatureInvitation(t, f, currentInviteID).state)
+		require.Equal(t, invite.State_Cancelled, getInvitesFeatureInvitation(t, f, retiredInviteID).state)
+		require.True(t, FindCDocJoinedWorkspaceByInvitingWorkspaceWSIDAndLogin(f.vit, f.ws.WSID, principal).isActive)
+	})
+
+	for _, tc := range []struct {
+		name        string
+		inviteEmail func(f *invitesFeatureFixture, alias string) string
+	}{
+		{
+			name: "empty InviteEmail",
+			inviteEmail: func(_ *invitesFeatureFixture, _ string) string {
+				return ""
+			},
+		},
+		{
+			name: "unresolvable InviteEmail",
+			inviteEmail: func(f *invitesFeatureFixture, _ string) string {
+				return fmt.Sprintf("missing_%d@example.com", f.vit.NextNumber())
+			},
+		},
+		{
+			name: "InviteEmail references the pending invitation",
+			inviteEmail: func(_ *invitesFeatureFixture, alias string) string {
+				return alias
+			},
+		},
+	} {
+		t.Run("legacy controller fallback: "+tc.name, func(t *testing.T) {
+			f := newInvitesFeatureFixture(t, "fallback")
+			principal, alias := setInvitesFeatureAlias(t, f)
+			previousInviteID, newInviteID, newCode := prepareInvitesFeatureReplacement(t, f, principal, f.email, alias)
+			subject := requireInvitesFeatureMembership(t, f, f.email, true)
+			setInvitesFeatureSubjectInviteEmail(t, f, subject.id, tc.inviteEmail(f, alias))
+
+			acceptInvitesFeatureInvitation(t, f, newInviteID, principal, newCode)
+
+			subject = requireInvitesFeatureMembership(t, f, f.email, true)
+			require.Equal(t, alias, subject.inviteEmail)
+			require.Equal(t, newRoles, subject.roles)
+			require.Equal(t, invite.State_Cancelled, getInvitesFeatureInvitation(t, f, previousInviteID).state)
+			require.Equal(t, invite.State_Joined, getInvitesFeatureInvitation(t, f, newInviteID).state)
+		})
+	}
+
+	t.Run("legacy controller fallback: InviteEmail references another Subject", func(t *testing.T) {
+		f := newInvitesFeatureFixture(t, "fallback_wrong_subject")
+		principal, alias := setInvitesFeatureAlias(t, f)
+		previousInviteID, newInviteID, newCode := prepareInvitesFeatureReplacement(t, f, principal, f.email, alias)
+		subject := requireInvitesFeatureMembership(t, f, f.email, true)
+
+		otherEmail := fmt.Sprintf("other_%d@example.com", f.vit.NextNumber())
+		otherLogin := f.vit.SignUp(otherEmail, "password", istructs.AppQName_test1_app1)
+		otherPrincipal := f.vit.SignIn(otherLogin)
+		otherInviteID, _, otherCode := sendInvitesFeatureInvitation(t, f, otherEmail, initialRoles, f.vit.Now().Add(time.Hour).UnixMilli())
+		acceptInvitesFeatureInvitation(t, f, otherInviteID, otherPrincipal, otherCode)
+		setInvitesFeatureSubjectInviteEmail(t, f, subject.id, otherEmail)
+
+		acceptInvitesFeatureInvitation(t, f, newInviteID, principal, newCode)
+
+		subject = requireInvitesFeatureMembership(t, f, f.email, true)
+		require.Equal(t, alias, subject.inviteEmail)
+		require.Equal(t, newRoles, subject.roles)
+		require.Equal(t, invite.State_Cancelled, getInvitesFeatureInvitation(t, f, previousInviteID).state)
+		require.Equal(t, invite.State_Joined, getInvitesFeatureInvitation(t, f, newInviteID).state)
+		require.Equal(t, invite.State_Joined, getInvitesFeatureInvitation(t, f, otherInviteID).state)
+	})
+
+	t.Run("invites: scn: User cannot replace a membership whose controlling invitation cannot be identified", func(t *testing.T) {
+		// Given User Login "jsmith@example.com" has active Login Alias "j.smith@example.com"
+		f := newInvitesFeatureFixture(t, "reject_missing_controller")
+		principal, alias := setInvitesFeatureAlias(t, f)
+
+		// And User Login "jsmith@example.com" is an active member of Workspace "Acme" with Role "app1pkg.LimitedAccessRole"
+		previousInviteID, newInviteID, newCode := prepareInvitesFeatureReplacement(t, f, principal, f.email, alias)
+		subject := requireInvitesFeatureMembership(t, f, f.email, true)
+
+		// And the membership has no identifiable previous controlling invitation
+		missingInviteEmail := fmt.Sprintf("missing_%d@example.com", f.vit.NextNumber())
+		setInvitesFeatureSubjectInviteEmail(t, f, subject.id, missingInviteEmail)
+		setInvitesFeatureInvitationState(t, f, previousInviteID, invite.State_Cancelled)
+
+		// And Workspace "Acme" has a pending invitation for "j.smith@example.com" with Role "app1pkg.SpecialAPITokenRole"
+		require.Equal(t, invite.State_Invited, getInvitesFeatureInvitation(t, f, newInviteID).state)
+
+		// When User Login "jsmith@example.com" submits the pending invitation verification code
+		// Then the response status is "409 Conflict"
+		// And error message is "A workspace membership is already active for canonical login \"jsmith@example.com\". The existing accepted invitation must be cancelled manually before another invitation can be accepted."
+		InitiateJoinWorkspace(f.vit, f.ws, newInviteID, principal, newCode,
+			it.Expect409(fmt.Sprintf("A workspace membership is already active for canonical login %q. The existing accepted invitation must be cancelled manually before another invitation can be accepted.", f.email)))
+
+		// And User Login "jsmith@example.com" remains an active member of Workspace "Acme" with Role "app1pkg.LimitedAccessRole"
+		subject = requireInvitesFeatureMembership(t, f, f.email, true)
+		require.Equal(t, initialRoles, subject.roles)
+		require.Equal(t, missingInviteEmail, subject.inviteEmail)
+
+		// And the invitation for "j.smith@example.com" remains pending
+		require.Equal(t, invite.State_Invited, getInvitesFeatureInvitation(t, f, newInviteID).state)
+		require.True(t, FindCDocJoinedWorkspaceByInvitingWorkspaceWSIDAndLogin(f.vit, f.ws.WSID, principal).isActive)
+	})
+
+	t.Run("current controlling invitation: owner cancellation retains InviteEmail and rejoin overwrites it", func(t *testing.T) {
+		f := newInvitesFeatureFixture(t, "current_cancel")
+		principal, alias := setInvitesFeatureAlias(t, f)
+		previousInviteID, currentInviteID, currentCode := prepareInvitesFeatureReplacement(t, f, principal, f.email, alias)
+		acceptInvitesFeatureInvitation(t, f, currentInviteID, principal, currentCode)
+
+		f.vit.PostWS(f.ws, "c.sys.InitiateCancelAcceptedInvite", fmt.Sprintf(`{"args":{"InviteID":%d}}`, currentInviteID))
+		WaitForInviteState(f.vit, f.ws, currentInviteID, invite.State_Joined, invite.State_Cancelled)
+
+		subject := requireInvitesFeatureMembership(t, f, f.email, false)
+		require.Equal(t, alias, subject.inviteEmail)
+		require.False(t, FindCDocJoinedWorkspaceByInvitingWorkspaceWSIDAndLogin(f.vit, f.ws.WSID, principal).isActive)
+
+		_, canonicalCode := resendInvitesFeatureInvitation(t, f, previousInviteID, f.email, initialRoles)
+		acceptInvitesFeatureInvitation(t, f, previousInviteID, principal, canonicalCode)
+
+		subject = requireInvitesFeatureMembership(t, f, f.email, true)
+		require.Equal(t, f.email, subject.inviteEmail)
+		require.Equal(t, invite.State_Joined, getInvitesFeatureInvitation(t, f, previousInviteID).state)
+	})
+
+	t.Run("current controlling invitation: member leave retains InviteEmail and rejoin overwrites it", func(t *testing.T) {
+		f := newInvitesFeatureFixture(t, "current_leave")
+		principal, alias := setInvitesFeatureAlias(t, f)
+		previousInviteID, currentInviteID, currentCode := prepareInvitesFeatureReplacement(t, f, principal, f.email, alias)
+		acceptInvitesFeatureInvitation(t, f, currentInviteID, principal, currentCode)
+
+		f.vit.PostWS(f.ws, "c.sys.InitiateLeaveWorkspace", "{}", httpu.WithAuthorizeBy(principal.Token))
+		WaitForInviteState(f.vit, f.ws, currentInviteID, invite.State_Joined, invite.State_Left)
+
+		subject := requireInvitesFeatureMembership(t, f, f.email, false)
+		require.Equal(t, alias, subject.inviteEmail)
+		require.False(t, FindCDocJoinedWorkspaceByInvitingWorkspaceWSIDAndLogin(f.vit, f.ws.WSID, principal).isActive)
+
+		_, canonicalCode := resendInvitesFeatureInvitation(t, f, previousInviteID, f.email, initialRoles)
+		acceptInvitesFeatureInvitation(t, f, previousInviteID, principal, canonicalCode)
+
+		subject = requireInvitesFeatureMembership(t, f, f.email, true)
+		require.Equal(t, f.email, subject.inviteEmail)
+		require.Equal(t, invite.State_Joined, getInvitesFeatureInvitation(t, f, previousInviteID).state)
 	})
 
 	t.Run("invites: scn: Workspace owner updates an invited member's roles", func(t *testing.T) {
@@ -605,6 +868,26 @@ func acceptInvitesFeatureInvitation(t *testing.T, f *invitesFeatureFixture, invi
 	WaitForInviteState(f.vit, f.ws, inviteID, invite.State_Invited, invite.State_Joined)
 }
 
+func prepareInvitesFeatureReplacement(t *testing.T, f *invitesFeatureFixture, principal *it.Principal, previousEmail, newEmail string) (previousInviteID, newInviteID istructs.RecordID, newVerificationCode string) {
+	t.Helper()
+	previousInviteID, _, previousCode := sendInvitesFeatureInvitation(t, f, previousEmail, initialRoles, f.vit.Now().Add(time.Hour).UnixMilli())
+	newInviteID, _, newVerificationCode = sendInvitesFeatureInvitation(t, f, newEmail, newRoles, f.vit.Now().Add(time.Hour).UnixMilli())
+	acceptInvitesFeatureInvitation(t, f, previousInviteID, principal, previousCode)
+	return previousInviteID, newInviteID, newVerificationCode
+}
+
+func setInvitesFeatureSubjectInviteEmail(t *testing.T, f *invitesFeatureFixture, subjectID istructs.RecordID, inviteEmail string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"InviteEmail":%q}}]}`, subjectID, inviteEmail)
+	f.vit.PostWS(f.ws, "c.sys.CUD", body)
+}
+
+func setInvitesFeatureInvitationState(t *testing.T, f *invitesFeatureFixture, inviteID istructs.RecordID, state invite.State) {
+	t.Helper()
+	body := fmt.Sprintf(`{"cuds":[{"sys.ID":%d,"fields":{"State":%d}}]}`, inviteID, state)
+	f.vit.PostWS(f.ws, "c.sys.CUD", body)
+}
+
 func setInvitesFeatureAlias(t *testing.T, f *invitesFeatureFixture) (*it.Principal, string) {
 	t.Helper()
 	alias := fmt.Sprintf("alias_%d@example.com", f.vit.NextNumber())
@@ -640,7 +923,7 @@ func getInvitesFeatureSubjects(t *testing.T, f *invitesFeatureFixture, login str
 	t.Helper()
 	resp := f.vit.PostWS(f.ws, "q.sys.Collection", fmt.Sprintf(`
 		{"args":{"Schema":"sys.Subject"},
-		"elements":[{"fields":["sys.ID","Login","Roles","sys.IsActive"]}],
+		"elements":[{"fields":["sys.ID","Login","Roles","InviteEmail","sys.IsActive"]}],
 		"filters":[{"expr":"eq","args":{"field":"Login","value":"%s"}}]}`, login))
 	if len(resp.Sections) == 0 {
 		return nil
@@ -649,10 +932,11 @@ func getInvitesFeatureSubjects(t *testing.T, f *invitesFeatureFixture, login str
 	for i := range resp.Sections[0].Elements {
 		row := resp.SectionRow(i)
 		subjects = append(subjects, invitesFeatureSubject{
-			id:       istructs.RecordID(row[0].(float64)),
-			login:    row[1].(string),
-			roles:    row[2].(string),
-			isActive: row[3].(bool),
+			id:          istructs.RecordID(row[0].(float64)),
+			login:       row[1].(string),
+			roles:       row[2].(string),
+			inviteEmail: row[3].(string),
+			isActive:    row[4].(bool),
 		})
 	}
 	return subjects

--- a/pkg/sys/sys.vsql
+++ b/pkg/sys/sys.vsql
@@ -75,26 +75,81 @@ ABSTRACT WORKSPACE Workspace (
 		SubjectKind int32 NOT NULL,
 		Roles varchar(1024) NOT NULL,
 		ProfileWSID int64 NOT NULL,
+
+		-- InviteEmail: exact Invite.Email of the current controlling accepted invitation while the Subject is active,
+		-- or of the last controlling accepted invitation while the Subject is inactive.
+		-- Optional because Subjects created before this field was introduced have an empty value.
+		InviteEmail varchar,
+
 		UNIQUEFIELD Login
 	) WITH Tags=(WorkspaceOwnerTableTag);
 
 	TABLE Invite INHERITS sys.CDoc (
 		SubjectKind int32,
-		-- Login: email address the invitation was sent to (set by InitiateInvitationByEMail)
+
+		-- Login: legacy field intended to hold the platform login resolved from the invitation Email.
+		-- Email-to-login resolution was never implemented. The current flow writes Login and Email from the same
+		-- InitiateInvitationByEMail.Email argument and does not subsequently change either field.
+		-- Consequently, Login equals Email and can contain an alias; it is not the canonical membership identity.
+		-- InviteIndexView.Login is populated separately from the command Email without reading this field.
+		-- Sources:
+		-- - pkg/sys/invite/impl_initiateinvitationbyemail.go: writes Invite.Login on creation
+		-- - pkg/sys/invite/impl_inviteindexprojector.go: writes InviteIndexView.Login without reading Invite.Login
 		Login varchar NOT NULL,
+
+		-- Email: original invitation recipient and the Invite's unique field.
+		-- Set together with Login from InitiateInvitationByEMail.Email when the Invite is created and not changed on re-invite.
+		-- Unlike the redundant Login field, Email is read by the current invitation flow.
+		-- InitiateJoinWorkspace requires it to match the authenticated canonical login or active alias.
+		-- ApplyInviteEvents uses it as the recipient of role-update emails.
+		-- Sources:
+		-- - pkg/sys/invite/impl_initiateinvitationbyemail.go: writes Invite.Email on creation
+		-- - pkg/sys/invite/impl_initiatejoinworkspace.go: reads Invite.Email to validate the authenticated recipient
+		-- - pkg/sys/invite/impl_applyinviteevents.go: reads Invite.Email to address role-update emails
 		Email varchar NOT NULL,
+
 		Roles varchar(1024),
+
+		-- ExpireDatetime: Unix epoch time in milliseconds after which the Invite cannot be accepted.
+		-- Set from InitiateInvitationByEMail.ExpireDatetime on creation and every re-invite.
+		-- Checked by InitiateJoinWorkspace before accepting the Invite.
+		-- Sources:
+		-- - pkg/sys/invite/impl_initiateinvitationbyemail.go: writes Invite.ExpireDatetime on creation and re-invite
+		-- - pkg/sys/invite/impl_initiatejoinworkspace.go: reads Invite.ExpireDatetime to reject expired Invites
 		ExpireDatetime int64,
+
 		VerificationCode varchar,
+
+		-- State: current Invite lifecycle state.
+		-- InitiateInvitationByEMail writes the transient ToBeInvited(1) state.
+		-- ApplyInviteEvents writes the final Invited(2), Joined(4), Cancelled(7), and Left(9) states.
+		-- Sources:
+		-- - pkg/sys/invite/impl_initiateinvitationbyemail.go: writes Invite.State as ToBeInvited
+		-- - pkg/sys/invite/impl_applyinviteevents.go: reads Invite.State for guards and writes final states
 		State int32 NOT NULL,
+
 		Created int64,
 		Updated int64 NOT NULL,
+
+		-- SubjectID: ID of the sys.Subject representing the accepted member in the inviting workspace.
+		-- Set by ApplyInviteEvents on join, using either the newly created Subject or an existing Subject for ActualLogin.
+		-- Used later to update roles or deactivate the Subject during cancellation or leave.
+		-- Sources: 
+		-- - pkg/sys/invite/impl_applyinviteevents.go: writes Invite.SubjectID on join and reads it for role update, cancellation, and leave
 		SubjectID ref,
+
 		InviteeProfileWSID int64,
-		-- ActualLogin: invitee's login from auth token (set by InitiateJoinWorkspace when user accepts)
-		-- Currently always equals Login because InitiateJoinWorkspace validates they match
-		-- Used for cdoc.sys.Subject.Login field
+
+		-- ActualLogin: authenticated invitee's canonical login and the canonical membership identity after acceptance.
+		-- It can differ from Login and Email when the Invite was addressed to an alias.
+		-- Set from the principal token by InitiateJoinWorkspace after Email matches the token's canonical login or active alias.
+		-- Cleared on re-invite and used by ApplyInviteEvents to find, create, or reactivate sys.Subject.
+		-- Sources:
+		-- - pkg/sys/invite/impl_initiatejoinworkspace.go: writes Invite.ActualLogin from the authenticated principal
+		-- - pkg/sys/invite/impl_initiateinvitationbyemail.go: clears Invite.ActualLogin on re-invite
+		-- - pkg/sys/invite/impl_applyinviteevents.go: reads Invite.ActualLogin to find, create, or reactivate sys.Subject
 		ActualLogin varchar,
+
 		-- Version: command-side discriminator; current commands write 1, pre-refactor events have 0 and are skipped by ap.sys.ApplyInviteEvents
 		Version int32,
 		UNIQUEFIELD Email

--- a/uspecs/changes/archive/2607/2607310945-replace-active-member-invite/change.md
+++ b/uspecs/changes/archive/2607/2607310945-replace-active-member-invite/change.md
@@ -1,0 +1,109 @@
+---
+change_id: 2607301440-replace-active-member-invite
+type: fix
+issue_url: https://untill.atlassian.net/browse/AIR-4631
+domains: [prod]
+scope: [auth]
+---
+
+# Change request: Replace accepted invitations without revoking membership
+
+## Why
+
+An active workspace member can accept another invitation addressed to the member's canonical login or active login alias, causing multiple invitations to share one membership. The acceptance flow must retire the previous accepted invitation before transferring control of the membership to the new invitation.
+
+## What
+
+Symptom: Accepting an additional invitation can leave multiple joined invitations controlling the same active membership, so cancelling any one of them can revoke the user's workspace access.
+
+```text
+active member accepts another valid invitation
+      |
+      v
+invitation acceptance attaches the new invitation to the existing membership without retiring the previous invitation  <-- fault: multiple invitations control one membership
+      |
+      v
+either accepted invitation can subsequently cancel the membership
+      |
+      v
+cancelling one invitation revokes the user's existing workspace access   (symptom)
+```
+
+Corrected behavior: When an active member accepts another valid invitation, the system retires the uniquely identified previous controlling invitation without interrupting membership, accepts the new invitation as the sole active controller, and applies its roles; if the previous invitation cannot be identified uniquely, the response is `409 Conflict` and nothing changes, while first-time joins and former-member rejoins remain unchanged.
+
+When multiple valid invitation acceptances are queued before projection, they are applied in PLog order and the last successfully applied invitation becomes the sole controller of the membership.
+
+## How
+
+`InitiateJoinWorkspace` validates the invitation and authenticated recipient and records the canonical membership identity, but does not retire another invitation or write final invitation state. `ApplyInviteEvents` remains the sole writer of final invitation states and performs replacement in PLog order as an idempotent transition, preserving an active Subject and JoinedWorkspace while retiring the previous controlling invitation.
+
+`Subject.InviteEmail` may be empty on Subjects created before the field was introduced. Every successful join, rejoin, or replacement writes the accepted `Invite.Email` to this field; when populated, it is the authoritative single link from a Subject to its controlling accepted invitation. `ApplyInviteEvents` resolves an existing value through `InviteIndexView` when replacing an invitation, retires the resolved invitation without deactivating the membership, and replaces `Subject.InviteEmail` with the newly accepted invitation's email.
+
+At most one invitation is actively linked to a Subject: it is in `Joined` state and its `Email` equals `Subject.InviteEmail`. Retired invitations keep their `SubjectID` as historical provenance, but their non-`Joined` state means they no longer control roles or membership cancellation.
+
+When membership cancellation or leave makes a Subject inactive, its `InviteEmail` remains as provenance for the last controlling invitation. An inactive Subject has no active invitation link regardless of that stored value; a successful rejoin overwrites `InviteEmail` with the newly accepted invitation's email.
+
+For an existing active Subject whose `InviteEmail` is absent or cannot be resolved, `InitiateJoinWorkspace` uses the authenticated canonical login and active login alias to look up candidates through `InviteIndexView`, excluding the invitation currently being accepted. Replacement proceeds only when exactly one candidate is joined and references the same Subject; `ApplyInviteEvents` repeats the authoritative check before applying the transition. Zero or multiple matches cause `409 Conflict` with no state changes.
+
+For each accepted join event, `ApplyInviteEvents` loads the invitation referenced by that event. A different queued invitation remains eligible while its state is `Invited`; applying it retires the Subject's current controlling invitation, changes the event's invitation to `Joined`, updates the Subject roles and `InviteEmail`, and leaves the membership active. These workspace-local changes are written together. Replaying an event for the same invitation is a no-op because that invitation is no longer in a valid source state for joining. Cross-workspace JoinedWorkspace role updates remain idempotent.
+
+## Functional design
+
+- [x] update: [auth/invites.feature](../../../../specs/prod/auth/invites.feature)
+  - update: "Alias-addressed invitation reuses an existing canonical membership" scenario -> cover both canonical-to-alias and alias-to-canonical replacement while keeping the existing membership active
+  - add: assertions that the previous accepted invitation is retired, the new invitation becomes the sole active controller, and the new invitation's roles take effect
+  - add: scenario verifying that cancelling or updating a retired invitation is rejected without affecting the active membership
+  - add: scenario verifying `409 Conflict` with no state changes when an active member's previous controlling invitation cannot be identified uniquely
+
+## Construction
+
+### Tests
+
+- [x] update: [sys/it/impl_invites_feature_test.go](../../../../../pkg/sys/it/impl_invites_feature_test.go)
+  - extend the Subject test projection with `InviteEmail`
+  - update the canonical-to-alias replacement scenario to assert that the previous invitation becomes `Cancelled` while retaining its historical `SubjectID`, the new invitation becomes `Joined`, the membership and JoinedWorkspace stay active, the new roles take effect, and `Subject.InviteEmail` identifies the new invitation
+  - add the reciprocal alias-to-canonical replacement scenario and verify that cancelling or updating the retired invitation is rejected without affecting membership
+  - cover an existing active Subject with empty, missing, non-`Joined`, or wrong-Subject `InviteEmail`: accept only when canonical-login/active-alias fallback finds exactly one different joined invitation for the same Subject, otherwise return `409 Conflict` with no changes
+  - verify that cancelling the current invitation and member-initiated leave both target the invitation identified by `Subject.InviteEmail`, retain that field on the inactive Subject, and allow rejoin to overwrite it
+
+- [x] update: [invite/impl_applyinviteevents_test.go](../../../../../pkg/sys/invite/impl_applyinviteevents_test.go)
+  - cover sequential join events for different invitations and assert deterministic PLog-order replacement with the last event as the sole active controller
+  - verify that replaying a join event for an invitation already in `Joined` state is a no-op
+  - verify that replacement writes the previous Invite, current Invite, and Subject changes together and does not deactivate Subject or JoinedWorkspace
+
+### Schema and shared helpers
+
+- [x] update: [sys/sys.vsql](../../../../../pkg/sys/sys.vsql)
+  - add optional `InviteEmail varchar` to `TABLE Subject`
+  - document that it stores the exact email of the current or last controlling accepted invitation and is empty on records created before the field exists
+
+- [x] update: [invite/consts.go](../../../../../pkg/sys/invite/consts.go)
+  - add the `InviteEmail` field-name constant used by Subject reads and writes
+
+- [x] update: [invite/errors.go](../../../../../pkg/sys/invite/errors.go)
+  - add the conflict error returned when an active Subject's controlling invitation cannot be identified uniquely
+
+- [x] update: [invite/utils.go](../../../../../pkg/sys/invite/utils.go)
+  - add exact invitation lookup through `InviteIndexView`
+  - add controlling-invitation resolution from `Subject.InviteEmail`, requiring the resolved invitation to be `Joined` and linked to the same Subject
+  - add legacy fallback resolution by authenticated canonical login and active alias, excluding the invitation being accepted and requiring exactly one joined invitation for the same Subject
+
+### Command validation
+
+- [x] update: [invite/impl_initiatejoinworkspace.go](../../../../../pkg/sys/invite/impl_initiatejoinworkspace.go)
+  - look up Subject by authenticated canonical login after recipient validation
+  - when the Subject is active, pre-validate the controlling invitation through `Subject.InviteEmail` or the legacy fallback and return `409 Conflict` without emitting changes when resolution is not unique
+  - preserve first-join and inactive-Subject rejoin behavior and continue recording canonical `Invite.ActualLogin`
+
+- [x] update: [invite/impl_initiateleaveworkspace.go](../../../../../pkg/sys/invite/impl_initiateleaveworkspace.go)
+  - resolve the active controlling invitation through `Subject.InviteEmail` instead of assuming its address is the canonical login
+  - use the same legacy fallback for existing Subjects with no resolvable `InviteEmail`
+
+### Projector
+
+- [x] update: [invite/impl_applyinviteevents.go](../../../../../pkg/sys/invite/impl_applyinviteevents.go)
+  - write `Subject.InviteEmail` on first join, rejoin, and replacement
+  - for an active Subject, repeat authoritative controlling-invitation resolution and retire the previous invitation without invoking membership deactivation
+  - apply previous Invite `Cancelled` while preserving its historical `SubjectID`, current Invite `Joined`, Subject roles, current Invite SubjectID linkage, and `Subject.InviteEmail` as one workspace-local CUD
+  - retain `Subject.InviteEmail` when cancel or leave deactivates membership
+  - preserve idempotent JoinedWorkspace role updates and PLog-order last-wins behavior

--- a/uspecs/changes/archive/2607/2607310945-replace-active-member-invite/decisions.md
+++ b/uspecs/changes/archive/2607/2607310945-replace-active-member-invite/decisions.md
@@ -1,0 +1,145 @@
+# Decisions: Replace accepted invitations without revoking membership
+
+## Uncertainty: Handling a second accepted invitation for an active member
+
+Decision: An active Subject identifies its single controlling accepted invitation through `Subject.InviteEmail`. Resolve that address through `InviteIndexView`, cancel the resolved previous invitation without deactivating the Subject or JoinedWorkspace, then accept the new invitation, apply its roles, and replace `Subject.InviteEmail` with the new `Invite.Email`.
+
+- Pros: Allows the new invitation to replace the previous one while preserving uninterrupted workspace access and gives each Subject one authoritative controlling invitation.
+- Cons: Gives cancellation two different side-effect profiles and cannot automatically replace membership when neither the stored address nor the current canonical-login/alias pair identifies a unique previous invitation.
+- Confidence: user-provided
+
+Alternatives:
+
+1. Reject the second acceptance with `409 Conflict`
+   - Pros: Preserves current membership ownership and requires no invitation-transfer semantics.
+   - Cons: Leaves the additional invitation pending and prevents intentional replacement through acceptance.
+   - Confidence: high
+2. Supersede the previous invitation with a dedicated state
+   - Pros: Makes replacement explicit in the state model and audit history.
+   - Cons: Requires a new state and corresponding command, projector, compatibility, and migration behavior.
+   - Confidence: medium
+
+## Uncertainty: Component responsible for retiring the previous invitation
+
+Decision: `InitiateJoinWorkspace` performs command-side validation and records the canonical membership identity, while `ApplyInviteEvents` performs the replacement in PLog order and remains the sole writer of final invitation states and membership side effects.
+
+- Pros: Preserves the single-projector architecture, serializes concurrent acceptance events, and supports idempotent replay and recovery.
+- Cons: Replacement failures discovered during projection cannot always be returned synchronously by `InitiateJoinWorkspace`.
+- Confidence: high
+
+Alternatives:
+
+1. Let `InitiateJoinWorkspace` directly retire the previous invitation
+   - Pros: Provides an immediate outcome to the caller.
+   - Cons: Introduces another writer of final invitation state and creates races with queued or replayed events.
+   - Confidence: low
+2. Introduce a dedicated replacement command
+   - Pros: Gives invitation replacement an explicit operation and contract.
+   - Cons: Expands the API and still requires coordination with the join event and projector.
+   - Confidence: medium
+
+## Uncertainty: Subject field used to identify the controlling invitation
+
+Decision: Add `Subject.InviteEmail` as the single authoritative link to the controlling accepted invitation. Store the exact immutable `Invite.Email` value and resolve it through `InviteIndexView` when the projector must load the previous invitation.
+
+- Pros: Expresses the one-controlling-invitation invariant directly on Subject and reuses the existing email-to-InviteID index.
+- Cons: Duplicates the invitation address on Subject and requires fallback lookup for existing Subjects without the field.
+- Confidence: user-provided
+
+Alternatives:
+
+1. Add `Subject.InviteID ref`
+   - Pros: Uses a stable direct record reference and avoids an index lookup.
+   - Cons: Requires a new reference field and the same compatibility handling for existing Subjects.
+   - Confidence: high
+2. Add a reverse invitation view keyed by `SubjectID`
+   - Pros: Avoids changing Subject and can expose existing duplicate invitation links.
+   - Cons: Requires a new maintained view and a rule for choosing among multiple joined invitations.
+   - Confidence: medium
+
+## Uncertainty: Compatibility for existing Subjects without a resolvable InviteEmail
+
+Decision: When `Subject.InviteEmail` is absent or cannot be resolved, use the authenticated canonical login and active login alias to look up invitations through `InviteIndexView`, excluding the invitation currently being accepted. Continue replacement only when exactly one candidate is joined and its `SubjectID` matches the active Subject; otherwise return `409 Conflict` with no state changes. A successful replacement stores the new `Invite.Email` in `Subject.InviteEmail`.
+
+- Pros: Handles the common canonical-login and active-alias legacy cases without a migration while refusing ambiguous ownership.
+- Cons: Cannot recover automatically when the previous invitation used an old or removed alias.
+- Confidence: high
+
+Alternatives:
+
+1. Always return `409 Conflict` when `Subject.InviteEmail` is absent or unresolved
+   - Pros: Never guesses which invitation controls membership.
+   - Cons: Existing members cannot replace invitations until their Subjects are migrated.
+   - Confidence: high
+2. Migrate existing Subjects before enabling replacement
+   - Pros: Provides deterministic links and an opportunity to detect existing duplicates.
+   - Cons: Requires migration and rollout work plus a policy for ambiguous historical data.
+   - Confidence: medium
+
+## Uncertainty: Concurrent invitation acceptances before projection
+
+Decision: Apply valid acceptance events in PLog order. Each event for a different `Invited` invitation replaces the Subject's current controlling invitation, and the last successfully applied event becomes the sole controller. An event replay for the same invitation is skipped after that invitation has reached `Joined`.
+
+- Pros: Produces deterministic last-wins behavior, preserves the single-projector architecture, and maintains exactly one controlling invitation after every applied event.
+- Cons: Multiple callers may receive successful command responses even though an earlier accepted invitation is quickly superseded by a later event.
+- Confidence: high
+
+Alternatives:
+
+1. Let the first applied invitation win and skip later acceptance events
+   - Pros: Prevents immediate replacement of a newly established controlling invitation.
+   - Cons: A later caller may receive command success even though its invitation is never applied.
+   - Confidence: medium
+2. Add command-side synchronization or uniqueness enforcement
+   - Pros: Allows later callers to receive an immediate conflict.
+   - Cons: Requires a broader synchronization mechanism outside the existing projector ordering.
+   - Confidence: medium
+
+## Ambiguity: Meaning of one invitation linked to a Subject
+
+Decision: Enforce at most one active controlling invitation per Subject. The active link is the `Joined` invitation whose `Email` equals `Subject.InviteEmail`. Cancelled, left, or otherwise retired invitations may retain `SubjectID` as historical provenance but cannot control roles or membership cancellation.
+
+- Pros: Preserves invitation history while making the active ownership invariant explicit and avoiding unnecessary mutation of historical records.
+- Cons: Queries that inspect `Invite.SubjectID` must also consider invitation state and `Subject.InviteEmail` rather than treating every historical reference as active.
+- Confidence: user-provided
+
+Alternatives:
+
+1. Clear the previous invitation's `SubjectID` during replacement
+   - Pros: Leaves only the active invitation with a direct Subject reference.
+   - Cons: Loses historical linkage and complicates auditing and diagnostics.
+   - Confidence: medium
+2. Preserve `SubjectID` and add an explicit supersession link
+   - Pros: Records the full replacement chain.
+   - Cons: Adds fields and lifecycle rules that are not required to prevent inactive invitations from affecting membership.
+   - Confidence: medium
+
+## Ambiguity: InviteEmail lifecycle when the Subject becomes inactive
+
+Decision: Retain `Subject.InviteEmail` when cancellation or leave makes the Subject inactive. Treat it as provenance for the last controlling invitation, not as an active link, and overwrite it when a later rejoin succeeds.
+
+- Pros: Preserves the last invitation association for diagnostics and history without requiring fallback lookup during rejoin.
+- Cons: Consumers must check Subject activity before treating `InviteEmail` as the active controlling link.
+- Confidence: high
+
+Alternatives:
+
+1. Clear `Subject.InviteEmail` when membership is cancelled or left
+   - Pros: A non-empty value would always describe a current or potentially active link.
+   - Cons: Loses the last invitation association and requires fallback lookup on rejoin.
+   - Confidence: medium
+
+## Ambiguity: Meaning of InviteEmail being optional for backward compatibility
+
+Decision: Describe the persisted-data behavior explicitly: `Subject.InviteEmail` may be empty on Subjects created before the field was introduced; every successful join, rejoin, or replacement writes it; and the canonical-login/alias fallback applies when it is empty.
+
+- Pros: States exactly which records can lack the value and how the system handles them without implying an API compatibility concern.
+- Cons: Requires a longer explanation than the generic backward-compatibility phrase.
+- Confidence: high
+
+Alternatives:
+
+1. Make `Subject.InviteEmail` required and migrate existing Subjects
+   - Pros: Every Subject immediately satisfies the populated-field invariant.
+   - Cons: Contradicts the selected no-migration fallback and expands rollout scope.
+   - Confidence: low

--- a/uspecs/specs/prod/auth/invites.feature
+++ b/uspecs/specs/prod/auth/invites.feature
@@ -78,12 +78,46 @@ Feature: Workspace invitations
         | has a different verification code |
         | was cancelled                     |
 
-    Scenario: Alias-addressed invitation reuses an existing canonical membership
+    Scenario Outline: Existing member replaces the controlling invitation through another authenticated identifier
       Given User Login "jsmith@example.com" has active Login Alias "j.smith@example.com"
-      And User Login "jsmith@example.com" is already a member of Workspace "Acme"
-      And Workspace "Acme" has an invitation for "j.smith@example.com"
-      When User Login "jsmith@example.com" submits the invitation verification code
-      Then Workspace "Acme" has exactly one membership for User Login "jsmith@example.com"
+      And User Login "jsmith@example.com" joined Workspace "Acme" through an invitation for "<previous recipient>" with Role "app1pkg.LimitedAccessRole"
+      And Workspace "Acme" has an invitation for "<new recipient>" with Role "app1pkg.SpecialAPITokenRole"
+      When User Login "jsmith@example.com" submits the new invitation verification code
+      Then User Login "jsmith@example.com" remains an active member of Workspace "Acme"
+      And Workspace "Acme" has exactly one membership for User Login "jsmith@example.com"
+      And the invitation for "<previous recipient>" is cancelled
+      And Workspace "Acme" has exactly one joined invitation for the membership, addressed to "<new recipient>"
+      And User Login "jsmith@example.com" has Role "app1pkg.SpecialAPITokenRole" in Workspace "Acme"
+
+      Examples:
+        | previous recipient  | new recipient       |
+        | jsmith@example.com  | j.smith@example.com |
+        | j.smith@example.com | jsmith@example.com  |
+
+    Scenario Outline: Workspace owner cannot manage a retired invitation
+      Given User Login "jsmith@example.com" is an active member of Workspace "Acme" through a joined invitation for "j.smith@example.com" with Role "app1pkg.SpecialAPITokenRole"
+      And the previous invitation for "jsmith@example.com" was retired after replacement
+      When Workspace Owner <operation>
+      Then the response status is "400 Bad Request"
+      And User Login "jsmith@example.com" remains an active member of Workspace "Acme"
+      And User Login "jsmith@example.com" has Role "app1pkg.SpecialAPITokenRole" in Workspace "Acme"
+      And the invitation for "j.smith@example.com" remains joined
+
+      Examples:
+        | operation                                                                            |
+        | cancels the retired invitation                                                       |
+        | updates the retired invitation to Role "app1pkg.LimitedAccessRole"                   |
+
+    Scenario: User cannot replace a membership whose controlling invitation cannot be identified
+      Given User Login "jsmith@example.com" has active Login Alias "j.smith@example.com"
+      And User Login "jsmith@example.com" is an active member of Workspace "Acme" with Role "app1pkg.LimitedAccessRole"
+      And the membership has no identifiable previous controlling invitation
+      And Workspace "Acme" has a pending invitation for "j.smith@example.com" with Role "app1pkg.SpecialAPITokenRole"
+      When User Login "jsmith@example.com" submits the pending invitation verification code
+      Then the response status is "409 Conflict"
+      And error message is "A workspace membership is already active for canonical login \"jsmith@example.com\". The existing accepted invitation must be cancelled manually before another invitation can be accepted."
+      And User Login "jsmith@example.com" remains an active member of Workspace "Acme" with Role "app1pkg.LimitedAccessRole"
+      And the invitation for "j.smith@example.com" remains pending
 
   Rule: Managing member roles
 


### PR DESCRIPTION
```yaml
change_id: 2607301440-replace-active-member-invite
type: fix
issue_url: https://untill.atlassian.net/browse/AIR-4631
domains: [prod]
scope: [auth]
```
## Why

An active workspace member can accept another invitation addressed to the member's canonical login or active login alias, causing multiple invitations to share one membership. The acceptance flow must retire the previous accepted invitation before transferring control of the membership to the new invitation.

## What

Symptom: Accepting an additional invitation can leave multiple joined invitations controlling the same active membership, so cancelling any one of them can revoke the user's workspace access.

```text
active member accepts another valid invitation
      |
      v
invitation acceptance attaches the new invitation to the existing membership without retiring the previous invitation  <-- fault: multiple invitations control one membership
      |
      v
either accepted invitation can subsequently cancel the membership
      |
      v
cancelling one invitation revokes the user's existing workspace access   (symptom)
```

Corrected behavior: When an active member accepts another valid invitation, the system retires the uniquely identified previous controlling invitation without interrupting membership, accepts the new invitation as the sole active controller, and applies its roles; if the previous invitation cannot be identified uniquely, the response is `409 Conflict` and nothing changes, while first-time joins and former-member rejoins remain unchanged.

When multiple valid invitation acceptances are queued before projection, they are applied in PLog order and the last successfully applied invitation becomes the sole controller of the membership.

## How

`InitiateJoinWorkspace` validates the invitation and authenticated recipient and records the canonical membership identity, but does not retire another invitation or write final invitation state. `ApplyInviteEvents` remains the sole writer of final invitation states and performs replacement in PLog order as an idempotent transition, preserving an active Subject and JoinedWorkspace while retiring the previous controlling invitation.

`Subject.InviteEmail` may be empty on Subjects created before the field was introduced. Every successful join, rejoin, or replacement writes the accepted `Invite.Email` to this field; when populated, it is the authoritative single link from a Subject to its controlling accepted invitation. `ApplyInviteEvents` resolves an existing value through `InviteIndexView` when replacing an invitation, retires the resolved invitation without deactivating the membership, and replaces `Subject.InviteEmail` with the newly accepted invitation's email.

At most one invitation is actively linked to a Subject: it is in `Joined` state and its `Email` equals `Subject.InviteEmail`. Retired invitations keep their `SubjectID` as historical provenance, but their non-`Joined` state means they no longer control roles or membership cancellation.



---
Content omitted. See change.md for full details.
