### PR TITLE
feat(apps,extensions): Stack traces for extension panics [AIR-4660]

### DIFF
--- a/pkg/iextengine/builtin/impl.go
+++ b/pkg/iextengine/builtin/impl.go
@@ -7,6 +7,7 @@ package iextenginebuiltin
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/iextengine"
@@ -28,7 +29,7 @@ func (e extensionEngine) SetLimits(iextengine.ExtensionLimits) {}
 func (e extensionEngine) Invoke(ctx context.Context, extName appdef.FullQName, io iextengine.IExtensionIO) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("extension %s panic: %v", extName, r)
+			err = fmt.Errorf("extension %s panic: %v\n%s", extName, r, debug.Stack())
 		}
 	}()
 	if f, ok := e.statelessFuncs[extName]; ok {

--- a/pkg/iextengine/builtin/impl_test.go
+++ b/pkg/iextengine/builtin/impl_test.go
@@ -7,6 +7,7 @@ package iextenginebuiltin
 import (
 	"context"
 	"errors"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -67,18 +68,19 @@ func Test_BasicUsage(t *testing.T) {
 	require.Equal(42, statelessFuncValue)
 }
 
+func panickingExtension(context.Context, iextengine.IExtensionIO) error {
+	panic("boom")
+}
+
 func Test_Panics(t *testing.T) {
 
 	require := require.New(t)
 
 	ext1name := appdef.NewFullQName("test", "ext1")
-	ext1func := func(ctx context.Context, io iextengine.IExtensionIO) error {
-		panic("boom")
-	}
 
 	factory := ProvideExtensionEngineFactory(iextengine.BuiltInAppExtFuncs{
 		istructs.AppQName_test1_app1: iextengine.BuiltInExtFuncs{
-			ext1name: ext1func,
+			ext1name: panickingExtension,
 		},
 	}, nil)
 
@@ -86,6 +88,11 @@ func Test_Panics(t *testing.T) {
 	require.NoError(err)
 	require.Len(engines, 5)
 
-	require.ErrorContains(engines[0].Invoke(context.Background(), ext1name, nil), "extension test.ext1 panic: boom")
+	err = engines[0].Invoke(context.Background(), ext1name, nil)
+	require.ErrorContains(err, "extension test.ext1 panic: boom")
+	require.ErrorContains(err, "goroutine ")
+	require.ErrorContains(err, "[running]:")
+	require.ErrorContains(err, "panickingExtension")
+	log.Println(err.Error())
 
 }

--- a/pkg/iextengine/builtin/impl_test.go
+++ b/pkg/iextengine/builtin/impl_test.go
@@ -92,6 +92,6 @@ func Test_Panics(t *testing.T) {
 	require.ErrorContains(err, "goroutine ")
 	require.ErrorContains(err, "[running]:")
 	require.ErrorContains(err, "panickingExtension")
-	t.Logf(err.Error())
+	t.Log(err.Error())
 
 }

--- a/pkg/iextengine/builtin/impl_test.go
+++ b/pkg/iextengine/builtin/impl_test.go
@@ -7,7 +7,6 @@ package iextenginebuiltin
 import (
 	"context"
 	"errors"
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -93,6 +92,6 @@ func Test_Panics(t *testing.T) {
 	require.ErrorContains(err, "goroutine ")
 	require.ErrorContains(err, "[running]:")
 	require.ErrorContains(err, "panickingExtension")
-	log.Println(err.Error())
+	t.Logf(err.Error())
 
 }

--- a/pkg/processors/schedulers/impl_test.go
+++ b/pkg/processors/schedulers/impl_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"iter"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/voedger/voedger/pkg/appdef"
@@ -18,9 +19,15 @@ import (
 	"github.com/voedger/voedger/pkg/appparts"
 	"github.com/voedger/voedger/pkg/goutils/logger"
 	"github.com/voedger/voedger/pkg/goutils/testingu"
+	"github.com/voedger/voedger/pkg/iextengine"
+	iextenginebuiltin "github.com/voedger/voedger/pkg/iextengine/builtin"
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/pipeline"
 )
+
+func panickingSchedulerExtension(context.Context, iextengine.IExtensionIO) error {
+	panic("scheduler extension boom")
+}
 
 func TestSchedulerLogging(t *testing.T) {
 	appName := istructs.AppQName_test1_app1
@@ -87,6 +94,56 @@ func TestSchedulerLogging(t *testing.T) {
 		cancel()
 		<-done
 	})
+
+	t.Run("built-in extension panic log", func(t *testing.T) {
+		logCap := logger.StartCapture(t, logger.LogLevelVerbose)
+		fullJobQName := appDef.FullQName(jobQName)
+		extEngineFactory := iextenginebuiltin.ProvideExtensionEngineFactory(iextengine.BuiltInAppExtFuncs{
+			appName: iextengine.BuiltInExtFuncs{
+				fullJobQName: panickingSchedulerExtension,
+			},
+		}, nil)
+		extEngines, err := extEngineFactory.New(context.Background(), appName, nil, nil, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		extEngine := extEngines[0]
+		defer extEngine.Close(context.Background())
+
+		mockParts := &mockAppPartitions{appDef: appDef, part: &mockAppPartition{
+			invoke: func(ctx context.Context, _ appdef.QName, state istructs.IState, intents istructs.IIntents) error {
+				return extEngine.Invoke(ctx, fullJobQName, iextengine.NewExtensionIO(appDef, state, intents))
+			},
+		}}
+
+		mockTime := testingu.NewMockTime()
+		sr := newSchedulers(BasicSchedulerConfig{Time: mockTime})
+		sr.SetAppPartitions(mockParts)
+
+		isolatedTime := sr.SchedulersTime().(testingu.IMockTime)
+		isolatedTime.FireNextTimerImmediately()
+
+		vvmCtx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			sr.NewAndRun(vvmCtx, appName, 0, 0, wsid, jobQName)
+		}()
+		defer func() {
+			cancel()
+			<-done
+		}()
+
+		panicMessage := "extension " + fullJobQName.String() + " panic: scheduler extension boom"
+		logCap.EventuallyHasLine("level=ERROR", "stage=job.error", vapp, wsidStr, extension, panicMessage, "goroutine ", "[running]:", "panickingSchedulerExtension")
+
+		for _, line := range strings.Split(logCap.String(), "\n") {
+			if strings.Contains(line, "stage=job.error") {
+				t.Logf("actual built-in extension panic log:\n%s", line)
+				break
+			}
+		}
+	})
 }
 
 type mockAppPartitions struct {
@@ -124,7 +181,9 @@ func (m *mockAppPartitions) UpgradeAppDef(_ appdef.AppQName, _ appdef.IAppDef) {
 	panic("not implemented")
 }
 
-type mockAppPartition struct{}
+type mockAppPartition struct {
+	invoke func(context.Context, appdef.QName, istructs.IState, istructs.IIntents) error
+}
 
 func (m *mockAppPartition) App() appdef.AppQName             { panic("not implemented") }
 func (m *mockAppPartition) ID() istructs.PartitionID         { panic("not implemented") }
@@ -133,7 +192,10 @@ func (m *mockAppPartition) Release()                         {}
 func (m *mockAppPartition) DoSyncActualizer(_ context.Context, _ pipeline.IWorkpiece) error {
 	panic("not implemented")
 }
-func (m *mockAppPartition) Invoke(_ context.Context, _ appdef.QName, _ istructs.IState, _ istructs.IIntents) error {
+func (m *mockAppPartition) Invoke(ctx context.Context, name appdef.QName, state istructs.IState, intents istructs.IIntents) error {
+	if m.invoke != nil {
+		return m.invoke(ctx, name, state, intents)
+	}
 	return nil
 }
 func (m *mockAppPartition) IsOperationAllowed(_ appdef.IWorkspace, _ appdef.OperationKind, _ appdef.QName, _ []appdef.FieldName, _ []appdef.QName) (bool, error) {

--- a/uspecs/changes/archive/2608/2608051222-extension-panic-stack-trace/change.md
+++ b/uspecs/changes/archive/2608/2608051222-extension-panic-stack-trace/change.md
@@ -1,0 +1,79 @@
+---
+change_id: 2608051132-extension-panic-stack-trace
+type: feat
+issue_url: https://untill.atlassian.net/browse/AIR-4660
+domains: [prod]
+scope: [apps, extensions]
+---
+
+# Change request: Stack traces for extension panics
+
+Refs:
+
+- [AIR-4660: extengine: provide the stack on extension panic](./issue-AIR-4660.md)
+
+## Why
+
+Extension panic logs currently report the panic without enough context to locate the failing application code. Stack context makes extension failures in the Voedger application platform diagnosable.
+
+## What
+
+Extension panic diagnostics in the Voedger application platform provide actionable failure context:
+
+- Panic log messages include the stack trace from the failed extension execution.
+- Panic log messages continue to identify the extension and panic value alongside the stack trace.
+
+## How
+
+Decisions:
+
+- Capture the current goroutine stack at the built-in extension engine's existing panic-recovery boundary, before the panic stack unwinds, and append it to the recovered error.
+- Preserve the existing panic-error prefix and error-return recovery contract; existing processors remain responsible for logging, retry, and response behavior instead of the extension engine emitting a duplicate log record.
+- Keep the stack in the same error message so processor-specific stages and context attributes remain attached to one correlated log event.
+- Verify stable diagnostic content: the extension identity, panic value, and an extension call-path frame, without binding tests to generated line numbers or the complete runtime stack.
+
+Assumptions:
+
+- Existing consumers treat the extension identity and panic value as the compatibility boundary and do not require built-in extension panic errors to remain single-line.
+
+Out of scope:
+
+- Changing stack extraction or panic formatting for WASM guest runtimes, which use a separate extension-engine error path.
+
+References:
+
+- [built-in extension panic recovery](../../../../../pkg/iextengine/builtin/impl.go)
+- [extension invocation boundary](../../../../../pkg/appparts/impl_app.go)
+- [scheduler error propagation](../../../../../pkg/processors/schedulers/impl_scheduler.go)
+- [extension panic regression coverage](../../../../../pkg/iextengine/builtin/impl_test.go)
+- [processor logging contract](../../../../../uspecs/specs/prod/apps/logging--td.md)
+
+## Technical design
+
+- [x] update: [apps/logging--td.md](../../../../specs/prod/apps/logging--td.md)
+  - add: built-in extension panic errors retain the extension identity and panic value and append the current goroutine stack before recovery unwinds
+  - clarify: existing processor error stages and context attributes remain responsible for logging the enriched error as one correlated log event
+  - clarify: WASM guest-runtime panic extraction and formatting remain unchanged
+
+## Construction
+
+- [x] update: [schedulers/impl_test.go](../../../../../pkg/processors/schedulers/impl_test.go)
+  - add: a named panicking scheduler extension and connect the mock app partition to a real built-in extension engine invocation
+  - add: an integration test that runs the scheduler and verifies one `job.error` record contains the panic prefix, stack markers, extension frame, and structured `vapp`, `wsid`, and `extension` attributes
+  - add: print the captured `job.error` record through `t.Logf` so `go test -v` shows the actual structured log with attributes
+
+- [x] update: [builtin/impl_test.go](../../../../../pkg/iextengine/builtin/impl_test.go)
+  - add: a named panicking extension fixture so its function name provides a stable call-path marker in the captured stack
+  - update: `Test_Panics` to invoke the named fixture, capture the returned error once, and preserve coverage of the `extension test.ext1 panic: boom` prefix and panic value
+  - add: verify current-goroutine stack markers and the named fixture frame without matching generated line numbers or the complete runtime stack
+  - add: print the recovered panic error during the test for direct diagnostic inspection
+
+- [x] update: [builtin/impl.go](../../../../../pkg/iextengine/builtin/impl.go)
+  - update: the existing deferred panic recovery to capture the current goroutine stack at the recovery boundary and append it on a new line after the existing extension identity and panic value
+  - preserve: the error-return recovery contract and absence of engine-level logging; leave the WASM engine path unchanged
+
+- [x] run: `go test ./pkg/iextengine/builtin`
+  - verify: built-in extension behavior and panic diagnostics pass at package scope
+
+- [x] run: `go test ./pkg/iextengine/builtin ./pkg/processors/schedulers`
+  - verify: built-in panic recovery and scheduler structured-log integration pass together at package scope

--- a/uspecs/changes/archive/2608/2608051222-extension-panic-stack-trace/issue-AIR-4660.md
+++ b/uspecs/changes/archive/2608/2608051222-extension-panic-stack-trace/issue-AIR-4660.md
@@ -1,0 +1,22 @@
+# extengine: provide the stack on extension panic
+
+- URL: https://untill.atlassian.net/browse/AIR-4660
+- ID: AIR-4660
+- State: in-progress
+- Author: Denis Gribanov
+- Labels: none
+- Assignees: Denis Gribanov
+
+## Why
+
+panic in extension → have no idea where it happened
+
+[example](https://untillmon.grafana.net/a/grafana-lokiexplore-app/explore/app/airs-bp/logs?from=2026-08-05T08%3A34%3A59.502Z&to=2026-08-05T08%3A35%3A00.502Z&var-ds=fejlmj7udkv7ka&var-filters=app%7C%3D%7Cairs-bp&var-filters=cluster%7C%3D%7Cair-dev&patterns=%5B%5D&var-lineFormat=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&displayedFields=%5B%22time%22%2C%22reqid%22%2C%22vapp%22%2C%22wsid%22%2C%22stage%22%2C%22extension%22%2C%22msg%22%2C%22woffset%22%2C%22poffset%22%5D&visualizationType=%22table%22&timezone=browser&var-all-fields=&userDisplayedFields=true&prettifyLogMessage=false&sortOrder=%22Descending%22&wrapLogMessage=false&panelState=%7B%22logs%22%3A%7B%22displayedFields%22%3A%5B%22time%22%2C%22reqid%22%2C%22vapp%22%2C%22wsid%22%2C%22stage%22%2C%22extension%22%2C%22msg%22%2C%22woffset%22%2C%22poffset%22%5D%2C%22id%22%3A%221785918900002307815_42ed2b8f%22%2C%22sortOrder%22%3A%22Descending%22%7D%7D&var-levels=detected_level%7C%3D%7Cerror&var-fields=extension%7C%3D%7C__CV%CE%A9__%7B%22value%22%3A%22job.air.RefreshTranslations%22__gfc__%22parser%22%3A%22mixed%22%7D%2Cjob.air.RefreshTranslations&var-fields=msg%7C%3D%7C__CV%CE%A9__%7B%22value%22%3A%22extension+github.com%2Funtillpro%2Fairs-bp3%2Fpackages%2Fair.RefreshTranslations+panic%3A+runtime+error%3A+invalid+memory+address+or+nil+pointer+dereference%22__gfc__%22parser%22%3A%22mixed%22%7D%2Cextension+github.com%2Funtillpro%2Fairs-bp3%2Fpackages%2Fair.RefreshTranslations+panic%3A+runtime+error%3A+invalid+memory+address+or+nil+pointer+dereference)
+
+```
+extension github.com/untillpro/airs-bp3/packages/air.RefreshTranslations panic: runtime error: invalid memory address or nil pointer dereference
+```
+
+## What
+
+include stack trace in the log message on panic

--- a/uspecs/changes/archive/2608/2608051222-extension-panic-stack-trace/issue-AIR-4660.md
+++ b/uspecs/changes/archive/2608/2608051222-extension-panic-stack-trace/issue-AIR-4660.md
@@ -11,10 +11,8 @@
 
 panic in extension → have no idea where it happened
 
-[example](https://untillmon.grafana.net/a/grafana-lokiexplore-app/explore/app/airs-bp/logs?from=2026-08-05T08%3A34%3A59.502Z&to=2026-08-05T08%3A35%3A00.502Z&var-ds=fejlmj7udkv7ka&var-filters=app%7C%3D%7Cairs-bp&var-filters=cluster%7C%3D%7Cair-dev&patterns=%5B%5D&var-lineFormat=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&displayedFields=%5B%22time%22%2C%22reqid%22%2C%22vapp%22%2C%22wsid%22%2C%22stage%22%2C%22extension%22%2C%22msg%22%2C%22woffset%22%2C%22poffset%22%5D&visualizationType=%22table%22&timezone=browser&var-all-fields=&userDisplayedFields=true&prettifyLogMessage=false&sortOrder=%22Descending%22&wrapLogMessage=false&panelState=%7B%22logs%22%3A%7B%22displayedFields%22%3A%5B%22time%22%2C%22reqid%22%2C%22vapp%22%2C%22wsid%22%2C%22stage%22%2C%22extension%22%2C%22msg%22%2C%22woffset%22%2C%22poffset%22%5D%2C%22id%22%3A%221785918900002307815_42ed2b8f%22%2C%22sortOrder%22%3A%22Descending%22%7D%7D&var-levels=detected_level%7C%3D%7Cerror&var-fields=extension%7C%3D%7C__CV%CE%A9__%7B%22value%22%3A%22job.air.RefreshTranslations%22__gfc__%22parser%22%3A%22mixed%22%7D%2Cjob.air.RefreshTranslations&var-fields=msg%7C%3D%7C__CV%CE%A9__%7B%22value%22%3A%22extension+github.com%2Funtillpro%2Fairs-bp3%2Fpackages%2Fair.RefreshTranslations+panic%3A+runtime+error%3A+invalid+memory+address+or+nil+pointer+dereference%22__gfc__%22parser%22%3A%22mixed%22%7D%2Cextension+github.com%2Funtillpro%2Fairs-bp3%2Fpackages%2Fair.RefreshTranslations+panic%3A+runtime+error%3A+invalid+memory+address+or+nil+pointer+dereference)
-
 ```
-extension github.com/untillpro/airs-bp3/packages/air.RefreshTranslations panic: runtime error: invalid memory address or nil pointer dereference
+extension <name> panic: runtime error: invalid memory address or nil pointer dereference
 ```
 
 ## What

--- a/uspecs/specs/prod/apps/logging--td.md
+++ b/uspecs/specs/prod/apps/logging--td.md
@@ -72,6 +72,13 @@ A key-value pair that provides additional context to log entries. Attributes are
 - Affected parts of both APIv1 and APIv2 must have the same logging, except when an attribute is not applicable in one of the API versions — in that case the attribute is set to the constant string `<not applicable in APIv1>`
 - If there is already some logging in the affected source code files that is not described in this document then this logging must be dropped
 
+### Built-in extension panic diagnostics
+
+- The [built-in extension engine](../../../../pkg/iextengine/builtin/impl.go) recovers an extension panic before its stack unwinds and returns one error containing `extension <full QName> panic: <panic value>`, followed by the current goroutine stack
+- The extension engine does not emit a separate log record; app partitions propagate the enriched error to the existing processor-specific error handlers
+- Each existing processor error handler logs the enriched error in one call, keeping the extension identity, panic value, stack, stage, and context attributes in the same correlated log record
+- WASM guest-runtime panic extraction and formatting remain unchanged
+
 ---
 
 ## Per-component logging


### PR DESCRIPTION
```yaml
change_id: 2608051132-extension-panic-stack-trace
type: feat
issue_url: https://untill.atlassian.net/browse/AIR-4660
domains: [prod]
scope: [apps, extensions]
```
## Why

Extension panic logs currently report the panic without enough context to locate the failing application code. Stack context makes extension failures in the Voedger application platform diagnosable.

## What

Extension panic diagnostics in the Voedger application platform provide actionable failure context:

- Panic log messages include the stack trace from the failed extension execution.
- Panic log messages continue to identify the extension and panic value alongside the stack trace.

## How

Decisions:

- Capture the current goroutine stack at the built-in extension engine's existing panic-recovery boundary, before the panic stack unwinds, and append it to the recovered error.
- Preserve the existing panic-error prefix and error-return recovery contract; existing processors remain responsible for logging, retry, and response behavior instead of the extension engine emitting a duplicate log record.
- Keep the stack in the same error message so processor-specific stages and context attributes remain attached to one correlated log event.
- Verify stable diagnostic content: the extension identity, panic value, and an extension call-path frame, without binding tests to generated line numbers or the complete runtime stack.

Assumptions:

- Existing consumers treat the extension identity and panic value as the compatibility boundary and do not require built-in extension panic errors to remain single-line.

Out of scope:

- Changing stack extraction or panic formatting for WASM guest runtimes, which use a separate extension-engine error path.

References:

- `[built-in extension panic recovery](/pkg/iextengine/builtin/impl.go)`
- `[extension invocation boundary](/pkg/appparts/impl_app.go)`
- `[scheduler error propagation](/pkg/processors/schedulers/impl_scheduler.go)`


---
Content omitted. See change.md for full details.
