### PR TITLE
[AIR-4649] relocate field registry.Login.CanonicalLoginDisabled to the end of the table

### DIFF
--- a/pkg/registry/appws.vsql
+++ b/pkg/registry/appws.vsql
@@ -17,14 +17,14 @@ ALTER WORKSPACE sys.AppWorkspaceWS (
 		-- [~server.authnz.groles/cmp.cdoc.registry.Login.GlobalRoles~impl]
 		GlobalRoles varchar(1024),
 
-		-- Absent or false means that the canonical Login is enabled.
-		CanonicalLoginDisabled bool,
-
 		-- Login alias lifecycle state. AliasInProc is non-zero while the
 		-- async alias projector is applying an alias create, update, or clear.
 		AliasInProc int32,
 		Alias varchar,
 		AliasError varchar(1024)
+
+		-- Absent or false means that the canonical Login is enabled.
+		CanonicalLoginDisabled bool
 	);
 
 	-- Active sign-in alias index. SourceAppWSID and CDocLoginID point back to

--- a/pkg/registry/appws.vsql
+++ b/pkg/registry/appws.vsql
@@ -21,7 +21,7 @@ ALTER WORKSPACE sys.AppWorkspaceWS (
 		-- async alias projector is applying an alias create, update, or clear.
 		AliasInProc int32,
 		Alias varchar,
-		AliasError varchar(1024)
+		AliasError varchar(1024),
 
 		-- Absent or false means that the canonical Login is enabled.
 		CanonicalLoginDisabled bool


### PR DESCRIPTION
relocate field registry.Login.CanonicalLoginDisabled to the end of the table
https://untill.atlassian.net/browse/AIR-4649

## Why
`registry.Login.CanonicalLoginDisabled` is inserted in the middle of the table in https://github.com/voedger/voedger/pull/4615. That is wrong, flatbuffer will be damaged

## What
relocate `registry.Login.CanonicalLoginDisabled` to the end of the table