### PR TITLE
[AIR-4676] refactor Scheduler job error tracking

### DIFF
--- a/pkg/processors/schedulers/impl_scheduler.go
+++ b/pkg/processors/schedulers/impl_scheduler.go
@@ -96,10 +96,10 @@ func (a *scheduler) runJob() error {
 	if err := borrowedPartition.Invoke(a.vvmCtx, a.job, state, state); err != nil {
 		return err
 	}
-	logger.VerboseCtx(a.logCtx, "job.success")
-	if err = state.ApplyIntents(); err != nil {
+	if err := state.ApplyIntents(); err != nil {
 		return err
 	}
+	logger.VerboseCtx(a.logCtx, "job.success")
 	if a.jobInErrAddr != nil {
 		if atomic.CompareAndSwapInt32(&a.projErrState, 1, 0) {
 			a.jobInErrAddr.Increase(-1)

--- a/pkg/processors/schedulers/impl_scheduler.go
+++ b/pkg/processors/schedulers/impl_scheduler.go
@@ -66,26 +66,12 @@ func (a *scheduler) Run(vvmCtx context.Context) {
 	a.finit()
 }
 
-func (a *scheduler) runJob() {
-	var err error
-	var borrowedPartition appparts.IAppPartition
-	defer func() {
-		if borrowedPartition != nil {
-			borrowedPartition.Release()
-		}
-		if err != nil {
-			logger.ErrorCtx(a.logCtx, "job.error", err)
-			if atomic.CompareAndSwapInt32(&a.projErrState, 0, 1) {
-				if a.jobInErrAddr != nil {
-					a.jobInErrAddr.Increase(1)
-				}
-			}
-		}
-	}()
-	borrowedPartition, err = a.appParts.WaitForBorrow(a.vvmCtx, a.conf.AppQName, a.conf.Partition, appparts.ProcessorKind_Scheduler)
+func (a *scheduler) runJob() error {
+	borrowedPartition, err := a.appParts.WaitForBorrow(a.vvmCtx, a.conf.AppQName, a.conf.Partition, appparts.ProcessorKind_Scheduler)
 	if err != nil {
-		return
+		return err
 	}
+	defer borrowedPartition.Release()
 	state := stateprovide.ProvideSchedulerStateFactory()(
 		a.vvmCtx,
 		func() istructs.IAppStructs { return borrowedPartition.AppStructs() },
@@ -107,19 +93,19 @@ func (a *scheduler) runJob() {
 		a.conf.HTTPClient,
 	)
 
-	if err = borrowedPartition.Invoke(a.vvmCtx, a.job, state, state); err != nil {
-		return
+	if err := borrowedPartition.Invoke(a.vvmCtx, a.job, state, state); err != nil {
+		return err
 	}
 	logger.VerboseCtx(a.logCtx, "job.success")
-	err = state.ApplyIntents()
-	if err != nil {
-		return
+	if err = state.ApplyIntents(); err != nil {
+		return err
 	}
-	if err == nil && a.jobInErrAddr != nil {
+	if a.jobInErrAddr != nil {
 		if atomic.CompareAndSwapInt32(&a.projErrState, 1, 0) {
 			a.jobInErrAddr.Increase(-1)
 		}
 	}
+	return nil
 }
 
 func (a *scheduler) init() (err error) {
@@ -156,7 +142,14 @@ func (a *scheduler) keepRunning() {
 			return
 		case now = <-timerChan:
 			logger.VerboseCtx(a.logCtx, "job.wake-up", now)
-			a.runJob()
+			if err := a.runJob(); err != nil {
+				logger.ErrorCtx(a.logCtx, "job.error", err)
+				if atomic.CompareAndSwapInt32(&a.projErrState, 0, 1) {
+					if a.jobInErrAddr != nil {
+						a.jobInErrAddr.Increase(1)
+					}
+				}
+			}
 			nextTime = a.schedule.Next(now)
 		}
 	}


### PR DESCRIPTION
## Why

Simplify scheduler job error handling and make error-state tracking explicit in the scheduling loop.
Currently it [looks very bad](https://github.com/voedger/voedger/blob/c5ea53f6720c810bad299ba824eccfa73850523f/pkg/processors/schedulers/impl_scheduler.go#L69)

## What

- Change `runJob()` to return errors from partition borrowing, job invocation, and intent application.
- Move error logging and the `JobsInError` metric update into `keepRunning()`.
- Preserve partition release with defer.
- Clear the scheduler’s error metric after a successful job run.
- Remove redundant error-state and deferred cleanup logic from `runJob()`.