### PR TITLE
fix(apps,storage): Scheduler HTTP storage availability [AIR-4662]

### DIFF
--- a/pkg/sys/it/impl_jobs_test.go
+++ b/pkg/sys/it/impl_jobs_test.go
@@ -8,6 +8,8 @@ package sys_it
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -155,6 +157,51 @@ func TestJobs_SendEmail(t *testing.T) {
 	require.Equal(t, "from@test.com", email.From)
 	require.Equal(t, []string{"to@test.com"}, email.To)
 	require.Equal(t, "Test body", email.Body)
+}
+
+func TestJobs_HTTPStorage(t *testing.T) {
+	const expectedBody = "scheduler HTTP response"
+	requestReceived := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case requestReceived <- r.Method + " " + r.URL.Path:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(expectedBody)); err != nil {
+			t.Errorf("write HTTP response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	cfg := it.NewOwnVITConfig(
+		it.WithApp(istructs.AppQName_test1_app2, it.ProvideApp2WithJobHTTP(server.URL), it.WithUserLogin("login", "1")),
+	)
+	vit := it.NewVIT(t, &cfg)
+	defer vit.TearDown()
+
+	anyAppWSID := istructs.NewWSID(istructs.CurrentClusterID(), istructs.FirstBaseAppWSID)
+	sysToken := vit.GetSystemPrincipal(istructs.AppQName_test1_app2).Token
+	vit.SchedulerTimeAdd(testJobFireInterval)
+
+	var result map[string]interface{}
+	require.Eventually(t, func() bool {
+		body := `{"args":{"Query":"select * from a1.app2pkg.HTTPResults where RequestID = 1 and Dummy = 1"},"elements":[{"fields":["Result"]}]}`
+		resp := vit.PostApp(istructs.AppQName_test1_app2, anyAppWSID, "q.sys.SqlQuery", body, httpu.WithAuthorizeBy(sysToken))
+		if resp.IsEmpty() {
+			return false
+		}
+		return json.Unmarshal([]byte(resp.SectionRow()[0].(string)), &result) == nil
+	}, 5*time.Second, 100*time.Millisecond)
+
+	select {
+	case request := <-requestReceived:
+		require.Equal(t, "GET /", request)
+	default:
+		t.Fatal("scheduler HTTP request was not received")
+	}
+	require.Equal(t, expectedBody, result["Body"])
+	require.Equal(t, float64(http.StatusOK), result["StatusCode"])
 }
 
 func waitForSidecarJobCounter(vit *it.VIT, wsid istructs.WSID, token string, expectedMinimalCounterValue int) {

--- a/pkg/sys/it/impl_jobs_test.go
+++ b/pkg/sys/it/impl_jobs_test.go
@@ -8,8 +8,6 @@ package sys_it
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -160,30 +158,20 @@ func TestJobs_SendEmail(t *testing.T) {
 }
 
 func TestJobs_HTTPStorage(t *testing.T) {
-	const expectedBody = "scheduler HTTP response"
-	requestReceived := make(chan string, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		select {
-		case requestReceived <- r.Method + " " + r.URL.Path:
-		default:
-		}
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte(expectedBody)); err != nil {
-			t.Errorf("write HTTP response: %v", err)
-		}
-	}))
-	defer server.Close()
-
 	cfg := it.NewOwnVITConfig(
-		it.WithApp(istructs.AppQName_test1_app2, it.ProvideApp2WithJobHTTP(server.URL), it.WithUserLogin("login", "1")),
+		it.WithApp(istructs.AppQName_test1_app2, it.ProvideApp2WithJobHTTP(), it.WithUserLogin("login", "1")),
 	)
 	vit := it.NewVIT(t, &cfg)
 	defer vit.TearDown()
 
 	anyAppWSID := istructs.NewWSID(istructs.CurrentClusterID(), istructs.FirstBaseAppWSID)
 	sysToken := vit.GetSystemPrincipal(istructs.AppQName_test1_app2).Token
+
+	// trigger the job
 	vit.SchedulerTimeAdd(testJobFireInterval)
 
+	// the job in shared_cfgs.go must use the http storage and then update StorageObtained
+	// checking that simple http storage usage causes no errors
 	var result map[string]interface{}
 	require.Eventually(t, func() bool {
 		body := `{"args":{"Query":"select * from a1.app2pkg.HTTPResults where RequestID = 1 and Dummy = 1"},"elements":[{"fields":["Result"]}]}`
@@ -194,14 +182,7 @@ func TestJobs_HTTPStorage(t *testing.T) {
 		return json.Unmarshal([]byte(resp.SectionRow()[0].(string)), &result) == nil
 	}, 5*time.Second, 100*time.Millisecond)
 
-	select {
-	case request := <-requestReceived:
-		require.Equal(t, "GET /", request)
-	default:
-		t.Fatal("scheduler HTTP request was not received")
-	}
-	require.Equal(t, expectedBody, result["Body"])
-	require.Equal(t, float64(http.StatusOK), result["StatusCode"])
+	require.True(t, result["StorageObtained"].(bool))
 }
 
 func waitForSidecarJobCounter(vit *it.VIT, wsid istructs.WSID, token string, expectedMinimalCounterValue int) {

--- a/pkg/vit/consts.go
+++ b/pkg/vit/consts.go
@@ -39,6 +39,8 @@ var (
 	SchemaTestApp2WithJobFS embed.FS
 	//go:embed schemaTestApp2WithJobSendMail.vsql
 	SchemaTestApp2WithJobSendMailFS embed.FS
+	//go:embed schemaTestApp2WithJobHTTP.vsql
+	SchemaTestApp2WithJobHTTPFS embed.FS
 
 	DefaultTestAppEnginesPool   = appparts.PoolSize(10, 10, 20, 10)
 	TestAppDeploymentDescriptor = appparts.AppDeploymentDescriptor{

--- a/pkg/vit/schemaTestApp2WithJobHTTP.vsql
+++ b/pkg/vit/schemaTestApp2WithJobHTTP.vsql
@@ -7,8 +7,7 @@ ALTER WORKSPACE sys.AppWorkspaceWS (
 	VIEW HTTPResults (
 		RequestID int32 NOT NULL,
 		Dummy int32 NOT NULL,
-		Body text NOT NULL,
-		StatusCode int32 NOT NULL,
+		StorageObtained bool NOT NULL,
 		PRIMARY KEY((RequestID), Dummy)
 	) AS RESULT OF JobHTTP;
 

--- a/pkg/vit/schemaTestApp2WithJobHTTP.vsql
+++ b/pkg/vit/schemaTestApp2WithJobHTTP.vsql
@@ -1,0 +1,18 @@
+-- Copyright (c) 2026-present unTill Software Development Group B.V.
+-- @author Denis Gribanov
+
+APPLICATION app2();
+
+ALTER WORKSPACE sys.AppWorkspaceWS (
+	VIEW HTTPResults (
+		RequestID int32 NOT NULL,
+		Dummy int32 NOT NULL,
+		Body text NOT NULL,
+		StatusCode int32 NOT NULL,
+		PRIMARY KEY((RequestID), Dummy)
+	) AS RESULT OF JobHTTP;
+
+	EXTENSION ENGINE BUILTIN (
+		JOB JobHTTP '* * * * *' STATE(sys.Http) INTENTS(sys.View(HTTPResults));
+	);
+);

--- a/pkg/vit/shared_cfgs.go
+++ b/pkg/vit/shared_cfgs.go
@@ -227,6 +227,61 @@ func ProvideApp2WithJobSendMail(apis builtinapps.APIs, cfg *istructsmem.AppConfi
 	}
 }
 
+func ProvideApp2WithJobHTTP(url string) builtinapps.Builder {
+	return func(_ builtinapps.APIs, cfg *istructsmem.AppConfigType, _ extensionpoints.IExtensionPoint) builtinapps.Def {
+		sysPackageFS := sysprovide.Provide(cfg)
+		app2PackageFS := parser.PackageFS{
+			Path: app2PkgPath,
+			FS:   SchemaTestApp2WithJobHTTPFS,
+		}
+		cfg.AddJobs(istructsmem.BuiltinJob{
+			Name: appdef.NewQName(app2PkgName, "JobHTTP"),
+			Func: func(st istructs.IState, intents istructs.IIntents) error {
+				httpKey, err := st.KeyBuilder(sys.Storage_HTTP, appdef.NullQName)
+				if err != nil {
+					return err
+				}
+				httpKey.PutString(sys.Storage_HTTP_Field_URL, url)
+
+				var body string
+				var statusCode int32
+				responseRead := false
+				err = st.Read(httpKey, func(_ istructs.IKey, value istructs.IStateValue) error {
+					responseRead = true
+					body = value.AsString(sys.Storage_HTTP_Field_Body)
+					statusCode = value.AsInt32(sys.Storage_HTTP_Field_StatusCode)
+					return nil
+				})
+				if err != nil {
+					return err
+				}
+				if !responseRead {
+					return errors.New("scheduler HTTP storage returned no response")
+				}
+
+				resultKey, err := st.KeyBuilder(sys.Storage_View, appdef.NewQName(app2PkgName, "HTTPResults"))
+				if err != nil {
+					return err
+				}
+				resultKey.PutInt32("RequestID", 1)
+				resultKey.PutInt32("Dummy", 1)
+				result, err := intents.NewValue(resultKey)
+				if err != nil {
+					return err
+				}
+				result.PutString("Body", body)
+				result.PutInt32("StatusCode", statusCode)
+				return nil
+			},
+		})
+		return builtinapps.Def{
+			AppQName:                istructs.AppQName_test1_app2,
+			Packages:                []parser.PackageFS{sysPackageFS, app2PackageFS},
+			AppDeploymentDescriptor: TestAppDeploymentDescriptor,
+		}
+	}
+}
+
 func ProvideApp1(apis builtinapps.APIs, cfg *istructsmem.AppConfigType, ep extensionpoints.IExtensionPoint) builtinapps.Def {
 	// sys package
 	sysPackageFS := sysprovide.Provide(cfg)

--- a/pkg/vit/shared_cfgs.go
+++ b/pkg/vit/shared_cfgs.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/voedger/voedger/pkg/appdef"
@@ -227,7 +228,7 @@ func ProvideApp2WithJobSendMail(apis builtinapps.APIs, cfg *istructsmem.AppConfi
 	}
 }
 
-func ProvideApp2WithJobHTTP(url string) builtinapps.Builder {
+func ProvideApp2WithJobHTTP() builtinapps.Builder {
 	return func(_ builtinapps.APIs, cfg *istructsmem.AppConfigType, _ extensionpoints.IExtensionPoint) builtinapps.Def {
 		sysPackageFS := sysprovide.Provide(cfg)
 		app2PackageFS := parser.PackageFS{
@@ -237,28 +238,22 @@ func ProvideApp2WithJobHTTP(url string) builtinapps.Builder {
 		cfg.AddJobs(istructsmem.BuiltinJob{
 			Name: appdef.NewQName(app2PkgName, "JobHTTP"),
 			Func: func(st istructs.IState, intents istructs.IIntents) error {
+				// try to use the http storage
 				httpKey, err := st.KeyBuilder(sys.Storage_HTTP, appdef.NullQName)
 				if err != nil {
 					return err
 				}
-				httpKey.PutString(sys.Storage_HTTP_Field_URL, url)
-
-				var body string
-				var statusCode int32
-				responseRead := false
-				err = st.Read(httpKey, func(_ istructs.IKey, value istructs.IStateValue) error {
-					responseRead = true
-					body = value.AsString(sys.Storage_HTTP_Field_Body)
-					statusCode = value.AsInt32(sys.Storage_HTTP_Field_StatusCode)
-					return nil
+				httpKey.PutString(sys.Storage_HTTP_Field_URL, "://invalid")
+				err = st.Read(httpKey, func(istructs.IKey, istructs.IStateValue) error {
+					return errors.New("unexpected HTTP storage response")
 				})
-				if err != nil {
-					return err
-				}
-				if !responseRead {
-					return errors.New("scheduler HTTP storage returned no response")
+				var urlErr *url.Error
+				if !errors.As(err, &urlErr) {
+					return errors.New("HTTP storage did not return the expected invalid URL error")
 				}
 
+				// if the storage is used without errors, i.e. underlying IHTTPClient is initialized correctly
+				// then set StorageObtained to check it in the test
 				resultKey, err := st.KeyBuilder(sys.Storage_View, appdef.NewQName(app2PkgName, "HTTPResults"))
 				if err != nil {
 					return err
@@ -269,8 +264,7 @@ func ProvideApp2WithJobHTTP(url string) builtinapps.Builder {
 				if err != nil {
 					return err
 				}
-				result.PutString("Body", body)
-				result.PutInt32("StatusCode", statusCode)
+				result.PutBool("StorageObtained", true)
 				return nil
 			},
 		})

--- a/pkg/vvm/provide.go
+++ b/pkg/vvm/provide.go
@@ -156,7 +156,7 @@ func wireVVM(vvmCtx context.Context, vvmConfig *VVMConfig) (*VVM, func(), error)
 	panic(wire.Build(
 		wire.Struct(new(VVM), "*"),
 		wire.Struct(new(builtinapps.APIs), "*"),
-		wire.Struct(new(schedulers.BasicSchedulerConfig), "VvmName", "SecretReader", "Tokens", "Metrics", "Broker", "Federation", "Time", "EmailSender"),
+		wire.Struct(new(schedulers.BasicSchedulerConfig), "VvmName", "SecretReader", "Tokens", "Metrics", "Broker", "Federation", "Time", "EmailSender", "HTTPClient"),
 		provideServicePipeline,
 		provideCommandProcessors,
 		provideQueryProcessors_V1,

--- a/pkg/vvm/wire_gen.go
+++ b/pkg/vvm/wire_gen.go
@@ -11,14 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
-	"os"
-	"path/filepath"
-	"runtime/debug"
-	"slices"
-	"strconv"
-	"strings"
-
 	"github.com/voedger/voedger/pkg/appdef"
 	"github.com/voedger/voedger/pkg/appdef/builder"
 	"github.com/voedger/voedger/pkg/appparts"
@@ -51,29 +43,36 @@ import (
 	"github.com/voedger/voedger/pkg/istructs"
 	"github.com/voedger/voedger/pkg/istructsmem"
 	"github.com/voedger/voedger/pkg/itokens"
-	payloads "github.com/voedger/voedger/pkg/itokens-payloads"
+	"github.com/voedger/voedger/pkg/itokens-payloads"
 	"github.com/voedger/voedger/pkg/itokensjwt"
-	imetrics "github.com/voedger/voedger/pkg/metrics"
+	"github.com/voedger/voedger/pkg/metrics"
 	"github.com/voedger/voedger/pkg/parser"
 	"github.com/voedger/voedger/pkg/pipeline"
 	"github.com/voedger/voedger/pkg/processors"
 	"github.com/voedger/voedger/pkg/processors/actualizers"
-	blobprocessor "github.com/voedger/voedger/pkg/processors/blobber"
-	commandprocessor "github.com/voedger/voedger/pkg/processors/command"
+	"github.com/voedger/voedger/pkg/processors/blobber"
+	"github.com/voedger/voedger/pkg/processors/command"
 	"github.com/voedger/voedger/pkg/processors/n10n"
-	queryprocessor "github.com/voedger/voedger/pkg/processors/query"
+	"github.com/voedger/voedger/pkg/processors/query"
 	"github.com/voedger/voedger/pkg/processors/query2"
 	"github.com/voedger/voedger/pkg/processors/schedulers"
 	"github.com/voedger/voedger/pkg/router"
 	"github.com/voedger/voedger/pkg/state"
 	"github.com/voedger/voedger/pkg/sys/invite"
 	"github.com/voedger/voedger/pkg/sys/sysprovide"
-	builtinapps "github.com/voedger/voedger/pkg/vvm/builtin"
-	dbcertcache "github.com/voedger/voedger/pkg/vvm/db_cert_cache"
+	"github.com/voedger/voedger/pkg/vvm/builtin"
+	"github.com/voedger/voedger/pkg/vvm/db_cert_cache"
 	"github.com/voedger/voedger/pkg/vvm/engines"
 	"github.com/voedger/voedger/pkg/vvm/metrics"
 	"github.com/voedger/voedger/pkg/vvm/storage"
 	"golang.org/x/crypto/acme/autocert"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"slices"
+	"strconv"
+	"strings"
 )
 
 // Injectors from provide.go:
@@ -142,6 +141,7 @@ func wireVVM(vvmCtx context.Context, vvmConfig *VVMConfig) (*VVM, func(), error)
 		Federation:   iFederation,
 		Time:         iTime,
 		EmailSender:  iEmailSender,
+		HTTPClient:   ihttpClient,
 	}
 	iSchedulerRunner := provideSchedulerRunner(basicSchedulerConfig)
 	bucketsFactoryType := provideBucketsFactory(iTime)
@@ -957,5 +957,6 @@ func provideServicePipeline(
 	publicEndpoint PublicEndpointServiceOperator,
 	appStorageProvider istorage.IAppStorageProvider,
 ) ServicePipeline {
-	return pipeline.NewSyncPipeline(vvmCtx, "ServicePipeline", pipeline.WireSyncOperator("internal services", pipeline.ForkOperator(pipeline.ForkSame, pipeline.ForkBranch(opQueryProcessors_v1), pipeline.ForkBranch(opQueryProcessors_v2), pipeline.ForkBranch(opCommandProcessors), pipeline.ForkBranch(opBLOBProcessors), pipeline.ForkBranch(pipeline.ServiceOperator(appPartsCtl)), pipeline.ForkBranch(pipeline.ServiceOperator(appStorageProvider)))), pipeline.WireSyncOperator("admin endpoint", adminEndpoint), pipeline.WireSyncOperator("bootstrap", bootstrapSyncOp), pipeline.WireSyncOperator("public endpoint", publicEndpoint))
+	return pipeline.NewSyncPipeline(vvmCtx, "ServicePipeline", pipeline.WireSyncOperator("internal services", pipeline.ForkOperator(pipeline.ForkSame, pipeline.ForkBranch(opQueryProcessors_v1), pipeline.ForkBranch(opQueryProcessors_v2), pipeline.ForkBranch(opCommandProcessors), pipeline.ForkBranch(opBLOBProcessors), pipeline.ForkBranch(pipeline.ServiceOperator(appPartsCtl)), pipeline.ForkBranch(pipeline.ServiceOperator(appStorageProvider)))), pipeline.WireSyncOperator("admin endpoint", adminEndpoint), pipeline.WireSyncOperator("bootstrap", bootstrapSyncOp), pipeline.WireSyncOperator("public endpoint", publicEndpoint),
+	)
 }

--- a/uspecs/changes/archive/2608/2608051515-scheduler-http-storage/change.md
+++ b/uspecs/changes/archive/2608/2608051515-scheduler-http-storage/change.md
@@ -1,0 +1,100 @@
+---
+change_id: 2608051451-scheduler-http-storage
+type: fix
+issue_url: https://untill.atlassian.net/browse/AIR-4662
+domains: [prod]
+scope: [apps, storage]
+---
+
+# Change request: Scheduler HTTP storage availability
+
+Refs:
+
+- [AIR-4662: voedger: enable sys.Storage_HTTP in scheduler state](./issue-AIR-4662.md)
+
+## Why
+
+Scheduled jobs can access HTTP storage exposed by the Voedger application platform, but the production VVM does not initialize the scheduler’s HTTP client. An HTTP storage read therefore ends in a nil-pointer panic instead of completing the request.
+
+## What
+
+Symptom: A scheduled job that reads from HTTP storage panics with a nil-pointer dereference.
+
+```text
+scheduled job reads HTTP storage
+      |
+      v
+scheduler creates host state
+      |
+      v
+VVM scheduler configuration       <-- fault: omits the managed HTTP client
+      |
+      v
+HTTP storage receives a nil client
+      |
+      v
+HTTP storage invokes ReqReader
+      |
+      v
+nil-pointer panic                  (symptom)
+```
+
+Corrected behavior: Scheduled jobs use the VVM-managed HTTP client for HTTP storage reads and no longer panic because the client is uninitialized.
+
+## How
+
+Decisions:
+
+- Keep HTTP client ownership and lifecycle at the VVM boundary, and inject the same managed client into scheduler configuration that is shared with other processor state factories.
+- Preserve the existing scheduler-state registration and HTTP storage contract; propagate the managed dependency through the existing scheduler state path instead of creating a scheduler-specific client or a nil-client fallback in HTTP storage.
+- Verify the complete scheduler-to-HTTP-storage path with an integration test using a controllable HTTP client, so dependency wiring and state availability are covered together.
+
+Assumptions:
+
+- None
+
+Out of scope:
+
+- Changing HTTP storage request, response, timeout, or retry semantics.
+
+References:
+
+- [VVM dependency graph and managed client lifetime](../../../../../pkg/vvm/provide.go)
+- [generated scheduler configuration](../../../../../pkg/vvm/wire_gen.go)
+- [scheduler dependency boundary](../../../../../pkg/processors/schedulers/interface.go)
+- [scheduler state construction](../../../../../pkg/processors/schedulers/impl_scheduler.go)
+- [scheduler HTTP storage registration](../../../../../pkg/state/stateprovide/impl_scheduler_state.go)
+- [HTTP storage client use](../../../../../pkg/sys/storages/impl_http_storage.go)
+- [scheduler integration-test pattern](../../../../../pkg/processors/schedulers/impl_test.go)
+
+## Construction
+
+### Tests
+
+- [x] update: [sys/it/impl_jobs_test.go](../../../../../pkg/sys/it/impl_jobs_test.go)
+  - add: an integration test that starts a local HTTP endpoint, deploys the HTTP scheduler-job fixture through the real VVM, and advances isolated scheduler time to run the job
+  - verify: the endpoint receives the scheduled request and the response persisted by the job is available from its result view
+
+- [x] create: [vit/schemaTestApp2WithJobHTTP.vsql](../../../../../pkg/vit/schemaTestApp2WithJobHTTP.vsql)
+  - provide: a dedicated VIT application schema for scheduler HTTP storage coverage
+  - declare: a result view and a built-in scheduled job with read access to `sys.Http` and intent access to that view
+  - support: the end-to-end scenario without changing permissions of existing job fixtures
+
+- [x] update: [vit/consts.go](../../../../../pkg/vit/consts.go)
+  - embed: the scheduler HTTP-storage VSQL fixture for VIT application construction
+
+- [x] update: [vit/shared_cfgs.go](../../../../../pkg/vit/shared_cfgs.go)
+  - add: a fixture builder that accepts the local endpoint URL and registers the built-in job implementation
+  - read: `sys.Storage_HTTP` from the scheduled job, validate the HTTP response callback, and persist the response in the fixture result view
+
+### Runtime wiring
+
+- [x] update: [vvm/provide.go](../../../../../pkg/vvm/provide.go)
+  - inject: the VVM-managed `IHTTPClient` when Wire constructs `BasicSchedulerConfig`, matching other processor configurations
+  - preserve: VVM ownership and cleanup of the shared client and all existing HTTP storage semantics
+
+- [x] run: `go generate ./pkg/vvm/provide.go`
+  - update: [vvm/wire_gen.go](../../../../../pkg/vvm/wire_gen.go) so generated scheduler configuration assigns the managed HTTP client
+
+- [x] run: `go test ./pkg/sys/it -run TestJobs_HTTPStorage`
+  - verify: scheduler HTTP storage works through production VVM dependency wiring

--- a/uspecs/changes/archive/2608/2608051515-scheduler-http-storage/change.md
+++ b/uspecs/changes/archive/2608/2608051515-scheduler-http-storage/change.md
@@ -47,7 +47,7 @@ Decisions:
 
 - Keep HTTP client ownership and lifecycle at the VVM boundary, and inject the same managed client into scheduler configuration that is shared with other processor state factories.
 - Preserve the existing scheduler-state registration and HTTP storage contract; propagate the managed dependency through the existing scheduler state path instead of creating a scheduler-specific client or a nil-client fallback in HTTP storage.
-- Verify the complete scheduler-to-HTTP-storage path with an integration test using a controllable HTTP client, so dependency wiring and state availability are covered together.
+- Verify the scheduler-to-HTTP-storage client path without external I/O by reading an intentionally invalid URL, so the managed client is exercised but rejects the URL before reaching its transport.
 
 Assumptions:
 
@@ -72,20 +72,21 @@ References:
 ### Tests
 
 - [x] update: [sys/it/impl_jobs_test.go](../../../../../pkg/sys/it/impl_jobs_test.go)
-  - add: an integration test that starts a local HTTP endpoint, deploys the HTTP scheduler-job fixture through the real VVM, and advances isolated scheduler time to run the job
-  - verify: the endpoint receives the scheduled request and the response persisted by the job is available from its result view
+  - add: an integration test that deploys the HTTP scheduler-job fixture through the real VVM and advances isolated scheduler time to run the job
+  - verify: the job reaches the managed HTTP client through `sys.Storage_HTTP` and persists a success marker without sending an external HTTP request
 
 - [x] create: [vit/schemaTestApp2WithJobHTTP.vsql](../../../../../pkg/vit/schemaTestApp2WithJobHTTP.vsql)
   - provide: a dedicated VIT application schema for scheduler HTTP storage coverage
-  - declare: a result view and a built-in scheduled job with read access to `sys.Http` and intent access to that view
+  - declare: a result view with a `StorageObtained` marker and a built-in scheduled job with read access to `sys.Http` and intent access to that view
   - support: the end-to-end scenario without changing permissions of existing job fixtures
 
 - [x] update: [vit/consts.go](../../../../../pkg/vit/consts.go)
   - embed: the scheduler HTTP-storage VSQL fixture for VIT application construction
 
 - [x] update: [vit/shared_cfgs.go](../../../../../pkg/vit/shared_cfgs.go)
-  - add: a fixture builder that accepts the local endpoint URL and registers the built-in job implementation
-  - read: `sys.Storage_HTTP` from the scheduled job, validate the HTTP response callback, and persist the response in the fixture result view
+  - add: a fixture builder that registers the built-in HTTP-storage job implementation
+  - read: `sys.Storage_HTTP` with an intentionally invalid URL and require the managed client to return `url.Error` before transport execution
+  - persist: `StorageObtained` in the fixture result view after the client path is exercised successfully
 
 ### Runtime wiring
 

--- a/uspecs/changes/archive/2608/2608051515-scheduler-http-storage/issue-AIR-4662.md
+++ b/uspecs/changes/archive/2608/2608051515-scheduler-http-storage/issue-AIR-4662.md
@@ -1,0 +1,19 @@
+# voedger: enable sys.Storage_HTTP in scheduler state
+
+- URL: https://untill.atlassian.net/browse/AIR-4662
+- ID: AIR-4662
+- State: in-progress
+- Author: Denis Gribanov
+- Labels: none
+- Assignees: Denis Gribanov
+
+## Why
+
+Scheduler state exposes `sys.Storage_HTTP`, but the scheduler’s `IHTTPClient` is not initialized by the production VVM wiring. Any scheduled job that reads from HTTP storage can therefore panic with a nil-pointer dereference.
+
+## What
+
+* Scheduled jobs can use `sys.Storage_HTTP` without panicking.
+* HTTP requests from scheduler state use the VVM-managed HTTP client.
+* Scheduler HTTP-storage behavior is covered by an integration test.
+


### PR DESCRIPTION
```yaml
change_id: 2608051451-scheduler-http-storage
type: fix
issue_url: https://untill.atlassian.net/browse/AIR-4662
domains: [prod]
scope: [apps, storage]
```
## Why

Scheduled jobs can access HTTP storage exposed by the Voedger application platform, but the production VVM does not initialize the scheduler’s HTTP client. An HTTP storage read therefore ends in a nil-pointer panic instead of completing the request.

## What

Symptom: A scheduled job that reads from HTTP storage panics with a nil-pointer dereference.

```text
scheduled job reads HTTP storage
      |
      v
scheduler creates host state
      |
      v
VVM scheduler configuration       <-- fault: omits the managed HTTP client
      |
      v
HTTP storage receives a nil client
      |
      v
HTTP storage invokes ReqReader
      |
      v
nil-pointer panic                  (symptom)
```

Corrected behavior: Scheduled jobs use the VVM-managed HTTP client for HTTP storage reads and no longer panic because the client is uninitialized.

## How

Decisions:



---
Content omitted. See change.md for full details.
