### PR TITLE
test(auth): Login alias reuse after profile deactivation [AIR-4675]

### DIFF
--- a/pkg/sys/it/authn_test.go
+++ b/pkg/sys/it/authn_test.go
@@ -1195,6 +1195,60 @@ func authnLoginAlias(t *testing.T) {
 		aliasToken := issuePrincipalToken(t, vit, clearedAlias, reuseLogin.Pwd, appQName)
 		assertPrincipalTokenClaims(t, vit, aliasToken, reuseLogin.Name, clearedAlias)
 	})
+
+	t.Run("authn: scn: Deactivated Login identifier can become another Login Alias without exposing profile data", func(t *testing.T) {
+		const workspaceName = "shared"
+
+		// Given Profile Workspace of User Login "active@example.com" owns child Workspace "shared" containing value "active"
+		activeLogin := vit.SignUp(fmt.Sprintf("active%d@example.com", vit.NextNumber()), "active-password", appQName)
+		activePrincipal := vit.SignIn(activeLogin)
+		activeWSParams := it.SimpleWSParams(workspaceName)
+		activeWSParams.InitDataJSON = `{"IntFld":1,"StrFld":"active"}`
+		activeWorkspace := vit.CreateWorkspace(activeWSParams, activePrincipal)
+
+		// And Profile Workspace of User Login "retired@example.com" owns child Workspace "shared" containing value "retired"
+		retiredLogin := vit.SignUp(fmt.Sprintf("retired%d@example.com", vit.NextNumber()), "retired-password", appQName)
+		retiredPrincipal := vit.SignIn(retiredLogin)
+		retiredWSParams := it.SimpleWSParams(workspaceName)
+		retiredWSParams.InitDataJSON = `{"IntFld":2,"StrFld":"retired"}`
+		retiredWorkspace := vit.CreateWorkspace(retiredWSParams, retiredPrincipal)
+
+		// And Profile Workspace of User Login "retired@example.com" is deactivated
+		vit.PostProfile(retiredPrincipal, "c.sys.InitiateDeactivateWorkspace", "{}")
+		waitForDeactivate(vit, retiredPrincipal.AppQName, retiredPrincipal.ProfileWSID, retiredLogin.Name)
+
+		// When System sets Login Alias "retired@example.com" for User Login "active@example.com"
+		initiateSetLoginAlias(t, vit, activeLogin, retiredLogin.Name, sysRegistryToken)
+		waitForLoginAlias(t, vit, activeLogin, retiredLogin.Name)
+
+		// And Client signs in using Login Alias "retired@example.com" and the password of User Login "active@example.com"
+		aliasToken := issuePrincipalToken(t, vit, retiredLogin.Name, activeLogin.Pwd, appQName)
+
+		// Then the issued Principal Token identifies User Login "active@example.com" and its Profile Workspace
+		payload := payloads.PrincipalPayload{}
+		_, err := vit.ITokens.ValidateToken(aliasToken, &payload)
+		require.NoError(err)
+		require.Equal(activeLogin.Name, payload.Login)
+		require.Equal(retiredLogin.Name, payload.Alias)
+		require.Equal(activePrincipal.ProfileWSID, payload.ProfileWSID)
+		require.NotEqual(retiredPrincipal.ProfileWSID, payload.ProfileWSID)
+		aliasPrincipal := &it.Principal{
+			Login:       activeLogin,
+			Token:       aliasToken,
+			ProfileWSID: payload.ProfileWSID,
+		}
+
+		// And Client reads value "active" from child Workspace "shared"
+		aliasWorkspace := vit.WaitForWorkspace(workspaceName, aliasPrincipal)
+		require.Equal(activeWorkspace.WSID, aliasWorkspace.WSID)
+		body := `{"args":{"Schema":"app1pkg.test_ws"},"elements":[{"fields":["StrFld"]}]}`
+		actualValue := vit.PostWS(aliasWorkspace, "q.sys.Collection", body).SectionRow()[0].(string)
+		require.Equal("active", actualValue)
+
+		// But Client does not read value "retired" from child Workspace "shared"
+		require.NotEqual(retiredWorkspace.WSID, aliasWorkspace.WSID)
+		require.NotEqual("retired", actualValue)
+	})
 }
 
 func authnLoginAliasCollisionsAndValidation(t *testing.T) {

--- a/uspecs/changes/archive/2608/2608071511-alias-deactivated-profile/change.md
+++ b/uspecs/changes/archive/2608/2608071511-alias-deactivated-profile/change.md
@@ -1,0 +1,58 @@
+---
+change_id: 2608071450-alias-deactivated-profile
+type: test
+issue_url: https://untill.atlassian.net/browse/AIR-4675
+domains: [prod]
+scope: [auth]
+---
+
+# Change request: Login alias reuse after profile deactivation
+
+Refs:
+
+- [AIR-4675: implement an integration test that will check setting alias to the email of a deactivated profile](./issue-AIR-4675.md)
+
+## Why
+
+Integration coverage does not establish whether a deactivated Profile Workspace's Login can safely become the Login Alias of another active Login. Coverage is needed to guard against resolving the alias to the deactivated profile or exposing its workspace-scoped data.
+
+## What
+
+Add integration-level coverage demonstrating that:
+
+- A deactivated Profile Workspace's Login identifier can be assigned as the Login Alias of another active Login.
+- Sign-in through the reused Login Alias resolves the Principal to the active Login's Profile Workspace.
+- Workspace-scoped data accessed through the alias belongs to the active profile and excludes data from the deactivated profile.
+
+## How
+
+Decisions:
+
+- Express the behavior as an Authentication feature scenario and preserve one-to-one Gherkin-to-Go integration-test traceability.
+- Exercise profile deactivation, Login Alias projection, sign-in, and child-workspace resolution through their public integration surfaces and established asynchronous wait helpers instead of directly mutating registry state.
+- Use the alias-issued Principal Token as the authorization context for all post-alias profile and workspace reads; reserve privileged authorization for the System-managed alias operation.
+
+Assumptions:
+
+- None
+
+References:
+
+- [authentication behavior specification](../../../../../uspecs/specs/prod/auth/authn.feature)
+- [authentication integration-test patterns](../../../../../pkg/sys/it/authn_test.go)
+- [Login Alias integration helpers](../../../../../pkg/sys/it/impl_signupin_test.go)
+- [workspace deactivation integration-test patterns](../../../../../pkg/sys/it/impl_deactivateworkspace_test.go)
+- [profile-scoped child-workspace fixtures and resolution](../../../../../pkg/vit/utils.go)
+
+## Functional design
+
+- [x] update: [prod/auth/authn.feature](../../../../specs/prod/auth/authn.feature)
+  - add: scenario proving that a deactivated Login identifier can become another active Login's Login Alias and resolves only that active Login's Profile Workspace and child-workspace data
+
+## Construction
+
+- [x] update: [sys/it/authn_test.go](../../../../../pkg/sys/it/authn_test.go)
+  - add: integration subtest for "Deactivated Login identifier can become another Login Alias without exposing profile data", preserving the scenario name and verbatim step comments
+  - arrange: two User Logins with same-named child Workspaces containing distinct values, then deactivate one Profile Workspace and await completion
+  - act: assign the deactivated Login identifier as the active Login's Login Alias, await projection completion, and sign in through the alias
+  - verify: the issued Principal Token identifies the active Login and Profile Workspace, and alias-authorized child-workspace reads return only the active profile's value

--- a/uspecs/changes/archive/2608/2608071511-alias-deactivated-profile/issue-AIR-4675.md
+++ b/uspecs/changes/archive/2608/2608071511-alias-deactivated-profile/issue-AIR-4675.md
@@ -1,0 +1,28 @@
+# implement an integration test that will check setting alias to the email of a deactivated profile
+
+- URL: https://untill.atlassian.net/browse/AIR-4675
+- ID: AIR-4675
+- State: In Progress
+- Author: Denis Gribanov
+- Assignees: Denis Gribanov
+- Labels: none
+
+## Why
+
+Case:
+
+* there are user Profile 1 and Profile 2
+* deactivate Profile 2
+* set login alias for Profile 1 to email of Profile 2
+
+Not clear will setting login alias will work in this case
+
+## What
+
+implement an integration test that will show the actual behaviour
+
+* create 2 profiles
+* create a child workspace in each
+* fill the same field in the same field with different values
+
+after setting the login alias check that under new alias we do not see values of a deactivated profile

--- a/uspecs/specs/prod/auth/authn.feature
+++ b/uspecs/specs/prod/auth/authn.feature
@@ -87,6 +87,16 @@ Feature: Authentication
         | updates   | login        |
         | updates   | active alias |
 
+    Scenario: Deactivated Login identifier can become another Login Alias without exposing profile data
+      Given Profile Workspace of User Login "active@example.com" owns child Workspace "shared" containing value "active"
+      And Profile Workspace of User Login "retired@example.com" owns child Workspace "shared" containing value "retired"
+      And Profile Workspace of User Login "retired@example.com" is deactivated
+      When System sets Login Alias "retired@example.com" for User Login "active@example.com"
+      And Client signs in using Login Alias "retired@example.com" and the password of User Login "active@example.com"
+      Then the issued Principal Token identifies User Login "active@example.com" and its Profile Workspace
+      And Client reads value "active" from child Workspace "shared"
+      But Client does not read value "retired" from child Workspace "shared"
+
     Scenario: Alias creation rejects an invalid sign-in identifier
       Given a user login exists
       When System sets an invalid login alias for the user


### PR DESCRIPTION
```yaml
change_id: 2608071450-alias-deactivated-profile
type: test
issue_url: https://untill.atlassian.net/browse/AIR-4675
domains: [prod]
scope: [auth]
```
## Why

Integration coverage does not establish whether a deactivated Profile Workspace's Login can safely become the Login Alias of another active Login. Coverage is needed to guard against resolving the alias to the deactivated profile or exposing its workspace-scoped data.

## What

Add integration-level coverage demonstrating that:

- A deactivated Profile Workspace's Login identifier can be assigned as the Login Alias of another active Login.
- Sign-in through the reused Login Alias resolves the Principal to the active Login's Profile Workspace.
- Workspace-scoped data accessed through the alias belongs to the active profile and excludes data from the deactivated profile.

## How

Decisions:

- Express the behavior as an Authentication feature scenario and preserve one-to-one Gherkin-to-Go integration-test traceability.
- Exercise profile deactivation, Login Alias projection, sign-in, and child-workspace resolution through their public integration surfaces and established asynchronous wait helpers instead of directly mutating registry state.
- Use the alias-issued Principal Token as the authorization context for all post-alias profile and workspace reads; reserve privileged authorization for the System-managed alias operation.

Assumptions:

- None

References:

- `[authentication behavior specification](/uspecs/specs/prod/auth/authn.feature)`
- `[authentication integration-test patterns](/pkg/sys/it/authn_test.go)`
- `[Login Alias integration helpers](/pkg/sys/it/impl_signupin_test.go)`
- `[workspace deactivation integration-test patterns](/pkg/sys/it/impl_deactivateworkspace_test.go)`
- `[profile-scoped child-workspace fixtures and resolution](/pkg/vit/utils.go)`

## Functional design


---
Content omitted. See change.md for full details.
